### PR TITLE
JP-4053: Remove import level log configuration

### DIFF
--- a/changes/9644.general.rst
+++ b/changes/9644.general.rst
@@ -1,0 +1,1 @@
+Remove import-level log configuration.

--- a/jwst/ami/ami_analyze.py
+++ b/jwst/ami/ami_analyze.py
@@ -9,7 +9,6 @@ from . import instrument_data, nrm_core, utils
 from .find_affine2d_parameters import find_rotation
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def apply_lg_plus(

--- a/jwst/ami/ami_average.py
+++ b/jwst/ami/ami_average.py
@@ -6,7 +6,6 @@ import logging
 from stdatamodels.jwst import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def average_lg(lg_products):

--- a/jwst/ami/ami_normalize.py
+++ b/jwst/ami/ami_normalize.py
@@ -8,7 +8,6 @@ import logging
 from . import oifits
 
 log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
 
 
 def normalize_lg(target_model, reference_model):

--- a/jwst/ami/analyticnrm2.py
+++ b/jwst/ami/analyticnrm2.py
@@ -11,7 +11,6 @@ import scipy.special
 from . import hextransformee, leastsqnrm, utils
 
 log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
 
 
 def jinc(x, y, d, lam, pitch, offx=0.0, offy=0.0):

--- a/jwst/ami/bp_fix.py
+++ b/jwst/ami/bp_fix.py
@@ -11,8 +11,6 @@ from stdatamodels.jwst.datamodels import dqflags
 from .matrix_dft import matrix_dft
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-logging.captureWarnings(True)
 
 micron = 1.0e-6
 filts = ["F277W", "F380M", "F430M", "F480M", "F356W", "F444W"]

--- a/jwst/ami/find_affine2d_parameters.py
+++ b/jwst/ami/find_affine2d_parameters.py
@@ -5,7 +5,6 @@ import numpy as np
 from . import lg_model, utils
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def create_afflist_rot(rotdegs):

--- a/jwst/ami/instrument_data.py
+++ b/jwst/ami/instrument_data.py
@@ -8,7 +8,6 @@ from . import bp_fix, utils
 from .mask_definition_ami import NRMDefinition
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 DO_NOT_USE = dqflags.pixel["DO_NOT_USE"]
 JUMP_DET = dqflags.pixel["JUMP_DET"]

--- a/jwst/ami/leastsqnrm.py
+++ b/jwst/ami/leastsqnrm.py
@@ -6,7 +6,6 @@ import numpy.linalg as linalg
 from scipy.special import comb
 
 log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
 
 
 def replacenan(array):

--- a/jwst/ami/lg_model.py
+++ b/jwst/ami/lg_model.py
@@ -6,8 +6,6 @@ from . import analyticnrm2, mask_definition_ami, utils
 from . import leastsqnrm as leastsqnrm
 
 log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
-log.setLevel(logging.DEBUG)
 
 
 m = 1.0

--- a/jwst/ami/nrm_core.py
+++ b/jwst/ami/nrm_core.py
@@ -6,7 +6,6 @@ from stdatamodels.jwst import datamodels
 from . import lg_model, oifits, utils
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class FringeFitter:

--- a/jwst/ami/oifits.py
+++ b/jwst/ami/oifits.py
@@ -11,7 +11,6 @@ from stdatamodels.jwst import datamodels
 from . import leastsqnrm
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class RawOifits:

--- a/jwst/ami/utils.py
+++ b/jwst/ami/utils.py
@@ -9,8 +9,6 @@ from scipy.integrate import simpson
 from .matrix_dft import matrix_dft
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-log.addHandler(logging.NullHandler())
 
 
 class Affine2d:

--- a/jwst/assign_mtwcs/assign_mtwcs_step.py
+++ b/jwst/assign_mtwcs/assign_mtwcs_step.py
@@ -8,7 +8,6 @@ from jwst.stpipe.utilities import record_step_status
 from .moving_target_wcs import assign_moving_target_wcs
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["AssignMTWcsStep"]
 

--- a/jwst/assign_mtwcs/moving_target_wcs.py
+++ b/jwst/assign_mtwcs/moving_target_wcs.py
@@ -22,7 +22,6 @@ from jwst.lib.exposure_types import IMAGING_TYPES
 from jwst.stpipe.utilities import record_step_status
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["assign_moving_target_wcs"]
 

--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -17,7 +17,6 @@ from .util import (
 )
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["load_wcs"]
 

--- a/jwst/assign_wcs/assign_wcs_step.py
+++ b/jwst/assign_wcs/assign_wcs_step.py
@@ -12,7 +12,6 @@ from .niriss import imaging as niriss_imaging
 from .util import MSAFileError, update_fits_wcsinfo, wcs_bbox_from_shape, wfss_imaging_wcs
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["AssignWcsStep"]
 

--- a/jwst/assign_wcs/fgs.py
+++ b/jwst/assign_wcs/fgs.py
@@ -17,7 +17,6 @@ from .util import (
 )
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["create_pipeline", "imaging"]

--- a/jwst/assign_wcs/miri.py
+++ b/jwst/assign_wcs/miri.py
@@ -29,7 +29,6 @@ from .util import (
 )
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["create_pipeline", "imaging", "lrs", "ifu"]

--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -25,7 +25,6 @@ from .util import (
 )
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["create_pipeline", "imaging", "tsgrism", "wfss"]

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -29,7 +29,6 @@ from .util import (
 )
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["create_pipeline", "imaging", "niriss_soss", "niriss_soss_set_input", "wfss"]
 

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -53,7 +53,6 @@ from . import pointing
 from .util import MSAFileError, NoDataOnDetectorError, not_implemented_mode, velocity_correction
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 FIXED_SLIT_NUMS = {"NONE": 0, "S200A1": 1, "S200A2": 2, "S400A1": 3, "S1600A1": 4, "S200B1": 5}
 

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -19,7 +19,6 @@ from stpipe.exceptions import StpipeExitException
 from jwst.lib.catalog_utils import SkyObject
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 _MAX_SIP_DEGREE = 6

--- a/jwst/associations/asn_gather.py
+++ b/jwst/associations/asn_gather.py
@@ -9,8 +9,7 @@ __all__ = ["asn_gather"]
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
-LogLevels = [logging.WARNING, logging.INFO, logging.DEBUG]
+LOGLEVELS = [logging.WARNING, logging.INFO, logging.DEBUG]
 
 
 def asn_gather(
@@ -182,7 +181,7 @@ def from_cmdline(args=None):
     parsed = parser.parse_args(args)
 
     # Set output detail.
-    level = LogLevels[min(len(LogLevels) - 1, parsed.verbose)]
+    level = LOGLEVELS[min(len(LOGLEVELS) - 1, parsed.verbose)]
     logger.setLevel(level)
 
     # That's all folks.

--- a/jwst/associations/association.py
+++ b/jwst/associations/association.py
@@ -20,7 +20,6 @@ __all__ = ["Association"]
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 # Timestamp template
 _TIMESTAMP_TEMPLATE = "%Y%m%dt%H%M%S"

--- a/jwst/associations/association_io.py
+++ b/jwst/associations/association_io.py
@@ -12,7 +12,6 @@ from .lib.member import Member
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 __all__: list = []
 

--- a/jwst/associations/generator/generate.py
+++ b/jwst/associations/generator/generate.py
@@ -13,7 +13,6 @@ from jwst.lib.progress import Bar
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 __all__ = ["generate"]
 

--- a/jwst/associations/generator/generate_per_candidate.py
+++ b/jwst/associations/generator/generate_per_candidate.py
@@ -12,7 +12,6 @@ from .generate_per_pool import CANDIDATE_RULESET, DISCOVER_RULESET, constrain_on
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 
 def generate_per_candidate(

--- a/jwst/associations/generator/generate_per_pool.py
+++ b/jwst/associations/generator/generate_per_pool.py
@@ -10,7 +10,6 @@ __all__ = ["generate_per_pool"]
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 # Ruleset names
 DISCOVER_RULESET = "discover"

--- a/jwst/associations/lib/constraint.py
+++ b/jwst/associations/lib/constraint.py
@@ -21,7 +21,6 @@ __all__ = [
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 
 class SimpleConstraintABC(abc.ABC):

--- a/jwst/associations/lib/diff.py
+++ b/jwst/associations/lib/diff.py
@@ -12,7 +12,6 @@ from jwst.lib.suffix import remove_suffix
 from .product_utils import sort_by_candidate
 
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 __all__ = [
     "compare_asn_files",

--- a/jwst/associations/lib/product_utils.py
+++ b/jwst/associations/lib/product_utils.py
@@ -4,7 +4,6 @@ import logging
 from collections import Counter
 
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 
 def sort_by_candidate(asns):

--- a/jwst/associations/lib/prune.py
+++ b/jwst/associations/lib/prune.py
@@ -11,7 +11,6 @@ from .product_utils import get_product_names, sort_by_candidate
 __all__ = ["prune"]
 
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 # Duplicate association counter
 # Used in function `prune_remove`

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -34,7 +34,6 @@ from jwst.lib.suffix import remove_suffix
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 __all__ = [
     "_EMPTY",

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -63,7 +63,6 @@ __all__ = [
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 
 # --------------------------------

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -62,7 +62,6 @@ __all__ = [
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 
 # --------------------------------

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -57,7 +57,6 @@ __all__ = [
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 # The schema that these associations must adhere to.
 ASN_SCHEMA = RegistryMarker.schema(libpath() / "asn_schema_jw_level3.json")

--- a/jwst/associations/lib/utilities.py
+++ b/jwst/associations/lib/utilities.py
@@ -10,7 +10,6 @@ from jwst.associations import config
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 
 def constrain_on_candidates(candidates):

--- a/jwst/associations/main.py
+++ b/jwst/associations/main.py
@@ -15,7 +15,7 @@ from jwst.associations.lib.log_config import DMS_config, log_config
 __all__ = ["Main", "main"]
 
 # Configure logging
-logger = log_config(name=__package__)
+logger = logging.getLogger(__package__)
 
 
 class Main:

--- a/jwst/associations/mkpool.py
+++ b/jwst/associations/mkpool.py
@@ -11,8 +11,7 @@ __all__ = ["mkpool"]
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
-LogLevels = [logging.WARNING, logging.INFO, logging.DEBUG]
+LOGLEVELS = [logging.WARNING, logging.INFO, logging.DEBUG]
 
 # Header keywords to ignore
 IGNORE_KEYS = ("", "COMMENT", "HISTORY")
@@ -217,7 +216,7 @@ def from_cmdline(args=None):
     parsed = parser.parse_args(args)
 
     # Set output detail.
-    level = LogLevels[min(len(LogLevels) - 1, parsed.verbose)]
+    level = LOGLEVELS[min(len(LOGLEVELS) - 1, parsed.verbose)]
     logger.setLevel(level)
 
     # That's all folks.

--- a/jwst/associations/registry.py
+++ b/jwst/associations/registry.py
@@ -23,7 +23,6 @@ __all__ = ["AssociationRegistry", "RegistryMarker"]
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 # Library files
 _ASN_RULE = "association_rules.py"

--- a/jwst/background/asn_intake.py
+++ b/jwst/background/asn_intake.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from stdatamodels.jwst import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 WFSS_TYPES = ["NIS_WFSS", "NRC_GRISM", "NRC_WFSS"]

--- a/jwst/background/background_sub.py
+++ b/jwst/background/background_sub.py
@@ -10,7 +10,6 @@ from stdatamodels.jwst import datamodels
 from . import subtract_images
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class ImageSubsetArray:

--- a/jwst/background/background_sub_wfss.py
+++ b/jwst/background/background_sub_wfss.py
@@ -10,7 +10,6 @@ from jwst.assign_wcs.util import create_grism_bbox
 from jwst.lib.reffile_utils import get_subarray_model
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def subtract_wfss_bkg(

--- a/jwst/background/subtract_images.py
+++ b/jwst/background/subtract_images.py
@@ -3,7 +3,6 @@ import logging
 import numpy as np
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def subtract(model1, model2):

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -8,7 +8,6 @@ from scipy import ndimage
 from stdatamodels.jwst import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 # Fallback value for ratio of slit spacing to slit height
 SLITRATIO = 1.15

--- a/jwst/charge_migration/charge_migration.py
+++ b/jwst/charge_migration/charge_migration.py
@@ -6,7 +6,6 @@ import numpy as np
 from stdatamodels.jwst.datamodels import dqflags
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 GOOD = dqflags.group["GOOD"]
 DNU = dqflags.group["DO_NOT_USE"]

--- a/jwst/charge_migration/charge_migration_step.py
+++ b/jwst/charge_migration/charge_migration_step.py
@@ -8,7 +8,6 @@ from jwst.stpipe import Step
 from . import charge_migration
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["ChargeMigrationStep"]
 

--- a/jwst/clean_flicker_noise/clean_flicker_noise.py
+++ b/jwst/clean_flicker_noise/clean_flicker_noise.py
@@ -20,7 +20,6 @@ from jwst.msaflagopen import MSAFlagOpenStep
 from jwst.ramp_fitting import RampFitStep
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 # Fixed slit region to mask, for NIRSpec MOS and IFU data
 # Values are y start and stop indices, for the edges of the

--- a/jwst/combine_1d/combine1d.py
+++ b/jwst/combine_1d/combine1d.py
@@ -9,7 +9,6 @@ from jwst.datamodels.utils.flat_multispec import expand_flat_spec
 from jwst.extract_1d.spec_wcs import create_spectral_wcs
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 # attributes that we want to copy unmodified from input to output spectra

--- a/jwst/coron/hlsp.py
+++ b/jwst/coron/hlsp.py
@@ -7,7 +7,6 @@ import numpy as np
 from stdatamodels.jwst import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def snr_image(target_model):

--- a/jwst/coron/imageregistration.py
+++ b/jwst/coron/imageregistration.py
@@ -6,7 +6,6 @@ from scipy.ndimage import fourier_shift
 from stdatamodels.jwst.datamodels import CubeModel
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def align_fourier_lsq(reference, target, mask=None):

--- a/jwst/coron/klip.py
+++ b/jwst/coron/klip.py
@@ -5,7 +5,6 @@ import logging
 import numpy as np
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def klip(target_model, refs_model, truncate):

--- a/jwst/coron/median_replace_img.py
+++ b/jwst/coron/median_replace_img.py
@@ -7,7 +7,6 @@ import numpy as np
 from stdatamodels.jwst.datamodels import dqflags
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def median_fill_value(input_array, input_dq_array, bsize, bad_bitvalue, xc, yc):

--- a/jwst/coron/stack_refs.py
+++ b/jwst/coron/stack_refs.py
@@ -6,7 +6,6 @@ import numpy as np
 from stdatamodels.jwst import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def make_cube(input_models):

--- a/jwst/cube_build/blot_cube_build.py
+++ b/jwst/cube_build/blot_cube_build.py
@@ -11,7 +11,6 @@ from . import instrument_defaults
 from .blot_median import blot_wrapper  # c extension
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class CubeBlot:

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -5,7 +5,6 @@ import logging
 from . import cube_build_io_util, file_table, instrument_defaults
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class CubeData:

--- a/jwst/cube_build/cube_build_io_util.py
+++ b/jwst/cube_build/cube_build_io_util.py
@@ -5,7 +5,6 @@ import logging
 from stdatamodels.jwst import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def read_cubepars(

--- a/jwst/cube_build/cube_build_wcs_util.py
+++ b/jwst/cube_build/cube_build_wcs_util.py
@@ -9,7 +9,6 @@ from jwst.assign_wcs import nirspec
 from jwst.assign_wcs.util import wrap_ra
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 # ******************************************************************************

--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -6,7 +6,6 @@ from stdatamodels.jwst import datamodels
 from jwst.datamodels import ModelContainer
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class DataTypes:

--- a/jwst/cube_build/file_table.py
+++ b/jwst/cube_build/file_table.py
@@ -3,7 +3,6 @@ import logging
 from stdatamodels.jwst import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class FileTable:

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -24,7 +24,6 @@ from .cube_match_sky_driz import cube_wrapper_driz  # c extension
 from .cube_match_sky_pointcloud import cube_wrapper  # c extension
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class IFUCubeData:

--- a/jwst/cube_build/instrument_defaults.py
+++ b/jwst/cube_build/instrument_defaults.py
@@ -3,7 +3,6 @@
 import logging
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class InstrumentInfo:

--- a/jwst/datamodels/container.py
+++ b/jwst/datamodels/container.py
@@ -26,7 +26,6 @@ EMPTY_ASN_TABLE = {
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 
 class ModelContainer(Sequence):

--- a/jwst/datamodels/utils/flat_multispec.py
+++ b/jwst/datamodels/utils/flat_multispec.py
@@ -8,7 +8,6 @@ from asdf.tags.core.ndarray import asdf_datatype_to_numpy_dtype
 from stdatamodels.jwst import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def determine_vector_and_meta_columns(input_datatype, output_datatype):

--- a/jwst/dq_init/dq_initialization.py
+++ b/jwst/dq_init/dq_initialization.py
@@ -7,7 +7,6 @@ from jwst.datamodels import dqflags  # type: ignore[attr-defined]
 from jwst.lib import reffile_utils
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 # FGS guide star mode exposure types

--- a/jwst/emicorr/emicorr.py
+++ b/jwst/emicorr/emicorr.py
@@ -8,7 +8,6 @@ from scipy import interpolate
 from stdatamodels.jwst import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 subarray_clocks = {
     "SLITLESSPRISM": {"rowclocks": 28, "frameclocks": 15904},

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -11,7 +11,6 @@ from jwst.datamodels import SourceModelContainer
 __all__ = ["exp_to_source", "multislit_to_container"]
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def exp_to_source(inputs):

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -41,7 +41,6 @@ __all__ = [
 
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 WFSS_EXPTYPES = ["NIS_WFSS", "NRC_WFSS", "NRC_GRISM"]
 """Exposure types to be regarded as wide-field slitless spectroscopy."""

--- a/jwst/extract_1d/ifu.py
+++ b/jwst/extract_1d/ifu.py
@@ -24,7 +24,6 @@ from jwst.residual_fringe import utils as rfutils
 __all__ = ["ifu_extract1d"]
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 # This is intended to be larger than any possible distance (in pixels)
 # between the target and any point in the image; used by locn_from_wcs().

--- a/jwst/extract_1d/psf_profile.py
+++ b/jwst/extract_1d/psf_profile.py
@@ -10,7 +10,6 @@ from jwst.extract_1d.source_location import middle_from_wcs, nod_pair_location, 
 __all__ = ["psf_profile"]
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 HORIZONTAL = 1
 VERTICAL = 2

--- a/jwst/extract_1d/soss_extract/atoca.py
+++ b/jwst/extract_1d/soss_extract/atoca.py
@@ -17,7 +17,6 @@ from scipy.sparse import csr_matrix, diags, issparse
 from . import atoca_utils
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class MaskOverlapError(Exception):

--- a/jwst/extract_1d/soss_extract/atoca_utils.py
+++ b/jwst/extract_1d/soss_extract/atoca_utils.py
@@ -18,7 +18,6 @@ from scipy.sparse import csr_matrix, diags
 from scipy.sparse.linalg import MatrixRankWarning, lsqr, spsolve
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def arange_2d(starts, stops):

--- a/jwst/extract_1d/soss_extract/soss_boxextract.py
+++ b/jwst/extract_1d/soss_extract/soss_boxextract.py
@@ -3,7 +3,6 @@ import logging
 import numpy as np
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def get_box_weights(centroid, n_pix, shape, cols):

--- a/jwst/extract_1d/soss_extract/soss_extract.py
+++ b/jwst/extract_1d/soss_extract/soss_extract.py
@@ -24,7 +24,6 @@ from .soss_boxextract import box_extract, estim_error_nearest_data, get_box_weig
 from .soss_syscor import make_background_mask, soss_background
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 ORDER2_SHORT_CUTOFF = 0.58
 

--- a/jwst/extract_1d/soss_extract/soss_syscor.py
+++ b/jwst/extract_1d/soss_extract/soss_syscor.py
@@ -4,7 +4,6 @@ import numpy as np
 from astropy.stats import SigmaClip
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def soss_background(scidata, scimask, bkg_mask):

--- a/jwst/extract_1d/source_location.py
+++ b/jwst/extract_1d/source_location.py
@@ -15,7 +15,6 @@ VERTICAL = 2
 """Vertical dispersion axis."""
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def middle_from_wcs(wcs, bounding_box, dispaxis):

--- a/jwst/extract_1d/spec_wcs.py
+++ b/jwst/extract_1d/spec_wcs.py
@@ -8,7 +8,6 @@ from gwcs import coordinate_frames as cf
 from gwcs.wcs import WCS
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def create_spectral_wcs(ra, dec, wavelength):

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -8,7 +8,6 @@ from .grisms import extract_grism_objects, extract_tso_object
 from .nirspec import nrs_extract2d
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["extract2d"]

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -17,7 +17,6 @@ from stdatamodels.jwst.transforms.models import IdealToV2V3
 from jwst.assign_wcs import util
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def extract_tso_object(

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -14,7 +14,6 @@ from jwst.assign_wcs import nirspec, util
 from jwst.lib import pipe_utils
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def nrs_extract2d(input_model, slit_names=None, source_ids=None):

--- a/jwst/firstframe/firstframe_sub.py
+++ b/jwst/firstframe/firstframe_sub.py
@@ -7,7 +7,6 @@ import numpy as np
 from stdatamodels.jwst.datamodels import dqflags
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(output, bright_use_group1=False):

--- a/jwst/flatfield/flat_field.py
+++ b/jwst/flatfield/flat_field.py
@@ -12,7 +12,6 @@ from jwst.assign_wcs import nirspec
 from jwst.lib import pipe_utils, reffile_utils, wcs_utils
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 MICRONS_100 = 1.0e-4  # 100 microns, in meters
 

--- a/jwst/fringe/fringe.py
+++ b/jwst/fringe/fringe.py
@@ -7,7 +7,6 @@ import logging
 import numpy as np
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(input_model, fringe_model):

--- a/jwst/gain_scale/gain_scale.py
+++ b/jwst/gain_scale/gain_scale.py
@@ -3,7 +3,6 @@ import logging
 import numpy as np
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(output_model, gain_factor):

--- a/jwst/group_scale/group_scale.py
+++ b/jwst/group_scale/group_scale.py
@@ -6,7 +6,6 @@
 import logging
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(model):

--- a/jwst/guider_cds/guider_cds.py
+++ b/jwst/guider_cds/guider_cds.py
@@ -7,7 +7,6 @@ from stdatamodels.jwst import datamodels
 from jwst.lib import reffile_utils
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def guider_cds(model, gain_model, readnoise_model):

--- a/jwst/guider_cds/guider_cds_step.py
+++ b/jwst/guider_cds/guider_cds_step.py
@@ -10,7 +10,6 @@ from jwst.stpipe import Step
 from . import guider_cds
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["GuiderCdsStep"]
 

--- a/jwst/ipc/ipc_corr.py
+++ b/jwst/ipc/ipc_corr.py
@@ -12,7 +12,6 @@ from jwst.lib import pipe_utils
 from . import x_irs2
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 NumRefPixels = namedtuple(
     "NumRefPixels", ["bottom_rows", "top_rows", "left_columns", "right_columns"]

--- a/jwst/lastframe/lastframe_sub.py
+++ b/jwst/lastframe/lastframe_sub.py
@@ -7,7 +7,6 @@ import numpy as np
 from stdatamodels.jwst.datamodels import dqflags
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(output):

--- a/jwst/lib/dispaxis.py
+++ b/jwst/lib/dispaxis.py
@@ -1,7 +1,6 @@
 import logging
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def get_dispersion_direction(exposure_type, grating="ANY", filter_wh="ANY", pupil="ANY"):

--- a/jwst/lib/engdb_direct.py
+++ b/jwst/lib/engdb_direct.py
@@ -12,7 +12,6 @@ from .engdb_lib import FORCE_STATUSES, RETRIES, TIMEOUT, EngDB_Value, EngdbABC
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 # #############################################
 # Where is the engineering service? Its HERE!!!

--- a/jwst/lib/engdb_mast.py
+++ b/jwst/lib/engdb_mast.py
@@ -24,7 +24,6 @@ SERVICE_URI = "mast:jwstedb/"
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 
 class EngdbMast(EngdbABC):

--- a/jwst/lib/engdb_tools.py
+++ b/jwst/lib/engdb_tools.py
@@ -61,7 +61,6 @@ from .engdb_mast import EngdbMast
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 __all__ = ["ENGDB_Service"]
 

--- a/jwst/lib/pipe_utils.py
+++ b/jwst/lib/pipe_utils.py
@@ -9,7 +9,6 @@ from stdatamodels.properties import ObjectNode
 from jwst.associations.lib.dms_base import TSO_EXP_TYPES
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def is_tso(model):

--- a/jwst/lib/pointing_summary.py
+++ b/jwst/lib/pointing_summary.py
@@ -41,7 +41,6 @@ from astropy.coordinates import SkyCoord
 from astropy.table import Table
 
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 __all__ = ["Delta", "calc_pointing_deltas", "calc_deltas"]
 

--- a/jwst/lib/progress.py
+++ b/jwst/lib/progress.py
@@ -14,7 +14,6 @@ __all__ = ["Bar"]
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 
 class _BarStub:

--- a/jwst/lib/reffile_utils.py
+++ b/jwst/lib/reffile_utils.py
@@ -4,7 +4,6 @@ import numpy as np
 from stdatamodels.jwst import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def is_subarray(input_model):

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -95,7 +95,6 @@ __all__ = [
 
 # Setup logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 DEBUG_FULL = logging.DEBUG - 1
 LOGLEVELS = [logging.INFO, logging.DEBUG, DEBUG_FULL]
 

--- a/jwst/lib/set_velocity_aberration.py
+++ b/jwst/lib/set_velocity_aberration.py
@@ -31,7 +31,6 @@ from jwst.datamodels import Level1bModel  # type: ignore[attr-defined]
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 SPEED_OF_LIGHT = speed_of_light / 1000  # km / s
 

--- a/jwst/lib/siafdb.py
+++ b/jwst/lib/siafdb.py
@@ -17,7 +17,6 @@ from .basic_utils import LoggingContext
 
 # Setup logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 # Map instrument three character mnemonic to full name
 INSTRUMENT_MAP = {"fgs": "fgs", "mir": "miri", "nis": "niriss", "nrc": "nircam", "nrs": "nirspec"}

--- a/jwst/lib/signal_slot.py
+++ b/jwst/lib/signal_slot.py
@@ -8,7 +8,6 @@ __all__ = ["Signal", "Signals", "SignalsNotAClass"]
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 Slot = namedtuple("Slot", ["func", "single_shot"])
 """Slot data structure."""

--- a/jwst/lib/suffix.py
+++ b/jwst/lib/suffix.py
@@ -25,7 +25,6 @@ __all__ = ["remove_suffix"]
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 # Suffixes that are hard-coded or otherwise
 # have to exist. Used by `find_suffixes` to

--- a/jwst/lib/v1_calculate.py
+++ b/jwst/lib/v1_calculate.py
@@ -10,7 +10,6 @@ from . import set_telescope_pointing as stp
 from . import siafdb
 
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 __all__ = ["v1_calculate_from_models", "v1_calculate_over_time"]
 

--- a/jwst/linearity/linearity.py
+++ b/jwst/linearity/linearity.py
@@ -7,7 +7,6 @@ from stdatamodels.jwst.datamodels import dqflags
 from jwst.lib import reffile_utils
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(output_model, lin_model):

--- a/jwst/master_background/create_master_bkg.py
+++ b/jwst/master_background/create_master_bkg.py
@@ -4,7 +4,6 @@ import numpy as np
 from stdatamodels.jwst import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def create_background(wavelength, surf_bright):

--- a/jwst/master_background/expand_to_2d.py
+++ b/jwst/master_background/expand_to_2d.py
@@ -10,7 +10,6 @@ from jwst.datamodels import ModelContainer
 from jwst.lib.wcs_utils import get_wavelengths
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 WFSS_EXPTYPES = ["NIS_WFSS", "NRC_WFSS", "NRC_GRISM", "NRC_TSGRISM"]
 

--- a/jwst/master_background/nirspec_utils.py
+++ b/jwst/master_background/nirspec_utils.py
@@ -4,7 +4,6 @@ import warnings
 from scipy.signal import medfilt
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def apply_master_background(source_model, bkg_model, inverse=False):

--- a/jwst/mrs_imatch/__init__.py
+++ b/jwst/mrs_imatch/__init__.py
@@ -7,4 +7,3 @@ from .mrs_imatch_step import MRSIMatchStep
 __all__ = ["MRSIMatchStep"]
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)

--- a/jwst/msaflagopen/msaflag_open.py
+++ b/jwst/msaflagopen/msaflag_open.py
@@ -21,7 +21,6 @@ from jwst.assign_wcs.nirspec import (
 from jwst.lib.basic_utils import LoggingContext
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 FAILEDOPENFLAG = datamodels.dqflags.pixel["MSA_FAILED_OPEN"]

--- a/jwst/outlier_detection/_fileio.py
+++ b/jwst/outlier_detection/_fileio.py
@@ -1,7 +1,6 @@
 import logging
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def save_median(median_model, make_output_path):

--- a/jwst/outlier_detection/coron.py
+++ b/jwst/outlier_detection/coron.py
@@ -11,7 +11,6 @@ from ._fileio import save_median
 from .utils import create_cube_median, flag_model_crs
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["detect_outliers"]

--- a/jwst/outlier_detection/ifu.py
+++ b/jwst/outlier_detection/ifu.py
@@ -40,7 +40,6 @@ from jwst.lib.pipe_utils import match_nans_and_flags
 from jwst.stpipe.utilities import record_step_status
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["detect_outliers"]
 

--- a/jwst/outlier_detection/imaging.py
+++ b/jwst/outlier_detection/imaging.py
@@ -14,7 +14,6 @@ from .utils import (
 )
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["detect_outliers"]

--- a/jwst/outlier_detection/spec.py
+++ b/jwst/outlier_detection/spec.py
@@ -14,7 +14,6 @@ from .utils import (
 )
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["detect_outliers"]

--- a/jwst/outlier_detection/tso.py
+++ b/jwst/outlier_detection/tso.py
@@ -10,7 +10,6 @@ from ._fileio import save_median
 from .utils import flag_model_crs, nanmedian3D
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["detect_outliers"]

--- a/jwst/outlier_detection/utils.py
+++ b/jwst/outlier_detection/utils.py
@@ -21,7 +21,6 @@ from jwst.resample.resample import compute_image_pixel_area
 from . import _fileio
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 DO_NOT_USE = datamodels.dqflags.pixel["DO_NOT_USE"]

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -12,7 +12,6 @@ from jwst.lib.pipe_utils import match_nans_and_flags
 from jwst.lib.wcs_utils import get_wavelengths
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 # There are 30 slices in the NIRSpec IFU, numbered from 0 to 29

--- a/jwst/persistence/persistence.py
+++ b/jwst/persistence/persistence.py
@@ -9,7 +9,6 @@ from stdatamodels.jwst import datamodels
 from stdatamodels.jwst.datamodels import dqflags
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 SCALEFACTOR = 2.0
 """This factor is to account for the difference in gain for charges freed

--- a/jwst/photom/miri_imager.py
+++ b/jwst/photom/miri_imager.py
@@ -3,7 +3,6 @@ import logging
 import numpy as np
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def time_corr_photom(param, t):

--- a/jwst/photom/miri_mrs.py
+++ b/jwst/photom/miri_mrs.py
@@ -5,7 +5,6 @@ from gwcs.wcstools import grid_from_bounding_box
 from scipy.interpolate import RegularGridInterpolator
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 # Set of routines to find a  correction for a time-wavelength
 # photometric response that is particularly significant at long wavelengths.

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -14,7 +14,6 @@ from jwst.lib.wcs_utils import get_wavelengths
 from . import miri_imager, miri_mrs
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 PHOT_TOL = 0.001  # relative tolerance between PIXAR_* keys
 

--- a/jwst/pipeline/calwebb_ami3.py
+++ b/jwst/pipeline/calwebb_ami3.py
@@ -10,7 +10,6 @@ __all__ = ["Ami3Pipeline"]
 
 # Define logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class Ami3Pipeline(Pipeline):

--- a/jwst/pipeline/calwebb_dark.py
+++ b/jwst/pipeline/calwebb_dark.py
@@ -23,7 +23,6 @@ __all__ = ["DarkPipeline"]
 
 # Define logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class DarkPipeline(Pipeline):

--- a/jwst/pipeline/calwebb_detector1.py
+++ b/jwst/pipeline/calwebb_detector1.py
@@ -30,7 +30,6 @@ __all__ = ["Detector1Pipeline"]
 
 # Define logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class Detector1Pipeline(Pipeline):

--- a/jwst/pipeline/calwebb_guider.py
+++ b/jwst/pipeline/calwebb_guider.py
@@ -13,7 +13,6 @@ __all__ = ["GuiderPipeline"]
 
 # Define logging
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class GuiderPipeline(Pipeline):

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -8,7 +8,6 @@ from stdatamodels.jwst import datamodels
 from jwst.assign_wcs import nirspec
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class PixelReplacement:

--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -11,7 +11,6 @@ from jwst.lib import reffile_utils
 from jwst.stpipe import Step
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["RampFitStep"]
 

--- a/jwst/refpix/irs2_subtract_reference.py
+++ b/jwst/refpix/irs2_subtract_reference.py
@@ -6,7 +6,6 @@ from scipy.ndimage import convolve1d
 from stdatamodels.jwst.datamodels import dqflags
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def correct_model(

--- a/jwst/refpix/optimized_convolution.py
+++ b/jwst/refpix/optimized_convolution.py
@@ -8,7 +8,6 @@ import logging
 import numpy as np
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def make_kernels(sirs_kernel_model, detector, gaussmooth, halfwidth):

--- a/jwst/refpix/reference_pixels.py
+++ b/jwst/refpix/reference_pixels.py
@@ -54,7 +54,6 @@ from .irs2_subtract_reference import make_irs2_mask
 from .optimized_convolution import apply_conv_kernel, make_kernels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 #
 # NIR Reference section dictionaries are zero indexed and specify the values
@@ -1247,7 +1246,6 @@ class NIRDataset(Dataset):
                 #
                 #  Now transform back from detector to DMS coordinates.
                 self.detector_to_dms(integration, group)
-        log.setLevel(logging.INFO)
         return
 
     def do_subarray_corrections(self):
@@ -1309,7 +1307,6 @@ class NIRDataset(Dataset):
                     thisgroup -= refpixvalue
                 #  Now transform back from detector to DMS coordinates.
                 self.detector_to_dms(integration, group)
-        log.setLevel(logging.INFO)
         return
 
     def get_multistripe_refvalues(self, group):
@@ -1416,8 +1413,6 @@ class NIRDataset(Dataset):
                 self.group = thisgroup
                 #  Now transform back from detector to DMS coordinates.
                 self.detector_to_dms(integration_num, group_num)
-
-        log.setLevel(logging.INFO)
 
         return
 
@@ -2338,7 +2333,6 @@ class MIRIDataset(Dataset):
                     break
                 self.do_left_right_correction(thisgroup, refvalues)
                 self.restore_group(integration, group)
-        log.setLevel(logging.INFO)
         log.info("Adding initial read back in")
 
         for i in range(self.nints):

--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -17,7 +17,6 @@ pytestmark = [pytest.mark.bigdata, pytest.mark.filterwarnings("error")]
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 # Decompose pool name to retrieve proposal and version id.
 pool_regex = re.compile(r"(?P<proposal>jw.+?)_(?P<versionid>.+)_pool")

--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -15,9 +15,6 @@ from jwst.associations.main import Main as asn_generate
 # Mark all tests in this module
 pytestmark = [pytest.mark.bigdata, pytest.mark.filterwarnings("error")]
 
-# Configure logging
-logger = logging.getLogger(__name__)
-
 # Decompose pool name to retrieve proposal and version id.
 pool_regex = re.compile(r"(?P<proposal>jw.+?)_(?P<versionid>.+)_pool")
 

--- a/jwst/regtest/test_fgs_pointing.py
+++ b/jwst/regtest/test_fgs_pointing.py
@@ -15,7 +15,6 @@ from jwst.datamodels import Level1bModel  # type: ignore[attr-defined] # noqa: E
 from jwst.lib import set_telescope_pointing as stp  # noqa: E402
 from jwst.lib import siafdb  # noqa: E402
 
-
 # All the FGS GUIDER examples. Generated from proposal JW01029
 FGS_PATHS = sorted(
     get_pkg_data_filenames("data/fgs_exposures", package="jwst.lib.tests", pattern="*.fits")

--- a/jwst/regtest/test_fgs_pointing.py
+++ b/jwst/regtest/test_fgs_pointing.py
@@ -7,8 +7,6 @@ import pytest
 # Only run if `pysiaf` is installed.
 pytest.importorskip("pysiaf")
 
-import logging  # noqa: E402
-
 from astropy.utils.data import get_pkg_data_filenames  # noqa: E402
 from numpy import array  # noqa: E402
 from numpy.testing import assert_allclose  # noqa: E402
@@ -17,12 +15,6 @@ from jwst.datamodels import Level1bModel  # type: ignore[attr-defined] # noqa: E
 from jwst.lib import set_telescope_pointing as stp  # noqa: E402
 from jwst.lib import siafdb  # noqa: E402
 
-# Set logging for the module to be tested.
-logger = logging.getLogger(stp.__name__)
-logger.setLevel(logging.INFO)
-handler = logging.StreamHandler()
-handler.setLevel(logging.INFO)
-logger.addHandler(handler)
 
 # All the FGS GUIDER examples. Generated from proposal JW01029
 FGS_PATHS = sorted(

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -16,10 +16,6 @@ from jwst.datamodels import ModelLibrary
 from jwst.model_blender.blender import ModelBlender
 from jwst.resample import resample_utils
 
-log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-
-
 __all__ = [
     "input_jwst_model_to_dict",
     "is_imaging_wcs",
@@ -36,7 +32,6 @@ _SUPPORTED_CUSTOM_WCS_PARS = [
 ]
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class ResampleImage(Resample):

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -26,7 +26,6 @@ from jwst.resample import resample_utils
 from jwst.resample.resample import ResampleImage
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["ResampleSpec"]

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -11,7 +11,6 @@ from jwst.stpipe import Step
 from . import resample
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 __all__ = ["ResampleStep"]
 

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -20,7 +20,6 @@ from stdatamodels.jwst.datamodels.dqflags import pixel
 __all__ = ["build_mask", "resampled_wcs_from_models"]
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def resampled_wcs_from_models(

--- a/jwst/reset/reset_sub.py
+++ b/jwst/reset/reset_sub.py
@@ -6,7 +6,6 @@ import logging
 import numpy as np
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(output_model, reset_model):

--- a/jwst/residual_fringe/residual_fringe.py
+++ b/jwst/residual_fringe/residual_fringe.py
@@ -14,7 +14,6 @@ from jwst.residual_fringe import utils
 from jwst.stpipe import Step
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 # Noise factor for DER_SNR spectroscopic signal-to-noise calculation
 # (see Stoehr, ADASS 2008: https://archive.stsci.edu/vodocs/der_snr.pdf)

--- a/jwst/residual_fringe/utils.py
+++ b/jwst/residual_fringe/utils.py
@@ -10,7 +10,6 @@ from scipy.interpolate import pchip
 from jwst.residual_fringe.fitter import spline_fitter
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.INFO)
 
 # Number of knots for bkg model if no other info provided
 # Hard coded parameter, has been selected based on testing but can be changed

--- a/jwst/rscd/rscd_sub.py
+++ b/jwst/rscd/rscd_sub.py
@@ -8,7 +8,6 @@ import numpy as np
 from stdatamodels.jwst.datamodels import dqflags
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(output_model, rscd_model):

--- a/jwst/saturation/saturation.py
+++ b/jwst/saturation/saturation.py
@@ -10,7 +10,6 @@ from jwst.lib import reffile_utils
 from . import x_irs2
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 DONOTUSE = dqflags.pixel["DO_NOT_USE"]
 SATURATED = dqflags.pixel["SATURATED"]

--- a/jwst/scripts/adjust_wcs.py
+++ b/jwst/scripts/adjust_wcs.py
@@ -18,11 +18,6 @@ from jwst.tweakreg.utils import adjust_wcs
 
 _ANGLE_PARS = ["-r", "--ra_delta", "-d", "--dec_delta", "-o", "--roll_delta"]
 
-# Configure logging
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-logger.addHandler(logging.NullHandler())
-
 
 def _replace_suffix(file, new_suffix):
     sep = "_"
@@ -152,6 +147,11 @@ def main():
                 argv_new.append(f" {angle_value}")
 
     options = parser.parse_args(argv_new)
+
+    # Configure logging
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+    logger.addHandler(logging.NullHandler())
 
     files = []
     for f in options.arg0:

--- a/jwst/scripts/collect_pipeline_cfgs.py
+++ b/jwst/scripts/collect_pipeline_cfgs.py
@@ -6,9 +6,6 @@ from pathlib import Path
 
 from jwst.pipeline.collect_pipeline_cfgs import collect_pipeline_cfgs
 
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-
 
 def main():
     """
@@ -17,6 +14,9 @@ def main():
     Use from terminal as follows:
     $ collect_pipeline_cfgs .
     """
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+
     if len(sys.argv) < 2:
         logger.error("ERROR: missing argument (destination directory")
         sys.exit(1)

--- a/jwst/scripts/pointing_summary.py
+++ b/jwst/scripts/pointing_summary.py
@@ -8,11 +8,6 @@ from sys import stdout
 
 from jwst.lib import pointing_summary
 
-log_handler = logging.StreamHandler()
-logger = logging.getLogger("jwst")
-logger.addHandler(log_handler)
-LogLevels = [logging.WARNING, logging.INFO, logging.DEBUG]
-
 
 # Begin execution
 def main():
@@ -52,8 +47,14 @@ def main():
 
     args = parser.parse_args()
 
+    # Configure logging
+    log_handler = logging.StreamHandler()
+    logger = logging.getLogger("jwst")
+    logger.addHandler(log_handler)
+    log_levels = [logging.WARNING, logging.INFO, logging.DEBUG]
+
     # Set output detail.
-    level = LogLevels[min(len(LogLevels) - 1, args.verbose)]
+    level = log_levels[min(len(log_levels) - 1, args.verbose)]
     logger.setLevel(level)
 
     # Process the file list.

--- a/jwst/scripts/schemadoc.py
+++ b/jwst/scripts/schemadoc.py
@@ -11,11 +11,6 @@ from pathlib import Path
 from stdatamodels.jwst.datamodels import _defined_models as defined_models
 from stdatamodels.schema import build_docstring
 
-# Set logger to only print to screen
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-
-
 def get_docstrings(template, model_names, all_models=False):
     """Get the docstring for every model class."""
     if all_models:
@@ -47,6 +42,10 @@ def main():
     parser.add_argument("-t", "--template", type=str, help="input file containing templates")
     parser.add_argument("models", nargs="*", help="Models to generate docstrings for")
     args = parser.parse_args()
+
+    # Set logger to only print to screen
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
 
     if args.template is None:
         template = "{path} : {title} ({datatype})\n"

--- a/jwst/scripts/schemadoc.py
+++ b/jwst/scripts/schemadoc.py
@@ -13,6 +13,7 @@ from stdatamodels.schema import build_docstring
 
 def get_docstrings(template, model_names, all_models=False):
     """Get the docstring for every model class."""
+    logger = logging.getLogger()
     if all_models:
         klasses = defined_models
     else:

--- a/jwst/scripts/schemadoc.py
+++ b/jwst/scripts/schemadoc.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from stdatamodels.jwst.datamodels import _defined_models as defined_models
 from stdatamodels.schema import build_docstring
 
+
 def get_docstrings(template, model_names, all_models=False):
     """Get the docstring for every model class."""
     logger = logging.getLogger()

--- a/jwst/scripts/set_telescope_pointing.py
+++ b/jwst/scripts/set_telescope_pointing.py
@@ -17,13 +17,6 @@ from pathlib import Path
 
 import jwst.lib.set_telescope_pointing as stp
 
-# Configure logging
-logger = logging.getLogger("jwst")
-logger.propagate = False
-logger_handler = logging.StreamHandler()
-logger.addHandler(logger_handler)
-logger_format_debug = logging.Formatter("%(levelname)s:%(filename)s::%(funcName)s: %(message)s")
-
 
 def main():
     """Set the initial world coordinate system."""
@@ -119,6 +112,13 @@ def main():
     )
 
     args = parser.parse_args()
+
+    # Configure logging
+    logger = logging.getLogger("jwst")
+    logger.propagate = False
+    logger_handler = logging.StreamHandler()
+    logger.addHandler(logger_handler)
+    logger_format_debug = logging.Formatter("%(levelname)s:%(filename)s::%(funcName)s: %(message)s")
 
     # Set output detail.
     level = stp.LOGLEVELS[min(len(stp.LOGLEVELS) - 1, args.verbose)]

--- a/jwst/scripts/set_velocity_aberration.py
+++ b/jwst/scripts/set_velocity_aberration.py
@@ -3,16 +3,11 @@
 """Add velocity aberration correction information to the FITS files provided."""
 
 import argparse
-import logging
 import sys
 import warnings
 from pathlib import Path
 
 from jwst.lib.set_velocity_aberration import add_dva
-
-# Configure logging
-logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 
 def parse_args(args):

--- a/jwst/scripts/stfitsdiff.py
+++ b/jwst/scripts/stfitsdiff.py
@@ -9,10 +9,6 @@ from argparse import ArgumentParser
 
 from jwst.regtest.st_fitsdiff import STFITSDiffBeta as STFITSDiff
 
-logging.basicConfig(level=logging.INFO, format="", datefmt="", stream=sys.stdout)
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-
 
 def _is_number(s):
     is_number = True
@@ -166,8 +162,13 @@ def main():
     )
 
     # Get the arguments
-
     args = parser.parse_args()
+
+    # Configure logging
+    logging.basicConfig(level=logging.INFO, format="", datefmt="", stream=sys.stdout)
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+
     file_a = args.file_a
     file_b = args.file_b
 

--- a/jwst/scripts/tests/test_argparsers.py
+++ b/jwst/scripts/tests/test_argparsers.py
@@ -13,7 +13,7 @@ def test_argparse_set_velocity_aberration():
     assert args.filename == args2.filename
 
     args3 = parse_args(["filename0", "filename1", "filename2"])
-    assert args3.force_level1bmodel is True
+    assert args3.force_level1bmodel == 1
 
 
 def test_argparse_set_velocity_aberration_bad_input(capsys):

--- a/jwst/scripts/tests/test_scripts.py
+++ b/jwst/scripts/tests/test_scripts.py
@@ -8,7 +8,6 @@ SCRIPTS = [
     "asn_gather",
     "asn_make_pool",
     "collect_pipeline_cfgs",
-    "create_data",
     "pointing_summary",
     "schemadoc",
     "set_telescope_pointing",

--- a/jwst/scripts/v1_calculate.py
+++ b/jwst/scripts/v1_calculate.py
@@ -11,13 +11,6 @@ from astropy.time import Time
 import jwst.lib.set_telescope_pointing as stp
 from jwst.lib import v1_calculate
 
-# Configure logging
-logger = logging.getLogger("jwst")
-logger.propagate = False
-logger_handler = logging.StreamHandler()
-logger.addHandler(logger_handler)
-logger_format_debug = logging.Formatter("%(levelname)s:%(filename)s::%(funcName)s: %(message)s")
-
 # Available reduce functions
 REDUCE_FUNCS_MAPPING = {
     "all": stp.all_pointings,
@@ -91,6 +84,13 @@ def main():
     )
 
     args = parser.parse_args()
+
+    # Configure logging
+    logger = logging.getLogger("jwst")
+    logger.propagate = False
+    logger_handler = logging.StreamHandler()
+    logger.addHandler(logger_handler)
+    logger_format_debug = logging.Formatter("%(levelname)s:%(filename)s::%(funcName)s: %(message)s")
 
     # Set output detail.
     level = stp.LOGLEVELS[min(len(stp.LOGLEVELS) - 1, args.verbose)]

--- a/jwst/scripts/world_coords.py
+++ b/jwst/scripts/world_coords.py
@@ -26,9 +26,6 @@ from stdatamodels.jwst.datamodels.util import open as dmopen
 
 from jwst.assign_wcs import nirspec
 
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-
 
 def main():
     """Loop over the input files and apply the proper method to create the output file."""
@@ -76,6 +73,11 @@ def main():
     parser.add_argument("-m", "--mode", default=None, help="set exposure mode")
 
     res = parser.parse_args()
+
+    # Configure logging
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+
     filenames = res.filenames
     mode = res.mode
 

--- a/jwst/scripts/world_coords.py
+++ b/jwst/scripts/world_coords.py
@@ -389,6 +389,7 @@ def imaging_coords(model):
 
 def warn_user(*argv):
     """Send a warning message to stderr."""
+    logger = logging.getLogger()
     logger.warning(*argv)
 
 

--- a/jwst/skymatch/__init__.py
+++ b/jwst/skymatch/__init__.py
@@ -1,13 +1,6 @@
 """Provide support for sky background subtraction and equalization (matching)."""
 
-import logging
-
 from .skymatch_step import SkyMatchStep
 
 __author__ = "Mihai Cara"
-
-
-log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-
 __all__ = ["SkyMatchStep"]

--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -22,7 +22,6 @@ from jwst.lib.suffix import remove_suffix
 from jwst.stpipe import Step
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["SkyMatchStep"]
@@ -76,8 +75,6 @@ class SkyMatchStep(Step):
         ModelLibrary
             A library of datamodels with the skymatch step applied.
         """
-        self.log.setLevel(logging.DEBUG)
-
         if isinstance(input_models, ModelLibrary):
             library = input_models
         else:

--- a/jwst/source_catalog/detection.py
+++ b/jwst/source_catalog/detection.py
@@ -13,7 +13,6 @@ from photutils.segmentation import deblend_sources, detect_sources
 from photutils.utils.exceptions import NoDetectionsWarning
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class JWSTBackground:

--- a/jwst/source_catalog/reference_data.py
+++ b/jwst/source_catalog/reference_data.py
@@ -8,7 +8,6 @@ from stdatamodels.jwst import datamodels
 from stdatamodels.jwst.datamodels import ABVegaOffsetModel, ImageModel
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class ReferenceData:

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -22,7 +22,6 @@ from jwst import __version__ as jwst_version
 from ._wcs_helpers import pixel_scale_angle_at_skycoord
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class JWSTSourceCatalog:

--- a/jwst/spectral_leak/spectral_leak.py
+++ b/jwst/spectral_leak/spectral_leak.py
@@ -4,7 +4,6 @@ import numpy as np
 from stdatamodels.jwst import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(sp_leak_ref, ch1b, ch3a):

--- a/jwst/srctype/srctype.py
+++ b/jwst/srctype/srctype.py
@@ -5,7 +5,6 @@ from stdatamodels.jwst import datamodels
 from jwst.lib import pipe_utils
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def set_source_type(input_model, source_type=None):

--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -15,7 +15,6 @@ from jwst.lib.suffix import remove_suffix
 from ._cal_logs import _LOG_FORMATTER
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class JwstStep(Step):

--- a/jwst/stpipe/tests/steps/local.py
+++ b/jwst/stpipe/tests/steps/local.py
@@ -3,7 +3,6 @@ import logging
 from jwst.stpipe import Step
 
 log = logging.getLogger("FOO")
-log.setLevel(logging.DEBUG)
 
 
 class DummyStep(Step):

--- a/jwst/stpipe/utilities.py
+++ b/jwst/stpipe/utilities.py
@@ -13,7 +13,6 @@ from jwst import datamodels
 
 # Configure logging
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
 
 # Step classes that are not user-api steps
 NON_STEPS = [

--- a/jwst/straylight/straylight.py
+++ b/jwst/straylight/straylight.py
@@ -12,7 +12,6 @@ from jwst import datamodels
 from .calc_xart import xart_wrapper  # c extension
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def makemodel_ccode(fimg, xvec, imin, imax, lor_fwhm, lor_amp, g_fwhm, g_dx, g1_amp, g2_amp):

--- a/jwst/superbias/bias_sub.py
+++ b/jwst/superbias/bias_sub.py
@@ -7,7 +7,6 @@ import numpy as np
 from jwst.lib import reffile_utils
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(input_model, bias_model):

--- a/jwst/tso_photometry/tso_photometry.py
+++ b/jwst/tso_photometry/tso_photometry.py
@@ -9,7 +9,6 @@ from photutils.aperture import ApertureStats, CircularAnnulus, CircularAperture
 from stdatamodels.jwst.datamodels import CubeModel
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def tso_aperture_photometry(

--- a/jwst/tweakreg/tweakreg_catalog.py
+++ b/jwst/tweakreg/tweakreg_catalog.py
@@ -14,7 +14,6 @@ from stdatamodels.jwst.datamodels import ImageModel, dqflags
 from jwst.source_catalog.detection import JWSTBackground
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 __all__ = ["make_tweakreg_catalog"]

--- a/jwst/wavecorr/wavecorr.py
+++ b/jwst/wavecorr/wavecorr.py
@@ -9,7 +9,6 @@ from gwcs import wcstools
 from stdatamodels.jwst import datamodels
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def do_correction(input_model, wavecorr_file):

--- a/jwst/wfs_combine/wfs_combine.py
+++ b/jwst/wfs_combine/wfs_combine.py
@@ -8,7 +8,6 @@ from stdatamodels.jwst import datamodels
 from stdatamodels.jwst.datamodels import dqflags
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 DO_NOT_USE = dqflags.pixel["DO_NOT_USE"]
 

--- a/jwst/wfss_contam/observations.py
+++ b/jwst/wfss_contam/observations.py
@@ -11,7 +11,6 @@ from stdatamodels.jwst import datamodels
 from .disperse import dispersed_pixel
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def background_subtract(

--- a/jwst/wfss_contam/sens1d.py
+++ b/jwst/wfss_contam/sens1d.py
@@ -5,7 +5,6 @@ import numpy as np
 from jwst.photom.photom import find_row
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def get_photom_data(phot_model, filter_name, pupil, order):

--- a/jwst/wfss_contam/wfss_contam.py
+++ b/jwst/wfss_contam/wfss_contam.py
@@ -10,7 +10,6 @@ from .observations import Observation
 from .sens1d import get_photom_data
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def contam_corr(input_model, waverange, photom, max_cores):

--- a/jwst/white_light/white_light.py
+++ b/jwst/white_light/white_light.py
@@ -7,7 +7,6 @@ import numpy as np
 from astropy.table import QTable
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def white_light(input_model, min_wave=None, max_wave=None):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4053](https://jira.stsci.edu/browse/JP-4053)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Remove or relocate all log configuration that happens at the import level.

The most critical change here is to move log configuration in the scripts from the import level to the main function.  This should alleviate the issue of unintentional global log changes when all jwst modules are imported.  The `caplog` fixture for unit tests should be reliably usable again after this is merged.

Also addressed here: 
- Remove setLevel and addHandler calls for local loggers (i.e. `log.setLevel(logging.DEBUG)` at the top of the module).  This will have the effect of removing most of the DEBUG level messages from the cal_logs members of output datamodels, for standard log configuration settings (which default to INFO level).
- Remove a couple log level modifications inside step code (refpix, skymatch)
- Remove a few other scattered import level log configurations, in test code and `__init__` files.
- Remove a global setting of logging.captureWarnings in jwst.ami

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
