### PR TITLE
Unit test source catalog against specific values

### DIFF
--- a/jwst/source_catalog/tests/test_source_catalog.py
+++ b/jwst/source_catalog/tests/test_source_catalog.py
@@ -127,6 +127,23 @@ def test_source_catalog(nircam_model, npixels, nsources):
     min_snr = np.min(cat["isophotal_flux"] / cat["isophotal_flux_err"])
     assert min_snr >= 100
 
+    if npixels == 5 and nsources == 2:
+        # test values of some specific computed quantities
+        assert np.isclose(cat["xcentroid"][1], 19.46399720865899)
+        assert np.isclose(cat["ycentroid"][1], 41.95288393407728)
+        assert np.isclose(cat["aper_bkg_flux"][1].value, 1400000.0)
+        assert np.isclose(cat["aper_bkg_flux_err"][1].value, 85223.70700074881)
+        assert np.isclose(cat["CI_50_30"][1], 2.3342599432074653)
+        assert np.isclose(cat["sharpness"][1], 0.9102634628764403)
+        assert np.isclose(cat["roundness"][1], 1.5954264)
+        assert np.isclose(cat["nn_dist"][1].value, 53.0737632103816)
+        assert np.isclose(cat["isophotal_flux"][1], 930.9999841451645)
+        assert np.isclose(cat["isophotal_flux_err"][1], 3.6102633)
+        assert np.isclose(cat["semimajor_sigma"][1].value, 18.847635525516534)
+        assert np.isclose(cat["semiminor_sigma"][1].value, 7.031371175038476)
+        assert np.isclose(cat["ellipticity"][1], 0.626936165784871)
+        assert np.isclose(cat["orientation"][1].value, -72.75413766990114)
+
 
 def test_source_catalog_no_sources(nircam_model, monkeypatch):
     npixels = 5000


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
Relates to https://github.com/spacetelescope/jwst/pull/9671

<!-- describe the changes comprising this PR here -->
This PR adds a unit test to the source catalog step, which was originally written in support of the above-linked PR. That PR is getting closed without merge but the unit test is still useful to have.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
