### PR TITLE
remove uncommon datamodels.open usage

### DIFF
--- a/jwst/regtest/test_stfitsdiff.py
+++ b/jwst/regtest/test_stfitsdiff.py
@@ -28,7 +28,7 @@ def mock_rampfiles(tmp_path_factory):
     data[1, 1, ...] += np.arange(3) * 0.0001
     pixdq = np.ones(shape=(nrows, ncols), dtype=int)
     gdq = np.ones(shape=(nints, ngroups, nrows, ncols), dtype=int)
-    with datamodels.open(data=data) as model:
+    with datamodels.JwstDataModel(data=data) as model:
         model.meta.observation.date = "2015-10-13"
         model.meta.instrument.gwa_tilt = 37.0610
         model.save(diff_exts)

--- a/jwst/stpipe/tests/steps/__init__.py
+++ b/jwst/stpipe/tests/steps/__init__.py
@@ -101,7 +101,7 @@ class OptionalRefTypeStep(Step):
     reference_file_types = ["to_be_ignored_ref_type"]
 
     def process(self):  # noqa: D102
-        ref_file = self.get_reference_file(datamodels.open(), "to_be_ignored_ref_type")
+        ref_file = self.get_reference_file(datamodels.JwstDataModel(), "to_be_ignored_ref_type")
         assert ref_file == ""  # noqa: S101
 
 

--- a/jwst/stpipe/tests/test_step.py
+++ b/jwst/stpipe/tests/test_step.py
@@ -707,7 +707,7 @@ def test_crds_override():
         "SomeOtherStepOriginal", par1=42.0, par2="abc def", override_flat_field=ff_name
     )
 
-    fd = step.get_reference_file(datamodels.open(), "flat_field")
+    fd = step.get_reference_file(datamodels.JwstDataModel(), "flat_field")
     assert fd == ff_name
 
 


### PR DESCRIPTION
Replace a few uncommon uses of `datamodels.open` with the more commonly used API.

Regtests pass: https://github.com/spacetelescope/RegressionTests/actions/runs/16529705448

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
