### PR TITLE
Test update following WFSS FITS unit change

### DIFF
--- a/jwst/datamodels/utils/tests/test_wfss_multispec.py
+++ b/jwst/datamodels/utils/tests/test_wfss_multispec.py
@@ -69,7 +69,7 @@ def test_make_wfss_multiexposure(input_model_maker, request):
     # test one vector-like column, which should come from the input specmodels
     # and one meta column, which should be copied from the schema by set_schema_units
     to_check = ["WAVELENGTH", "SOURCE_RA"]
-    expected_units = ["um", "degrees"]
+    expected_units = ["um", "deg"]
     for exposure in output_model.spec:
         for col in to_check:
             assert col in exposure.spec_table.columns.names

--- a/jwst/datamodels/utils/tests/test_wfss_multispec.py
+++ b/jwst/datamodels/utils/tests/test_wfss_multispec.py
@@ -195,7 +195,7 @@ def test_make_wfss_combined(comb1d_list):
 
         # test units
         to_check = ["WAVELENGTH", "SOURCE_RA"]
-        expected_units = ["um", "degrees"]
+        expected_units = ["um", "deg"]
         for col in to_check:
             assert col in spec.spec_table.columns.names
             assert spec.spec_table.columns[col].unit == expected_units[to_check.index(col)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "scikit-image>=0.20.0",
     "scipy>=1.14.1",
     "spherical-geometry>=1.3",
-    "stdatamodels @ git+https://github.com/tapastro/stdatamodels.git@rename-fits-units",
+    "stdatamodels @ git+https://github.com/spacetelescope/stdatamodels.git@main",
     "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
     "stpipe>=0.10.0,<0.11.0",
     "stsci.imagestats>=1.6.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "scikit-image>=0.20.0",
     "scipy>=1.14.1",
     "spherical-geometry>=1.3",
-    "stdatamodels @ git+https://github.com/spacetelescope/stdatamodels.git@main",
+    "stdatamodels @ git+https://github.com/tapastro/stdatamodels.git@rename-fits-units",
     "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
     "stpipe>=0.10.0,<0.11.0",
     "stsci.imagestats>=1.6.3",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Related to [JP-3931](https://jira.stsci.edu/browse/JP-3931)

<!-- describe the changes comprising this PR here -->
This PR follows from https://github.com/spacetelescope/stdatamodels/pull/529 , which modified the unit string for WFSS tables. This updates the truth to get passing tests.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
