### PR TITLE
JP-3961 - Replace NIRDetector subclass methods with generics

### DIFF
--- a/jwst/lib/reffile_utils.py
+++ b/jwst/lib/reffile_utils.py
@@ -564,6 +564,42 @@ def science_detector_frame_transform(data, fastaxis, slowaxis):
     return data
 
 
+def detector_science_frame_transform(data, fastaxis, slowaxis):
+    """
+    Swap data array between detector and science frames.
+
+    Use the fastaxis and slowaxis keywords to invert
+    and/or transpose data array axes to move between the
+    detector frame and the science frame.
+
+    Parameters
+    ----------
+    data : np.array
+        Science array containing at least two dimensions.
+    fastaxis : int
+        Value of the fastaxis keyword for the data array
+        to be transformed.
+    slowaxis : int
+        Value of the slowaxis keyword for the data array
+        to be transformed.
+
+    Returns
+    -------
+    np.array
+        Data array transformed between detector and
+        science frames.
+    """
+    # If fastaxis is x-axis
+    if np.abs(fastaxis) == 1:
+        # Use sign of keywords to possibly reverse the ordering of the axes.
+        data = data[..., :: slowaxis // np.abs(slowaxis), :: fastaxis // np.abs(fastaxis)]
+    # Else fastaxis is y-axis, also need to transpose array
+    else:
+        data = np.swapaxes(data, -2, -1)
+        data = data[..., :: fastaxis // np.abs(fastaxis), :: slowaxis // np.abs(slowaxis)]
+    return data
+
+
 class MatchRowError(Exception):
     """Raised when more than one row is matched in a FITS table or list of dict."""
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3961](https://jira.stsci.edu/browse/JP-3961)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR adds a new function to lib/reffile_utils to convert an array from DMS to detector format using fastaxis and slowaxis.
Replaces all the NIRDetector subclasses (one for each NIR detector) with a single set of NIRDetector methods

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
