### PR TITLE
Update dq_init docs with missing step in description

### DIFF
--- a/docs/jwst/dq_init/description.rst
+++ b/docs/jwst/dq_init/description.rst
@@ -29,6 +29,10 @@ The actual process consists of the following steps:
 #. Propagate the DQ flags from the reference file DQ array to the science data "PIXELDQ"
    array using numpy's ``bitwise_or`` function.
 
+#. Propagate any DO_NOT_USE flags from the reference file DQ array to the science data
+   "GROUPDQ" array, if present - this lets us avoid generating a ramp for pixels
+   marked as unusable by the reference file.
+
 Note that when applying the ``dq_init`` step to FGS guide star data, as is done in
 the :ref:`calwebb_guider <calwebb_guider>` pipeline, the flags from the MASK reference
 file are propagated into the guide star dataset "DQ" array, instead of the "PIXELDQ" array.


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses an issue found by internal review of documentation - the step description failed to mention propagation of DNU flags into the groupdq array.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
