### PR TITLE
STY: Apply flake8 to test modules and fix most violations

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -76,7 +76,6 @@ ban-relative-imports = "all"  # Disallow all relative imports.
     "TID252",  # Checks for relative imports
 ]
 "**/tests/test_*.py" = [
-    "F",      # Pyflakes (part of default flake8)
     "E",      # pycodestyle (part of default flake8)
     "W",      # pycodestyle (part of default flake8)
     "D",      # docstrings, see also numpydoc pre-commit action
@@ -85,6 +84,7 @@ ban-relative-imports = "all"  # Disallow all relative imports.
     "ARG",    # flake8-unused-arguments (prevent unused arguments)
     "B",      # flake8-bugbear (miscellaneous best practices to avoid bugs)
     "C4",     # flake8-comprehensions (best practices for comprehensions)
+    "F841",   # Local variable `result` is assigned to but never used
     "ICN",    # flake8-import-conventions (enforce import conventions)
     "INP",    # flake8-no-pep420 (prevent use of PEP420, i.e. implicit name spaces)
     "ISC",    # flake8-implicit-str-concat (conventions for concatenating long strings)
@@ -100,7 +100,6 @@ ban-relative-imports = "all"  # Disallow all relative imports.
     "YTT",    # flake8-2020 (prevent some specific gotchas from sys.version)
 ]
 "**/regtest/test_*.py" = [
-    "F",      # Pyflakes (part of default flake8)
     "E",      # pycodestyle (part of default flake8)
     "W",      # pycodestyle (part of default flake8)
     "D",      # docstrings, see also numpydoc pre-commit action

--- a/jwst/ami/tests/test_lg_model.py
+++ b/jwst/ami/tests/test_lg_model.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
 
 from jwst.ami import lg_model
 from jwst.ami.tests.conftest import PXSC_RAD

--- a/jwst/ami/tests/test_nrm_core.py
+++ b/jwst/ami/tests/test_nrm_core.py
@@ -5,9 +5,7 @@ Since nrm_core makes oifits objects, we also test oifits here.
 """
 
 import numpy as np
-import pytest
 import stdatamodels.jwst.datamodels as dm
-from numpy.testing import assert_allclose
 from scipy.signal import convolve
 
 from jwst.ami.bp_fix import filtwl_d

--- a/jwst/ami/tests/test_utils.py
+++ b/jwst/ami/tests/test_utils.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 import pytest
-import stdatamodels.jwst.datamodels as dm
 from numpy.testing import assert_allclose
 
 from jwst.ami import utils

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -2,7 +2,6 @@
 Test functions for NIRSPEC WCS - all modes.
 """
 
-import functools
 import shutil
 from math import cos, sin
 

--- a/jwst/clean_flicker_noise/tests/test_clean_flicker_noise.py
+++ b/jwst/clean_flicker_noise/tests/test_clean_flicker_noise.py
@@ -1,5 +1,3 @@
-import warnings
-
 import gwcs
 import numpy as np
 import pytest

--- a/jwst/cube_build/tests/test_configuration.py
+++ b/jwst/cube_build/tests/test_configuration.py
@@ -365,7 +365,6 @@ def test_calspec3_config_miri_multi_ch1(tmp_cwd, miri_full_coverage):
     par_filename = "None"
 
     pars = {
-        "channel": pars_input["channel"],
         "subchannel": pars_input["subchannel"],
         "grating": pars_input["grating"],
         "filter": pars_input["filter"],
@@ -498,8 +497,6 @@ def test_calspec3_config_nirspec_grating(tmp_cwd, nirspec_medium_coverage):
     pars = {
         "channel": pars_input["channel"],
         "subchannel": pars_input["subchannel"],
-        "grating": pars_input["grating"],
-        "filter": pars_input["filter"],
         "weighting": weighting,
         "grating": grating,
         "filter": filter,
@@ -544,8 +541,6 @@ def test_calspec3_config_nirspec_no_grating(tmp_cwd, nirspec_medium_coverage):
     pars = {
         "channel": pars_input["channel"],
         "subchannel": pars_input["subchannel"],
-        "grating": pars_input["grating"],
-        "filter": pars_input["filter"],
         "weighting": weighting,
         "grating": grating,
         "filter": filter,

--- a/jwst/emicorr/tests/test_emicorr.py
+++ b/jwst/emicorr/tests/test_emicorr.py
@@ -166,21 +166,6 @@ def model_with_emi(emicorr_model):
     return emicorr_model
 
 
-@pytest.fixture()
-def module_log_watcher(monkeypatch):
-    import logging
-
-    from jwst.tests.helpers import LogWatcher
-
-    # Set a log watcher to check for a log message at any level
-    # in the emicorr module
-    watcher = LogWatcher("")
-    logger = logging.getLogger("jwst.emicorr.emicorr")
-    for level in ["debug", "info", "warning", "error"]:
-        monkeypatch.setattr(logger, level, watcher)
-    return watcher
-
-
 def test_emicorrstep_skip_default():
     step = emicorr_step.EmiCorrStep()
     # Default is that step is skipped

--- a/jwst/emicorr/tests/test_emicorr.py
+++ b/jwst/emicorr/tests/test_emicorr.py
@@ -168,6 +168,10 @@ def model_with_emi(emicorr_model):
 
 @pytest.fixture()
 def module_log_watcher(monkeypatch):
+    import logging
+
+    from jwst.tests.helpers import LogWatcher
+
     # Set a log watcher to check for a log message at any level
     # in the emicorr module
     watcher = LogWatcher("")

--- a/jwst/extract_1d/tests/test_extract_1d_step.py
+++ b/jwst/extract_1d/tests/test_extract_1d_step.py
@@ -343,7 +343,7 @@ def test_save_output_wfss_l3(tmp_path, mock_niriss_wfss_l3):
     )
     result.close()
 
-    fname = f"test0_x1d.fits"
+    fname = "test0_x1d.fits"
     output_path = str(tmp_path / fname)
 
     assert os.path.isfile(output_path)

--- a/jwst/ipc/tests/test_ipc_corr.py
+++ b/jwst/ipc/tests/test_ipc_corr.py
@@ -1,5 +1,3 @@
-from collections import namedtuple
-
 import numpy as np
 import pytest
 from stdatamodels.jwst import datamodels

--- a/jwst/ipc/tests/test_x_irs2.py
+++ b/jwst/ipc/tests/test_x_irs2.py
@@ -1,7 +1,6 @@
 """Test the x_irs2 module in the ipc package."""
 
 import re
-from collections import namedtuple
 
 import numpy as np
 import pytest

--- a/jwst/pathloss/tests/test_pathloss_step.py
+++ b/jwst/pathloss/tests/test_pathloss_step.py
@@ -9,7 +9,6 @@ import jwst
 from jwst.assign_wcs import AssignWcsStep
 from jwst.assign_wcs.tests.test_nirspec import (
     create_nirspec_fs_file,
-    create_nirspec_ifu_file,
     create_nirspec_mos_file,
 )
 from jwst.extract_2d import Extract2dStep

--- a/jwst/pipeline/tests/test_calwebb_spec3.py
+++ b/jwst/pipeline/tests/test_calwebb_spec3.py
@@ -1,6 +1,5 @@
 import os
 
-import numpy as np
 import pytest
 import stdatamodels.jwst.datamodels as dm
 

--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -2,7 +2,6 @@
 Test using SDP-generated pools.
 """
 
-import logging
 import os
 import re
 from glob import glob

--- a/jwst/regtest/test_miri_image.py
+++ b/jwst/regtest/test_miri_image.py
@@ -1,7 +1,5 @@
-import tracemalloc
 import warnings
 
-import numpy as np
 import pytest
 from gwcs.wcstools import grid_from_bounding_box
 from numpy.testing import assert_allclose

--- a/jwst/regtest/test_nirspec_brightobj.py
+++ b/jwst/regtest/test_nirspec_brightobj.py
@@ -5,7 +5,6 @@ import pytest
 import stdatamodels.jwst.datamodels as dm
 
 from jwst.flatfield import FlatFieldStep
-from jwst.lib.suffix import replace_suffix
 from jwst.regtest.st_fitsdiff import STFITSDiff as FITSDiff
 from jwst.stpipe import Step
 

--- a/jwst/regtest/test_nirspec_fs_spec2.py
+++ b/jwst/regtest/test_nirspec_fs_spec2.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 
 import numpy as np
 import pytest

--- a/jwst/regtest/test_nirspec_ifu_internal_cal.py
+++ b/jwst/regtest/test_nirspec_ifu_internal_cal.py
@@ -1,7 +1,5 @@
 """Test CubeBuildStep NIRSPEC internal_cal cubes"""
 
-import warnings
-
 import pytest
 
 from jwst.regtest.st_fitsdiff import STFITSDiff as FITSDiff

--- a/jwst/regtest/test_nirspec_ifu_spec2.py
+++ b/jwst/regtest/test_nirspec_ifu_spec2.py
@@ -1,7 +1,5 @@
 """Regression tests for NIRSpec IFU"""
 
-import warnings
-
 import pytest
 
 from jwst.regtest import regtestdata as rt

--- a/jwst/regtest/test_nirspec_ifu_spec3.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3.py
@@ -1,7 +1,5 @@
 """Regression tests for NIRSpec IFU"""
 
-import warnings
-
 import pytest
 
 from jwst.regtest import regtestdata as rt

--- a/jwst/regtest/test_nirspec_ifu_spec3_emsm.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3_emsm.py
@@ -1,7 +1,5 @@
 """Regression tests for NIRSpec IFU"""
 
-import warnings
-
 import pytest
 
 from jwst.regtest import regtestdata as rt

--- a/jwst/regtest/test_nirspec_ifu_spec3_moving_target.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3_moving_target.py
@@ -1,5 +1,3 @@
-import warnings
-
 import pytest
 
 from jwst.regtest.st_fitsdiff import STFITSDiff as FITSDiff

--- a/jwst/regtest/test_nirspec_ifu_spec3_pixelreplace.py
+++ b/jwst/regtest/test_nirspec_ifu_spec3_pixelreplace.py
@@ -1,7 +1,5 @@
 """Regression tests for NIRSpec IFU"""
 
-import warnings
-
 import pytest
 
 from jwst.regtest import regtestdata as rt

--- a/jwst/regtest/test_nirspec_masterbackground.py
+++ b/jwst/regtest/test_nirspec_masterbackground.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import pytest
 import stdatamodels.jwst.datamodels as dm

--- a/jwst/regtest/test_nirspec_steps_spec2.py
+++ b/jwst/regtest/test_nirspec_steps_spec2.py
@@ -1,7 +1,5 @@
 """Regression tests for NIRSpec IFU"""
 
-import warnings
-
 import numpy as np
 import pytest
 import stdatamodels.jwst.datamodels as dm

--- a/jwst/regtest/test_nirspec_wcs.py
+++ b/jwst/regtest/test_nirspec_wcs.py
@@ -1,5 +1,3 @@
-import warnings
-
 import pytest
 from gwcs.wcstools import grid_from_bounding_box
 from numpy.testing import assert_allclose

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 from os.path import abspath
@@ -9,7 +8,7 @@ from astropy.extern.configobj.configobj import ConfigObj
 from astropy.utils.data import get_pkg_data_filename
 from crds.core.exceptions import CrdsLookupError
 from stdatamodels.jwst import datamodels
-from stpipe import cmdline, crds_client
+from stpipe import crds_client
 from stpipe.config import StepConfig
 from stpipe.config_parser import ValidationError
 

--- a/jwst/tso_photometry/tests/test_tso_photometry.py
+++ b/jwst/tso_photometry/tests/test_tso_photometry.py
@@ -2,7 +2,6 @@ import math
 
 import astropy.units as u
 import numpy as np
-import pytest
 from stdatamodels.jwst import datamodels
 
 from jwst.lib import reffile_utils

--- a/jwst/wavecorr/tests/test_wavecorr.py
+++ b/jwst/wavecorr/tests/test_wavecorr.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import numpy as np
 import pytest
 from astropy.utils.data import get_pkg_data_filename


### PR DESCRIPTION

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR addresses most F rules in test modules.

Motivation: I have flake8 hooked into my Emacs and it bothers me that it complains about unused imports in test modules I work on, but the pre-commit here just happily ignores such travesty.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md)) https://github.com/spacetelescope/RegressionTests/actions/runs/16374773497
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
