### PR TITLE
JP-4067: Fix white_light crash on repeated time stamps

### DIFF
--- a/changes/9672.white_light.rst
+++ b/changes/9672.white_light.rst
@@ -1,0 +1,1 @@
+Fix a crash caused by repeated time stamps in the spectral table. If found, warn and keep only the first one.

--- a/jwst/white_light/tests/test_white_light.py
+++ b/jwst/white_light/tests/test_white_light.py
@@ -13,6 +13,15 @@ from jwst.tests.helpers import LogWatcher
 from jwst.white_light.white_light import _determine_wavelength_range, white_light
 from jwst.white_light.white_light_step import WhiteLightStep
 
+TIME_KEYS = [
+    "MJD-BEG",
+    "MJD-AVG",
+    "MJD-END",
+    "TDB-BEG",
+    "TDB-MID",
+    "TDB-END",
+]
+
 
 @pytest.fixture(scope="module")
 def make_datamodel():
@@ -140,19 +149,12 @@ def make_datamodel():
 
     # set blank times for one integration in order 1 to test warning raise
     model.spec[0].spec_table["INT_NUM"][2] = 0
-    time_keys = [
-        "MJD-BEG",
-        "MJD-AVG",
-        "MJD-END",
-        "TDB-BEG",
-        "TDB-MID",
-        "TDB-END",
-    ]
-    for key in time_keys:
+
+    for key in TIME_KEYS:
         model.spec[0].spec_table[key][2] = np.nan
 
     # set one time to a different value for order 2 to test table integration
-    for key in time_keys:
+    for key in TIME_KEYS:
         model.spec[1].spec_table[key][2] += 0.01
 
     return model
@@ -162,7 +164,7 @@ def test_white_light(make_datamodel, monkeypatch):
     """Test white light step"""
     data = make_datamodel
 
-    watcher = LogWatcher("1 spectra in order 1 with no mid time or repeated mid time (20")
+    watcher = LogWatcher("1 spectra in order 1 with no mid time or duplicate mid time (20")
     monkeypatch.setattr(logging.getLogger("jwst.white_light.white_light"), "warning", watcher)
     result = white_light(data)
     watcher.assert_seen()
@@ -250,33 +252,29 @@ def test_white_light_multi_detector(make_datamodel):
     assert_allclose(result["whitelight_flux_order_2_NRS2"], expected_flux_order_2, equal_nan=True)
 
 
-def test_white_light_repeated_times(monkeypatch, make_datamodel):
-    """Test white light step on data with repeated time stamps."""
-    # Set all integration times to the same value for order 1
+def test_white_light_duplicate_times(monkeypatch, make_datamodel):
+    """Test white light step on data with duplicate time stamps."""
+    # Set all times to the same value for order 1
     data = make_datamodel.copy()
-    data.spec[0].spec_table["MJD-AVG"][:] = 0.1
+    for key in TIME_KEYS:
+        data.spec[0].spec_table[key][:] = data.spec[0].spec_table[key][0]
 
-    watcher = LogWatcher("4 spectra in order 1 with no mid time or repeated mid time")
+    watcher = LogWatcher("4 spectra in order 1 with no mid time or duplicate mid time")
     monkeypatch.setattr(logging.getLogger("jwst.white_light.white_light"), "warning", watcher)
     result = white_light(data)
     watcher.assert_seen()
 
-    n_spec = len(data.spec[0].spec_table)
-    times = np.linspace(0, 1, n_spec + 1)
-    start_times = times[:-1]
-    end_times = times[1:]
-    mid_times = (start_times + end_times) / 2.0
-
-    # add the adjusted midtime for order 2
-    mid_times[2] = 0.51
-    expected_tdb = mid_times + 3
+    # Expected times match input for the order 2 spectrum
+    n_spec = len(data.spec[1].spec_table)
+    mid_times = data.spec[1].spec_table["MJD-AVG"]
+    expected_tdb = data.spec[1].spec_table["TDB-MID"]
 
     np.testing.assert_allclose(result["MJD_UTC"], mid_times)
     np.testing.assert_allclose(result["BJD_TDB"], expected_tdb, equal_nan=True)
     assert result["whitelight_flux_order_1"].shape == (len(mid_times),)
     assert result["whitelight_flux_order_2"].shape == (len(mid_times),)
 
-    # For order 1, repeated timestamps so only the first flux is kept
+    # For order 1, duplicate timestamps so only the first flux is kept
     assert np.sum(np.isnan(result["whitelight_flux_order_1"])) == n_spec - 1
 
     # check fluxes are summed appropriately

--- a/jwst/white_light/tests/test_white_light.py
+++ b/jwst/white_light/tests/test_white_light.py
@@ -162,7 +162,7 @@ def test_white_light(make_datamodel, monkeypatch):
     """Test white light step"""
     data = make_datamodel
 
-    watcher = LogWatcher("There were 1 spectra in order 1 with no mid time (20")
+    watcher = LogWatcher("1 spectra in order 1 with no mid time or repeated mid time (20")
     monkeypatch.setattr(logging.getLogger("jwst.white_light.white_light"), "warning", watcher)
     result = white_light(data)
     watcher.assert_seen()
