### PR TITLE
JP-3673: Update background-subtraction intermediate products for WFSS

### DIFF
--- a/jwst/background/background_step.py
+++ b/jwst/background/background_step.py
@@ -27,6 +27,7 @@ class BackgroundStep(Step):
         wfss_maxiter = integer(default=5)  # WFSS iterative outlier rejection max iterations
         wfss_rms_stop = float(default=0)  # WFSS iterative outlier rejection RMS improvement threshold (percent)
         wfss_outlier_percent = float(default=1)  # WFSS outlier percentile to reject per iteration
+        wfss_save_bsub = boolean(default=False)  # Save the background mask used in an extension
     """  # noqa: E501
 
     # These reference files are only used for WFSS/GRISM or SOSS data.
@@ -87,6 +88,12 @@ class BackgroundStep(Step):
                 result = input_model.copy()
                 result.meta.cal_step.bkg_subtract = "SKIPPED"
             else:
+                # Save the intermediary file with the background mask
+                if self.wfss_save_bsub:
+                    wfss_mask_bsub = self.make_output_path(suffix="bsub")
+                    self.output_file = wfss_mask_bsub
+                    self.suffix = "bsub"
+                    result.save(wfss_mask_bsub)
                 result.meta.cal_step.bkg_subtract = "COMPLETE"
 
         elif input_model.meta.exposure.type == "NIS_SOSS":

--- a/jwst/background/background_sub_wfss.py
+++ b/jwst/background/background_sub_wfss.py
@@ -110,6 +110,7 @@ def subtract_wfss_bkg(
     result.data = input_model.data - subtract_this
     result.dq = np.bitwise_or(input_model.dq, bkg_ref.dq)
     result.meta.background.scaling_factor = factor
+    result.bkgdmask = bkg_mask
 
     log.info(f"Average of scaled background image = {np.nanmean(subtract_this):.3e}")
     log.info(f"Scaling factor = {factor:.5e}")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3673](https://jira.stsci.edu/browse/JP-3673)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR addresses adding an extension for the background mask used for WFSS data to the datamodel and intermediary file.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
