### PR TITLE
TST: Fix dir for devdeps and docs in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,10 +52,10 @@ deps =
     xdist: pytest-xdist
     oldestdeps: minimum_dependencies
 commands_pre =
-    oldestdeps: minimum_dependencies jwst --filename requirements-min.txt
-    oldestdeps: pip install -r requirements-min.txt
-    stdevdeps: pip install -r requirements-dev-st.txt -U --upgrade-strategy eager
-    devdeps: pip install -r requirements-dev-thirdparty.txt -U --upgrade-strategy eager
+    oldestdeps: minimum_dependencies jwst --filename {toxinidir}/requirements-min.txt
+    oldestdeps: pip install -r {toxinidir}/requirements-min.txt
+    stdevdeps: pip install -r {toxinidir}/requirements-dev-st.txt -U --upgrade-strategy eager
+    devdeps: pip install -r {toxinidir}/requirements-dev-thirdparty.txt -U --upgrade-strategy eager
     pip freeze
 commands =
     pytest {toxinidir}/docs --pyargs jwst \
@@ -65,6 +65,7 @@ commands =
     {posargs}
 
 [testenv:build-docs]
+changedir = docs
 description = invoke sphinx-build to build the HTML docs
 extras = docs
 commands =


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR follows up on #9660 😬 

RT does use tox, so no need to run RT here.

### TODO

- [x] Make sure coverage is still non-zero.
- [x] Make sure devdeps green
- [x] Make sure oldestdeps is really old

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