@@ -201,7 +201,7 @@ def test_white_light(make_datamodel, monkeypatch):
 
 
 def test_white_light_multi_detector(make_datamodel):
-    """Test white light step"""
+    """Test white light step on data with multiple detectors."""
     # Set the detectors in the two spec tables to different values
     data = make_datamodel.copy()
     data.spec[0].detector = "NRS1"
@@ -248,6 +248,51 @@ def test_white_light_multi_detector(make_datamodel):
 
     assert_allclose(result["whitelight_flux_order_1_NRS1"], expected_flux_order_1, equal_nan=True)
     assert_allclose(result["whitelight_flux_order_2_NRS2"], expected_flux_order_2, equal_nan=True)
+
+
+def test_white_light_repeated_times(monkeypatch, make_datamodel):
+    """Test white light step on data with repeated time stamps."""
+    # Set all integration times to the same value for order 1
+    data = make_datamodel.copy()
+    data.spec[0].spec_table["MJD-AVG"][:] = 0.1
+
+    watcher = LogWatcher("4 spectra in order 1 with no mid time or repeated mid time")
+    monkeypatch.setattr(logging.getLogger("jwst.white_light.white_light"), "warning", watcher)
+    result = white_light(data)
+    watcher.assert_seen()
+
+    n_spec = len(data.spec[0].spec_table)
+    times = np.linspace(0, 1, n_spec + 1)
+    start_times = times[:-1]
+    end_times = times[1:]
+    mid_times = (start_times + end_times) / 2.0
+
+    # add the adjusted midtime for order 2
+    mid_times[2] = 0.51
+    expected_tdb = mid_times + 3
+
+    np.testing.assert_allclose(result["MJD_UTC"], mid_times)
+    np.testing.assert_allclose(result["BJD_TDB"], expected_tdb, equal_nan=True)
+    assert result["whitelight_flux_order_1"].shape == (len(mid_times),)
+    assert result["whitelight_flux_order_2"].shape == (len(mid_times),)
+
+    # For order 1, repeated timestamps so only the first flux is kept
+    assert np.sum(np.isnan(result["whitelight_flux_order_1"])) == n_spec - 1
+
+    # check fluxes are summed appropriately
+    expected_flux_per_spec = np.sum(np.arange(1, 21, dtype=np.float32))
+    expected_flux = np.array(
+        [
+            expected_flux_per_spec,
+        ]
+        * len(mid_times)
+    )
+    expected_flux_order_1 = expected_flux.copy()
+    expected_flux_order_1[1:] = np.nan
+    expected_flux_order_2 = expected_flux.copy()
+
+    assert_allclose(result["whitelight_flux_order_1"], expected_flux_order_1, equal_nan=True)
+    assert_allclose(result["whitelight_flux_order_2"], expected_flux_order_2, equal_nan=True)
 
 
 @pytest.fixture

--- a/jwst/white_light/white_light.py
+++ b/jwst/white_light/white_light.py
@@ -70,6 +70,14 @@ def white_light(input_model, waverange_table=None, min_wave=None, max_wave=None)
         # Get mid times for all integrations in this order
         mid_time = spec.spec_table["MJD-AVG"]
         mid_tdb = spec.spec_table["TDB-MID"]
+
+        # Check for unique time stamps: keep only the first
+        _, unq_idx = np.unique(mid_time, return_index=True)
+        is_unique = np.full(mid_time.shape, False)
+        is_unique[unq_idx] = True
+        mid_time[~is_unique] = np.nan
+
+        # Store time arrays
         good = ~np.isnan(mid_time)
         if len(mid_times) == 0:
             mid_times = mid_time
@@ -94,9 +102,10 @@ def white_light(input_model, waverange_table=None, min_wave=None, max_wave=None)
         if problems > 0:
             log.warning(
                 f"There were {problems} spectra in order {spectral_order} "
-                f"with no mid time ({100.0 * problems / n_spec} percent of spectra). "
-                "These spectra will be ignored in the output table."
+                "with no mid time or repeated mid time "
+                f"({100.0 * problems / n_spec} percent of spectra). "
             )
+            log.warning("These spectra will be ignored in the output table.")
 
     # Set up output table, removing problems
     tbl = _make_empty_output_table(input_model)

--- a/jwst/white_light/white_light.py
+++ b/jwst/white_light/white_light.py
@@ -102,7 +102,7 @@ def white_light(input_model, waverange_table=None, min_wave=None, max_wave=None)
         if problems > 0:
             log.warning(
                 f"There were {problems} spectra in order {spectral_order} "
-                "with no mid time or repeated mid time "
+                "with no mid time or duplicate mid time "
                 f"({100.0 * problems / n_spec} percent of spectra). "
             )
             log.warning("These spectra will be ignored in the output table.")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4067](https://jira.stsci.edu/browse/JP-4067)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Catch repeated time stamps in the spectral table. If found, warn and keep only the first one.

Test data is:
jw02183-o117_20250411t072937_tso3_00001_asn.json, containing jw02183117001_03103_00001-seg001_nrcalong_calints.fits

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
