### PR TITLE
TST: Remove unused tox flags and outdated comment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,8 +221,6 @@ addopts = [
     "--color=yes",
 ]
 xfail_strict = true
-# This is for regtests. All unhandled warnings become exceptions for
-# regular CI in tox.ini file.
 filterwarnings = [
     "error"
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     check-dependencies
-    test{,-oldestdeps,-stdevdeps,-devdeps}{,-warnings,-regtests,-cov}-xdist
+    test{,-oldestdeps,-stdevdeps,-devdeps}{,-cov}-xdist
     build-{docs,dist}
     linkcheck
 
@@ -31,8 +31,6 @@ description =
     stdevdeps: with the latest developer version of upstream spacetelescope dependencies
     devdeps: with the latest developer version of upstream third-party dependencies
     oldestdeps: with the oldest supported version of key dependencies
-    warnings: treating warnings as errors
-    regtests: with --bigdata and --slow flags
     cov: with coverage
     xdist: using parallel processing
 pass_env =
@@ -45,8 +43,6 @@ pass_env =
     PASS_INVALID_VALUES
     VALIDATE_ON_ASSIGNMENT
     TEST_BIGDATA
-set_env =
-    regtests: CRDS_CONTEXT = jwst-edit
 extras =
     test
 deps =
@@ -61,7 +57,6 @@ commands_pre =
 commands =
     pytest {toxinidir}/docs --pyargs jwst \
     cov: --cov jwst --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml --cov-report term-missing \
-    regtests: --bigdata --slow --basetemp={homedir}/test_outputs \
     xdist: -n auto \
     {posargs}
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR addresses a couple of things I noticed while working on other stuff. Particularly regression test suite does not use tox (it uses uv + pytest), so the regtests stuff in `tox.ini` is not used and probably also broken. A warnings directive is defined but never used as well. Also outdated comment in pyproject.toml that no longer applies after #9490

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md)) https://github.com/spacetelescope/RegressionTests/actions/runs/16334361807 and https://github.com/spacetelescope/RegressionTests/actions/runs/16376297713
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
