### PR TITLE
 TST: Fix tox for pyargs (try 2)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,10 @@ commands =
     python jwst/tests/test_import.py
 
 [testenv]
+# Run the tests in a temporary directory to make sure that we don't import
+# jwst from the source tree
+changedir = .tmp/{envname}
+
 description =
     run tests
     stdevdeps: with the latest developer version of upstream spacetelescope dependencies
@@ -55,7 +59,7 @@ commands_pre =
     pip freeze
 commands =
     pytest {toxinidir}/docs --pyargs jwst \
-    cov: --cov . --cov-report xml --cov-report term-missing \
+    cov: --cov jwst --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml --cov-report term-missing \
     regtests: --bigdata --slow --basetemp={homedir}/test_outputs \
     xdist: -n auto \
     {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ description = verify that install_requires in setup.cfg has correct dependencies
 # `extras` needs to be empty to check modules without additional dependencies
 extras =
 commands =
-    python jwst/tests/test_import.py
+    python {toxinidir}/jwst/tests/test_import.py
 
 [testenv]
 # Run the tests in a temporary directory to make sure that we don't import


### PR DESCRIPTION
Exorcise zero coverage (try 2). Follow-up of https://github.com/spacetelescope/jwst/pull/9550

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
* close https://github.com/spacetelescope/jwst/pull/9651
* close https://github.com/spacetelescope/jwst/pull/9649
* close https://github.com/spacetelescope/jwst/pull/9652

<!-- describe the changes comprising this PR here -->

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
