### PR TITLE
JP-3943: Fix unit handling for orientation column when iraf is selected finder

### DIFF
--- a/jwst/source_catalog/tests/test_source_catalog.py
+++ b/jwst/source_catalog/tests/test_source_catalog.py
@@ -220,6 +220,13 @@ def test_source_catalog_point_sources(finder, nircam_model, tmp_cwd):
     cat_name = "step_SourceCatalogStep_cat.ecsv"
     assert Path(cat_name).exists()
 
+    # test coverage for bug that iraf orientation did not have units
+    assert "orientation" in cat.colnames
+    if finder != "dao":
+        assert cat["orientation"].unit == "deg"
+    else:
+        assert np.all(np.isnan(cat["orientation"]))
+
     if finder == "segmentation":
         segm_name = "step_SourceCatalogStep_segm.fits"
         assert Path(segm_name).exists()

--- a/jwst/tweakreg/tweakreg_catalog.py
+++ b/jwst/tweakreg/tweakreg_catalog.py
@@ -2,6 +2,7 @@ import inspect
 import logging
 import warnings
 
+import astropy.units as u
 import numpy as np
 from astropy.convolution import Gaussian2DKernel, convolve
 from astropy.stats import SigmaClip, gaussian_fwhm_to_sigma
@@ -160,7 +161,7 @@ def _convolve_data(data, kernel_fwhm, mask=None):
 
 def _rename_columns(sources):
     """
-    Rename catalog columns to be consistent between the three star finders.
+    Rename catalog columns and add astropy units to be consistent between the three star finders.
 
     Table is modified in place.
 
@@ -178,6 +179,10 @@ def _rename_columns(sources):
     for old_col, new_col in rename_map.items():
         if old_col in sources.colnames:
             sources.rename_column(old_col, new_col)
+    units_map = {"orientation": u.deg}
+    for col, unit in units_map.items():
+        if col in sources.colnames:
+            sources[col] = u.Quantity(sources[col], unit=unit)
 
 
 def _sourcefinder_wrapper(data, threshold_img, kernel_fwhm, mask=None, **kwargs):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Bugfix for issue discovered while testing [JP-3943](https://jira.stsci.edu/browse/JP-3943)

This PR fixes a crash caused by the "orientation" column of the source catalog lacking Astropy units when the sourcefinder was set to "iraf".

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
