### PR TITLE
JP-4074: Allowing Nirspec prism ifu cubes to have non-linear wavelength range

### DIFF
--- a/changes/9718.cube_build.rst
+++ b/changes/9718.cube_build.rst
@@ -1,1 +1,1 @@
-Force NIRSpec Prism IFU cubes to have non-linear wavelength range
+Force NIRSpec prism IFU cubes to have non-linear wavelength range

--- a/changes/9718.cube_build.rst
+++ b/changes/9718.cube_build.rst
@@ -1,1 +1,1 @@
-Force NIRSpec prism IFU cubes to have non-linear wavelength range
+Allow NIRSpec prism IFU cubes to have non-linear wavelength range if output_type=multi.

--- a/changes/9718.cube_build.rst
+++ b/changes/9718.cube_build.rst
@@ -1,0 +1,1 @@
+Force NIRSpec Prism IFU cubes to have non-linear wavelength range

--- a/docs/jwst/cube_build/arguments.rst
+++ b/docs/jwst/cube_build/arguments.rst
@@ -23,9 +23,9 @@ each band will be created.
     wavelength dimension. In both cases,  the input filename  suffix ``cal`` is replaced with ``s3d``.
 
   - ``pipeline = 3`` setups up the results for making ``calwebb_spec3`` pipeline type cbes. For NIRSpec data
-    the default rules will a single IFU cube from the same grating and filter, while for MIRI data the a single
-    IFU cube is create for each channel and band. In both cases, the output IFU cube will contain the grating and
-    filter name [NIRSpec] or channel and band (MIRI]. 
+    the default rules will produce a single IFU cube from the same grating and filter, while for MIRI data a single
+    IFU cube is created for each channel and band. In both cases, the output IFU cube will contain the grating and
+    filter name (NIRSpec) or channel and band (MIRI). 
 
 ``channel [string]``
   This is a MIRI only option and the valid values are 1, 2, 3, 4, and ALL.
@@ -75,20 +75,20 @@ each band will be created.
     grating option into a single IFU cube.  This option is currently not being used by the pipeline.
     For NIRSpec data ``output_type = band or multi`` only. 
 
-  - ``output_type = multi`` combines data  into a single "uber".
+  - ``output_type = multi`` combines data  into a single "uber" cube.
     In addition, if channel, band, grating, or filter are also set, then only the data set by those
     parameters will be combined into an "uber" cube.
-    If the ``output_type=multi`` option is used with  NIRSPec prism data, then the output IFU cubes will
+    If the ``output_type=multi`` option is used with  NIRSpec prism data, then the output IFU cubes will
     have a non-linear wavelength plane. 
 
 
   The default rules for creating IFU cube depend on the instrument and  which pipeline called `cube_build`.
   
-  - ``calwebb_spec2`` pipeline rules for NIRSpec is produce ``output_type`` = band.
-  - ``calwebb_spec3`` pipeline rules for NIRSpec is produce ``output_type`` = band.
+  - ``calwebb_spec2`` pipeline rules for NIRSpec is to produce ``output_type`` = band.
+  - ``calwebb_spec3`` pipeline rules for NIRSpec is to produce ``output_type`` = band.
 
-  - ``calwebb_spec2`` pipeline rules for MIRI is produce ``output_type`` = multi.
-  - ``calwebb_spec3`` pipeline rules for MIRI is produce ``output_type`` = band.    
+  - ``calwebb_spec2`` pipeline rules for MIRI is to produce ``output_type`` = multi.
+  - ``calwebb_spec3`` pipeline rules for MIRI is to produce ``output_type`` = band.    
 
 
 

--- a/docs/jwst/cube_build/arguments.rst
+++ b/docs/jwst/cube_build/arguments.rst
@@ -14,13 +14,13 @@ each band will be created.
   have a different name depending which pipeline calls it. This parameter defaults to 3 which follows the rules
   for creating cubes based on the ``calwebb_spec3`` pipeline and is also the behavior when running
   ``cube_build`` stand-alone. When the ``calwebb_spec2`` pipeline  calls cube
-  build it sets `pipeline = 2`.   When running stand-alone or in 
-  ``calwebb_spec3`` pipeline the parameter `pipeline=3` is set for ``cube_build``.
+  build it sets ``pipeline = 2``.   When running stand-alone or in 
+  ``calwebb_spec3`` pipeline the parameter ``pipeline=3`` is set for ``cube_build``.
   
   - ``pipeline = 2`` sets up the rules for making ``calwebb_spec2`` pipeline type cubes. For NIRSpec data the default
     rules   produce cubes with a single grating and filter and  with a linear wavelength dimension. For MIRI data
     the default rules produce a single IFU cube contains the two channels in the input data with a non-linear
-    wavelength dimension. In both cases,  the input filename  suffix `cal` is replaced with `s3d`.
+    wavelength dimension. In both cases,  the input filename  suffix ``cal`` is replaced with ``s3d``.
 
   - ``pipeline = 3`` setups up the results for making ``calwebb_spec3`` pipeline type cbes. For NIRSpec data
     the default rules will a single IFU cube from the same grating and filter, while for MIRI data the a single
@@ -78,17 +78,17 @@ each band will be created.
   - ``output_type = multi`` combines data  into a single "uber".
     In addition, if channel, band, grating, or filter are also set, then only the data set by those
     parameters will be combined into an "uber" cube.
-    If the `output_type=multi` option is used with  NIRSPec prism data, then the output IFU cubes will
+    If the ``output_type=multi`` option is used with  NIRSPec prism data, then the output IFU cubes will
     have a non-linear wavelength plane. 
 
 
   The default rules for creating IFU cube depend on the instrument and  which pipeline called `cube_build`.
   
-  - `'calwebb_spec2`` pipeline rules for NIRSpec is produce ``output_type`` = band.
-  - `'calwebb_spec3`` pipeline rules for NIRSpec is produce ``output_type`` = band.
+  - ``calwebb_spec2`` pipeline rules for NIRSpec is produce ``output_type`` = band.
+  - ``calwebb_spec3`` pipeline rules for NIRSpec is produce ``output_type`` = band.
 
-  - `'calwebb_spec2`` pipeline rules for MIRI is produce ``output_type`` = multi.
-  - `'calwebb_spec3`` pipeline rules for MIRI is produce ``output_type`` = band.    
+  - ``calwebb_spec2`` pipeline rules for MIRI is produce ``output_type`` = multi.
+  - ``calwebb_spec3`` pipeline rules for MIRI is produce ``output_type`` = band.    
 
 
 

--- a/docs/jwst/cube_build/arguments.rst
+++ b/docs/jwst/cube_build/arguments.rst
@@ -59,11 +59,11 @@ each band will be created.
 
   - ``output_type = multi`` combines data  into a single "uber" IFU cube, this the default mode for
     :ref:`calwebb_spec2 <calwebb_spec2>` pipeline for MIRI data (the default mode for NIRSpec data in the
-   :ref:`calwebb_spec2 <calwebb_spec2>` pipeline is to produce ``band`` cubes). 
-    If in addition,  channel, band, grating, or filter are also set, then only the data set by those
+    :ref:`calwebb_spec2 <calwebb_spec2>` pipeline is to produce ``band`` cubes). 
+    If in addition, if channel, band, grating, or filter are also set, then only the data set by those
     parameters will be combined into an "uber" cube.
     If the `output_type=multi` 	option is used with  NIRSPec prism data when running the cube_build step
-    standalone  the output IFU cubes will have a non-linear wavelength plane. 
+    standalone, then  the output IFU cubes will have a non-linear wavelength plane. 
 
 The following arguments control the size and sampling characteristics of the output IFU cube.
 

--- a/docs/jwst/cube_build/arguments.rst
+++ b/docs/jwst/cube_build/arguments.rst
@@ -10,12 +10,12 @@ created. For example, if the input data span several bands, but ``output_type = 
 each band will be created.
 
 ``pipeline [integer]``
-  `Cube_build` can be called from ``calwebb_spec2``, ``calwebb_spec3``, or stand-alone. The output IFU cubes
+  ``Cube_build`` can be called from ``calwebb_spec2``, ``calwebb_spec3``, or stand-alone. The output IFU cubes
   have a different name depending which pipeline calls it. This parameter defaults to 3 which follows the rules
   for creating cubes based on the ``calwebb_spec3`` pipeline and is also the behavior when running
-  `cube_build` stand-alone. When the ``calwebb_spec2` pipeline  calls cube
+  ``cube_build`` stand-alone. When the ``calwebb_spec2`` pipeline  calls cube
   build it sets `pipeline = 2`.   When running stand-alone or in 
-  ``calwebb_spec3`` pipeline the parameter `pipeline=3` is set for `cube_build`.
+  ``calwebb_spec3`` pipeline the parameter `pipeline=3` is set for ``cube_build``.
   
   - ``pipeline = 2`` sets up the rules for making ``calwebb_spec2`` pipeline type cubes. For NIRSpec data the default
     rules   produce cubes with a single grating and filter and  with a linear wavelength dimension. For MIRI data

--- a/docs/jwst/cube_build/arguments.rst
+++ b/docs/jwst/cube_build/arguments.rst
@@ -75,10 +75,10 @@ each band will be created.
     grating option into a single IFU cube.  This option is currently not being used by the pipeline.
     For NIRSpec data ``output_type = band or multi`` only. 
 
-  - ``output_type = multi`` combines data  into a single "uber"
+  - ``output_type = multi`` combines data  into a single "uber".
     In addition, if channel, band, grating, or filter are also set, then only the data set by those
     parameters will be combined into an "uber" cube.
-    If the `output_type=multi` 	option is used with  NIRSPec prism data, then the output IFU cubes will
+    If the `output_type=multi` option is used with  NIRSPec prism data, then the output IFU cubes will
     have a non-linear wavelength plane. 
 
 

--- a/docs/jwst/cube_build/arguments.rst
+++ b/docs/jwst/cube_build/arguments.rst
@@ -18,8 +18,8 @@ each band will be created.
   ``calwebb_spec3`` pipeline the parameter ``pipeline=3`` is set for ``cube_build``.
   
   - ``pipeline = 2`` sets up the rules for making ``calwebb_spec2`` pipeline type cubes. For NIRSpec data the default
-    rules   produce cubes with a single grating and filter and  with a linear wavelength dimension. For MIRI data
-    the default rules produce a single IFU cube contains the two channels in the input data with a non-linear
+    rules produce cubes with a single grating and filter and  with a linear wavelength dimension. For MIRI data
+    the default rules produce a single IFU cube containing the two channels in the input data with a non-linear
     wavelength dimension. In both cases,  the input filename  suffix ``cal`` is replaced with ``s3d``.
 
   - ``pipeline = 3`` setups up the results for making ``calwebb_spec3`` pipeline type cbes. For NIRSpec data

--- a/docs/jwst/cube_build/arguments.rst
+++ b/docs/jwst/cube_build/arguments.rst
@@ -62,8 +62,8 @@ each band will be created.
     :ref:`calwebb_spec2 <calwebb_spec2>` pipeline is to produce ``band`` cubes). 
     If in addition, if channel, band, grating, or filter are also set, then only the data set by those
     parameters will be combined into an "uber" cube.
-    If the `output_type=multi` 	option is used with  NIRSPec prism data when running the cube_build step
-    standalone, then  the output IFU cubes will have a non-linear wavelength plane. 
+    If the `output_type=multi` 	option is used with  NIRSPec prism data, then the output IFU cubes will
+    have a non-linear wavelength plane. 
 
 The following arguments control the size and sampling characteristics of the output IFU cube.
 

--- a/docs/jwst/cube_build/arguments.rst
+++ b/docs/jwst/cube_build/arguments.rst
@@ -58,9 +58,12 @@ each band will be created.
     :ref:`calwebb_spec3 <calwebb_spec3>` pipeline for NIRSpec data. 
 
   - ``output_type = multi`` combines data  into a single "uber" IFU cube, this the default mode for
-    :ref:`calwebb_spec2 <calwebb_spec2>` pipeline.  
+    :ref:`calwebb_spec2 <calwebb_spec2>` pipeline for MIRI data (the default mode for NIRSpec data in the
+   :ref:`calwebb_spec2 <calwebb_spec2>` pipeline is to produce ``band`` cubes). 
     If in addition,  channel, band, grating, or filter are also set, then only the data set by those
     parameters will be combined into an "uber" cube.
+    If the `output_type=multi` 	option is used with  NIRSPec prism data when running the cube_build step
+    standalone  the output IFU cubes will have a non-linear wavelength plane. 
 
 The following arguments control the size and sampling characteristics of the output IFU cube.
 

--- a/docs/jwst/cube_build/arguments.rst
+++ b/docs/jwst/cube_build/arguments.rst
@@ -60,7 +60,7 @@ each band will be created.
   - ``output_type = multi`` combines data  into a single "uber" IFU cube, this the default mode for
     :ref:`calwebb_spec2 <calwebb_spec2>` pipeline for MIRI data (the default mode for NIRSpec data in the
     :ref:`calwebb_spec2 <calwebb_spec2>` pipeline is to produce ``band`` cubes). 
-    If in addition, if channel, band, grating, or filter are also set, then only the data set by those
+    In addition, if channel, band, grating, or filter are also set, then only the data set by those
     parameters will be combined into an "uber" cube.
     If the `output_type=multi` 	option is used with  NIRSPec prism data, then the output IFU cubes will
     have a non-linear wavelength plane. 

--- a/docs/jwst/cube_build/arguments.rst
+++ b/docs/jwst/cube_build/arguments.rst
@@ -9,6 +9,24 @@ The  step arguments can be used to control the properties of the output IFU cube
 created. For example, if the input data span several bands, but ``output_type = band``  then a cube for
 each band will be created.
 
+``pipeline [integer]``
+  `Cube_build` can be called from ``calwebb_spec2``, ``calwebb_spec3``, or stand-alone. The output IFU cubes
+  have a different name depending which pipeline calls it. This parameter defaults to 3 which follows the rules
+  for creating cubes based on the ``calwebb_spec3`` pipeline and is also the behavior when running
+  `cube_build` stand-alone. When the ``calwebb_spec2` pipeline  calls cube
+  build it sets `pipeline = 2`.   When running stand-alone or in 
+  ``calwebb_spec3`` pipeline the parameter `pipeline=3` is set for `cube_build`.
+  
+  - ``pipeline = 2`` sets up the rules for making ``calwebb_spec2`` pipeline type cubes. For NIRSpec data the default
+    rules   produce cubes with a single grating and filter and  with a linear wavelength dimension. For MIRI data
+    the default rules produce a single IFU cube contains the two channels in the input data with a non-linear
+    wavelength dimension. In both cases,  the input filename  suffix `cal` is replaced with `s3d`.
+
+  - ``pipeline = 3`` setups up the results for making ``calwebb_spec3`` pipeline type cbes. For NIRSpec data
+    the default rules will a single IFU cube from the same grating and filter, while for MIRI data the a single
+    IFU cube is create for each channel and band. In both cases, the output IFU cube will contain the grating and
+    filter name [NIRSpec] or channel and band (MIRI]. 
+
 ``channel [string]``
   This is a MIRI only option and the valid values are 1, 2, 3, 4, and ALL.
   If the ``channel`` argument is given, then only data corresponding to that channel  will be used in
@@ -50,20 +68,30 @@ each band will be created.
     (channel/sub-channel for MIRI or grating/filter combination for NIRSpec).
 
   - ``output_type = channel`` creates a single IFU cube from each unique channel of MIRI data
-    (or just those channels set by the 'channel' option). This is the default mode for the
-    :ref:`calwebb_spec3 <calwebb_spec3>` pipeline for MIRI data. 
+    (or just those channels set by the 'channel' option).
+
 
   - ``output_type = grating`` combines all the gratings in the NIRSpec data or set by the
-    grating option into a single IFU cube. The is the default mode for the
-    :ref:`calwebb_spec3 <calwebb_spec3>` pipeline for NIRSpec data. 
+    grating option into a single IFU cube.  This option is currently not being used by the pipeline.
+    For NIRSpec data ``output_type = band or multi`` only. 
 
-  - ``output_type = multi`` combines data  into a single "uber" IFU cube, this the default mode for
-    :ref:`calwebb_spec2 <calwebb_spec2>` pipeline for MIRI data (the default mode for NIRSpec data in the
-    :ref:`calwebb_spec2 <calwebb_spec2>` pipeline is to produce ``band`` cubes). 
+  - ``output_type = multi`` combines data  into a single "uber"
     In addition, if channel, band, grating, or filter are also set, then only the data set by those
     parameters will be combined into an "uber" cube.
     If the `output_type=multi` 	option is used with  NIRSPec prism data, then the output IFU cubes will
     have a non-linear wavelength plane. 
+
+
+  The default rules for creating IFU cube depend on the instrument and  which pipeline called `cube_build`.
+  
+  - `'calwebb_spec2`` pipeline rules for NIRSpec is produce ``output_type`` = band.
+  - `'calwebb_spec3`` pipeline rules for NIRSpec is produce ``output_type`` = band.
+
+  - `'calwebb_spec2`` pipeline rules for MIRI is produce ``output_type`` = multi.
+  - `'calwebb_spec3`` pipeline rules for MIRI is produce ``output_type`` = band.    
+
+
+
 
 The following arguments control the size and sampling characteristics of the output IFU cube.
 

--- a/jwst/cube_build/cube_build.py
+++ b/jwst/cube_build/cube_build.py
@@ -461,8 +461,9 @@ class CubeData:
                     cube_no = str(num_cubes)
                     cube_pars[cube_no] = {}
                     this_grating = []
-                    this_filter = band_subchannel
-                    this_grating.append(i)
+                    this_filter = []
+                    this_grating.append(band_grating[i])
+                    this_filter.append(band_filter[i])
                     cube_pars[cube_no]["par1"] = this_grating
                     cube_pars[cube_no]["par2"] = this_filter
 

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -147,7 +147,7 @@ class CubeBuildStep(Step):
             self.weighting = "emsm"
             if self.output_type is None:  # when running stand alone
                 self.output_type = "band"
-            self.pipeline = 2
+            self.pipeline = 3
 
         # if interpolation is point cloud then weighting can be
         # 1. MSM: modified Shepard method

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -147,7 +147,6 @@ class CubeBuildStep(Step):
             self.weighting = "emsm"
             if self.output_type is None:  # when running stand alone
                 self.output_type = "band"
-            self.pipeline = 3
 
         # if interpolation is point cloud then weighting can be
         # 1. MSM: modified Shepard method

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -230,9 +230,10 @@ class CubeBuildStep(Step):
         # Read in the first input model to determine with instrument we have
         # output type is by default 'Channel' for MIRI and 'Band' for NIRSpec
         instrument = self.input_models[0].meta.instrument.name.upper()
+
         if self.output_type is None:
             if instrument == "NIRSPEC":
-                self.output_type = "band"
+                self.output_type = "grating"
 
             elif instrument == "MIRI":
                 self.output_type = "channel"
@@ -325,7 +326,9 @@ class CubeBuildStep(Step):
         filenames = master_table.FileMap["filename"]
 
         self.pipeline = 3
-        if self.output_type == "multi" and len(filenames) == 1:
+        if self.output_type == "multi" and len(filenames) == 1 and instrument == "MIRI":
+            self.pipeline = 2
+        if self.output_type == "band" and len(filenames) == 1 and instrument == "NIRSPEC":
             self.pipeline = 2
         # ________________________________________________________________________________
         # How many and what type of cubes will be made.

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -232,16 +232,16 @@ class CubeBuildStep(Step):
         instrument = self.input_models[0].meta.instrument.name.upper()
 
         # Set up output_type for pipeline 3 type cubes.
-        # MIRI calwebb_spec2 parameter reference file has output_type =multi
-        # TODO - determine if we should make a calwebb_spec2 parameter reference file for NIRSpec
-        # that sets output_type = band.
-        # Instead in calwebb_spec2 if output_type is None for NIRSpec data then set it to band
+        # calspec2 sets the default output_type for each instrument. This could be moved to a
+        # the parameter reference file.
+        # In calspec3 the output_type default type is grating for NIRSpec and band for MIRI.
+        # MIRI sets output_type in the calspec3 parameter reference file.
         if self.output_type is None:
             if instrument == "NIRSPEC":
                 self.output_type = "grating"
 
             elif instrument == "MIRI":
-                self.output_type = "channel"
+                self.output_type = "band"
         self.pars_input["output_type"] = self.output_type
         log.info(f"Setting output type to: {self.output_type}")
         # ________________________________________________________________________________
@@ -330,10 +330,13 @@ class CubeBuildStep(Step):
             return
         filenames = master_table.FileMap["filename"]
 
+        # Because the names are different calspec2 and calspec3 output try and figure out which
+        # pipeline we have. #TODO we might want to update how we do this.
         self.pipeline = 3
         if self.output_type == "multi" and len(filenames) == 1 and instrument == "MIRI":
             self.pipeline = 2
-        # if self.output_type == "band" and len(filenames) == 1 and instrument == "NIRSPEC":
+        # By default pipeline 2 sets output_type=band for NIRSpec but the user can override this
+        # for prism data so we want to handle that case too.
         if len(filenames) == 1 and instrument == "NIRSPEC":
             self.pipeline = 2
 

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -231,6 +231,11 @@ class CubeBuildStep(Step):
         # output type is by default 'Channel' for MIRI and 'Band' for NIRSpec
         instrument = self.input_models[0].meta.instrument.name.upper()
 
+        # Set up output_type for pipeline 3 type cubes.
+        # MIRI calwebb_spec2 parameter reference file has output_type =multi
+        # TODO - determine if we should make a calwebb_spec2 parameter reference file for NIRSpec
+        # that sets output_type = band.
+        # Instead in calwebb_spec2 if output_type is None for NIRSpec data then set it to band
         if self.output_type is None:
             if instrument == "NIRSPEC":
                 self.output_type = "grating"
@@ -328,8 +333,10 @@ class CubeBuildStep(Step):
         self.pipeline = 3
         if self.output_type == "multi" and len(filenames) == 1 and instrument == "MIRI":
             self.pipeline = 2
-        if self.output_type == "band" and len(filenames) == 1 and instrument == "NIRSPEC":
+        # if self.output_type == "band" and len(filenames) == 1 and instrument == "NIRSPEC":
+        if len(filenames) == 1 and instrument == "NIRSPEC":
             self.pipeline = 2
+
         # ________________________________________________________________________________
         # How many and what type of cubes will be made.
         # send self.pars_input['output_type'], all_channel, all_subchannel, all_grating, all_filter

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -22,7 +22,7 @@ class CubeBuildStep(Step):
     class_alias = "cube_build"
 
     spec = """
-         pipeline = integer(2,3, default=2) # Set calwebb_spec2 or calwebb_spec3
+         pipeline = integer(2,3, default=3) # Set calwebb_spec2 or calwebb_spec3
          channel = option('1','2','3','4','all',default='all') # Channel
          band = option('short','medium','long','short-medium','short-long','medium-short', \
                 'medium-long', 'long-short', 'long-medium','all',default='all') # Band
@@ -250,7 +250,7 @@ class CubeBuildStep(Step):
 
         if self.pipeline == 3 and self.output_type is None:
             if instrument == "NIRSPEC":
-                self.output_type = "grating"
+                self.output_type = "band"  # we might switch that to grating
 
             elif instrument == "MIRI":
                 self.output_type = "band"

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -218,67 +218,71 @@ class IFUCubeData:
         newname : str
             Output name of the IFU cube.
         """
-        if self.pipeline == 2:
-            newname = self.output_name_base + "_" + self.suffix + ".fits"
-        else:
-            if self.instrument == "MIRI":
-                # Check to see if the output base name already contains the
-                # field "clear", which sometimes shows up in IFU product
-                # names created by the ASN rules. If so, strip it off, so
-                # that the remaining suffixes created below form the entire
-                # list of optical elements in the final output name.
-                basename = self.output_name_base
-                suffix = basename[basename.rfind("_") + 1 :]
-                if suffix in ["clear"]:
-                    self.output_name_base = basename[: basename.rfind("_")]
+        # if self.pipeline == 2:
+        #    newname = self.output_name_base + "_" + self.suffix + ".fits"
+        # else:
+        if self.instrument == "MIRI":
+            # Check to see if the output base name already contains the
+            # field "clear", which sometimes shows up in IFU product
+            # names created by the ASN rules. If so, strip it off, so
+            # that the remaining suffixes created below form the entire
+            # list of optical elements in the final output name.
+            basename = self.output_name_base
+            suffix = basename[basename.rfind("_") + 1 :]
+            if suffix in ["clear"]:
+                self.output_name_base = basename[: basename.rfind("_")]
 
-                # Now compose the appropriate list of optical element suffix names
-                # based on MRS channel and sub-channel
-                channels = []
-                for ch in self.list_par1:
-                    if ch not in channels:
-                        channels.append(ch)
-                    number_channels = len(channels)
-                    ch_name = "_ch"
-                    for i in range(number_channels):
-                        ch_name = ch_name + channels[i]
-                        if i < number_channels - 1:
-                            ch_name = ch_name + "-"
+            # Now compose the appropriate list of optical element suffix names
+            # based on MRS channel and sub-channel
+            channels = []
+            for ch in self.list_par1:
+                if ch not in channels:
+                    channels.append(ch)
+                number_channels = len(channels)
+                ch_name = "_ch"
+                for i in range(number_channels):
+                    ch_name = ch_name + channels[i]
+                    if i < number_channels - 1:
+                        ch_name = ch_name + "-"
 
-                # Sort by inverse alphabetical, e.g. short -> medium -> long
-                subchannels = sorted(set(self.list_par2))[::-1]
-                log.info(f"Subchannel listing: {subchannels}")
-                number_subchannels = len(subchannels)
-                b_name = ""
-                for i in range(number_subchannels):
-                    b_name = b_name + subchannels[i]
-                b_name = b_name.lower()
-                newname = self.output_name_base + ch_name + "-" + b_name
-                if self.coord_system == "internal_cal":
-                    newname = self.output_name_base + ch_name + "-" + b_name + "_internal"
-                if self.output_type == "single":
-                    newname = self.output_name_base + ch_name + "-" + b_name + "_single"
-            # ________________________________________________________________________________
-            elif self.instrument == "NIRSPEC":
-                # Check to see if the output base name already has a grating/prism
-                # suffix attached. If so, strip it off, and let the following logic
-                # add all necessary grating and filter suffixes.
-                basename = self.output_name_base
-                suffix = basename[basename.rfind("_") + 1 :]
-                if suffix in ["g140m", "g235m", "g395m", "g140h", "g235h", "g395h", "prism"]:
-                    self.output_name_base = basename[: basename.rfind("_")]
+            # Sort by inverse alphabetical, e.g. short -> medium -> long
+            subchannels = sorted(set(self.list_par2))[::-1]
+            log.info(f"Subchannel listing: {subchannels}")
+            number_subchannels = len(subchannels)
+            b_name = ""
+            for i in range(number_subchannels):
+                b_name = b_name + subchannels[i]
+            b_name = b_name.lower()
+            newname = self.output_name_base + ch_name + "-" + b_name
+            if self.coord_system == "internal_cal":
+                newname = self.output_name_base + ch_name + "-" + b_name + "_internal"
+            elif self.output_type == "single":
+                newname = self.output_name_base + ch_name + "-" + b_name + "_single"
+            elif self.pipeline == 2:
+                newname = self.output_name_base + "_" + self.suffix + ".fits"
 
-                fg_name = "_"
-                for i in range(len(self.list_par1)):
-                    fg_name = fg_name + self.list_par1[i] + "-" + self.list_par2[i]
-                    if i < self.num_bands - 1:
-                        fg_name = fg_name + "-"
-                fg_name = fg_name.lower()
-                newname = self.output_name_base + fg_name
-                if self.output_type == "single":
-                    newname = self.output_name_base + fg_name + "_single"
-                if self.coord_system == "internal_cal":
-                    newname = self.output_name_base + fg_name + "_internal"
+        elif self.instrument == "NIRSPEC":
+            # Check to see if the output base name already has a grating/prism
+            # suffix attached. If so, strip it off, and let the following logic
+            # add all necessary grating and filter suffixes.
+            basename = self.output_name_base
+            suffix = basename[basename.rfind("_") + 1 :]
+            if suffix in ["g140m", "g235m", "g395m", "g140h", "g235h", "g395h", "prism"]:
+                self.output_name_base = basename[: basename.rfind("_")]
+
+            fg_name = "_"
+            for i in range(len(self.list_par1)):
+                fg_name = fg_name + self.list_par1[i] + "-" + self.list_par2[i]
+                if i < self.num_bands - 1:
+                    fg_name = fg_name + "-"
+            fg_name = fg_name.lower()
+            newname = self.output_name_base + fg_name
+            if self.output_type == "single":
+                newname = self.output_name_base + fg_name + "_single"
+            elif self.coord_system == "internal_cal":
+                newname = self.output_name_base + fg_name + "_internal"
+            elif self.pipeline == 2:
+                newname = self.output_name_base + "_" + self.suffix + ".fits"
 
         if self.output_type != "single":
             log.info(f"Output Name: {newname}")

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1193,12 +1193,10 @@ class IFUCubeData:
                 par2 = self.list_par2[i]
 
             a_scale, b_scale, w_scale = self.instrument_info.get_scale(par1, par2)
-
             spaxelsize[i] = a_scale
             spectralsize[i] = w_scale
             minwave[i] = self.instrument_info.get_wave_min(par1, par2)
             maxwave[i] = self.instrument_info.get_wave_max(par1, par2)
-
             # pull out the values from the cube pars reference file
             roiw[i] = self.instrument_info.get_wave_roi(par1, par2)
             rois[i] = self.instrument_info.get_spatial_roi(par1, par2)
@@ -1208,7 +1206,6 @@ class IFUCubeData:
 
         # Check the spatial size. If it is the same for the array set up the parameters
         all_same = np.all(spaxelsize == spaxelsize[0])
-
         if all_same:
             self.spatial_size = spaxelsize[0]
             spatial_roi = rois[0]
@@ -1239,7 +1236,6 @@ class IFUCubeData:
         all_same_spectral = np.all(spectralsize == spectralsize[0])
 
         # check if scalew has been set - if yes then linear scale
-
         if self.scalew != 0:
             self.spectral_size = self.scalew
             self.linear_wavelength = True
@@ -1357,13 +1353,13 @@ class IFUCubeData:
                     )
 
                 # set wave_roi and  weight_power to same values if they are in  list
+
         if self.roiw == 0:
             self.roiw = wave_roi
         if self.weight_power == 0:
             self.weight_power = weight_power
         if self.scalexy != 0:
             self.spatial_size = self.scalexy
-
         # check on valid values
 
         found_error = False
@@ -1608,7 +1604,6 @@ class IFUCubeData:
                         ch_corners = cube_build_wcs_util.find_corners_miri(
                             input_model, this_a, self.instrument_info, self.coord_system
                         )
-
                         ca1, cb1, ca2, cb2, ca3, cb3, ca4, cb4, lmin, lmax = ch_corners
 
                 # now append this model spatial and spectral corner

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1245,7 +1245,11 @@ class IFUCubeData:
             self.scalerad = np.amin(scalerad)
 
         # if we have NIRSPEC Prism then force wavelength to be non-linear
-        elif self.instrument == "NIRSPEC" and "prism" in self.list_par1:
+        elif (
+            self.instrument == "NIRSPEC"
+            and "prism" in self.list_par1
+            and self.output_type == "multi"
+        ):
             self.linear_wavelength = False
             (
                 table_wavelength,

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1249,18 +1249,17 @@ class IFUCubeData:
             self.scalerad = np.amin(scalerad)
 
         # if we have NIRSPEC Prism then force wavelength to be non-linear
-        elif self.instrument == "NIRSPEC":
-            if "prism" in self.list_par1:
-                self.linear_wavelength = False
-                table = self.instrument_info.get_prism_table()
-                (
-                    table_wavelength,
-                    table_sroi,
-                    table_wroi,
-                    table_power,
-                    table_softrad,
-                    table_scalerad,
-                ) = table
+        elif self.instrument == "NIRSPEC" and "prism" in self.list_par1:
+            self.linear_wavelength = False
+            table = self.instrument_info.get_prism_table()
+            (
+                table_wavelength,
+                table_sroi,
+                table_wroi,
+                table_power,
+                table_softrad,
+                table_scalerad,
+            ) = table
 
         # if all bands have the same spectral size then linear_wavelength
         elif all_same_spectral:

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -255,7 +255,7 @@ class IFUCubeData:
                 newname = self.output_name_base + ch_name + "-" + b_name + "_internal"
             elif self.output_type == "single":
                 newname = self.output_name_base + ch_name + "-" + b_name + "_single"
-            elif self.pipeline == 2:
+            elif self.pipelineb == 2:
                 newname = self.output_name_base + "_" + self.suffix + ".fits"
 
         elif self.instrument == "NIRSPEC":

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -218,9 +218,6 @@ class IFUCubeData:
         newname : str
             Output name of the IFU cube.
         """
-        # if self.pipeline == 2:
-        #    newname = self.output_name_base + "_" + self.suffix + ".fits"
-        # else:
         if self.instrument == "MIRI":
             # Check to see if the output base name already contains the
             # field "clear", which sometimes shows up in IFU product

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1247,7 +1247,6 @@ class IFUCubeData:
         # if we have NIRSPEC Prism then force wavelength to be non-linear
         elif self.instrument == "NIRSPEC" and "prism" in self.list_par1:
             self.linear_wavelength = False
-            table = self.instrument_info.get_prism_table()
             (
                 table_wavelength,
                 table_sroi,
@@ -1255,7 +1254,7 @@ class IFUCubeData:
                 table_power,
                 table_softrad,
                 table_scalerad,
-            ) = table
+            ) = self.instrument_info.get_prism_table()
 
         # if all bands have the same spectral size then linear_wavelength
         elif all_same_spectral:

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -1248,6 +1248,20 @@ class IFUCubeData:
             self.soft_rad = np.amin(softrad)
             self.scalerad = np.amin(scalerad)
 
+        # if we have NIRSPEC Prism then force wavelength to be non-linear
+        elif self.instrument == "NIRSPEC":
+            if "prism" in self.list_par1:
+                self.linear_wavelength = False
+                table = self.instrument_info.get_prism_table()
+                (
+                    table_wavelength,
+                    table_sroi,
+                    table_wroi,
+                    table_power,
+                    table_softrad,
+                    table_scalerad,
+                ) = table
+
         # if all bands have the same spectral size then linear_wavelength
         elif all_same_spectral:
             self.spectral_size = spectralsize[0]
@@ -1292,8 +1306,11 @@ class IFUCubeData:
                         table_softrad,
                         table_scalerad,
                     ) = table
-            # based on Min and Max wavelength - pull out the tables values that fall in this range
-            # find the closest table entries to the self.wavemin and self.wavemax limits
+
+        # non-linear wavelength range.
+        # Based on Min and Max wavelength - pull out the tables values that fall in this range.
+        # Find the closest table entries to the self.wavemin and self.wavemax limits
+        if not self.linear_wavelength:
             imin = (np.abs(table_wavelength - self.wavemin)).argmin()
             imax = (np.abs(table_wavelength - self.wavemax)).argmin()
 

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -255,7 +255,7 @@ class IFUCubeData:
                 newname = self.output_name_base + ch_name + "-" + b_name + "_internal"
             elif self.output_type == "single":
                 newname = self.output_name_base + ch_name + "-" + b_name + "_single"
-            elif self.pipelineb == 2:
+            elif self.pipeline == 2:
                 newname = self.output_name_base + "_" + self.suffix + ".fits"
 
         elif self.instrument == "NIRSPEC":

--- a/jwst/cube_build/tests/test_cube_build_step.py
+++ b/jwst/cube_build/tests/test_cube_build_step.py
@@ -239,7 +239,7 @@ def test_call_cube_build_nirspec_multi(tmp_cwd, nirspec_data, tmp_path, as_filen
     step.channel = "1"
     step.coord_system = "internal_cal"
     step.save_results = True
-    step.output_type = "multi"
+    step.output_type = "band"
     result = step.run(step_input)
 
     assert isinstance(result, ModelContainer)

--- a/jwst/cube_build/tests/test_cube_build_step.py
+++ b/jwst/cube_build/tests/test_cube_build_step.py
@@ -208,7 +208,6 @@ def test_call_cube_build_nirspec(tmp_cwd, nirspec_data, tmp_path, as_filename):
     else:
         step_input = nirspec_data
     step = CubeBuildStep()
-    step.channel = "1"
     step.coord_system = "internal_cal"
     step.save_results = True
     result = step.run(step_input)
@@ -219,34 +218,6 @@ def test_call_cube_build_nirspec(tmp_cwd, nirspec_data, tmp_path, as_filename):
     assert model.meta.cal_step.cube_build == "COMPLETE"
     assert model.meta.filename == "test_nirspec_g395h-f290lp_internal_s3d.fits"
     assert os.path.isfile(model.meta.filename)
-
-    # make sure input is not modified
-    assert result is not step_input
-    assert result[0] is not step_input
-    if not as_filename:
-        assert step_input.meta.cal_step.cube_build is None
-
-
-@pytest.mark.parametrize("as_filename", [True, False])
-def test_call_cube_build_nirspec_band(tmp_cwd, nirspec_data, tmp_path, as_filename):
-    if as_filename:
-        fn = tmp_path / "test_nirspec_cal.fits"
-        nirspec_data.save(fn)
-        step_input = fn
-    else:
-        step_input = nirspec_data
-    step = CubeBuildStep()
-    step.channel = "1"
-    step.coord_system = "internal_cal"
-    step.save_results = True
-    step.output_type = "band"
-    result = step.run(step_input)
-
-    assert isinstance(result, ModelContainer)
-    assert len(result) == 1
-    model = result[0]
-    assert model.meta.cal_step.cube_build == "COMPLETE"
-    assert model.meta.filename == "test_nirspec_s3d.fits"
 
     # make sure input is not modified
     assert result is not step_input

--- a/jwst/cube_build/tests/test_cube_build_step.py
+++ b/jwst/cube_build/tests/test_cube_build_step.py
@@ -228,7 +228,7 @@ def test_call_cube_build_nirspec(tmp_cwd, nirspec_data, tmp_path, as_filename):
 
 
 @pytest.mark.parametrize("as_filename", [True, False])
-def test_call_cube_build_nirspec_multi(tmp_cwd, nirspec_data, tmp_path, as_filename):
+def test_call_cube_build_nirspec_band(tmp_cwd, nirspec_data, tmp_path, as_filename):
     if as_filename:
         fn = tmp_path / "test_nirspec_cal.fits"
         nirspec_data.save(fn)

--- a/jwst/cube_build/tests/test_nirspec_cubepars.py
+++ b/jwst/cube_build/tests/test_nirspec_cubepars.py
@@ -28,10 +28,10 @@ def nirspec_cube_pars(tmp_path_factory):
 
     # make the first extension
     disp = np.array(
-        ["prism", "g140m", "g140m", "g140m", "g140h", "g235m", "g235h", "g395m", "g395h"]
+        ["prism", "g140m", "g140m", "g140h", "g140h", "g235m", "g235h", "g395m", "g395h"]
     )
     filt = np.array(
-        ["clear", "f070lp", "f100lp", "f070lp", "f100lp", "f170lp", "f170lp", "F290lp", "f290lp"]
+        ["clear", "f070lp", "f100lp", "f070lp", "f100lp", "f170lp", "f170lp", "f290lp", "f290lp"]
     )
 
     spsize = np.array([0.10, 0.10, 0.10, 0.10, 0.10, 0.10, 0.10, 0.10, 0.10])
@@ -172,7 +172,7 @@ def test_nirspec_cubepars_test1(tmp_cwd, nirspec_cube_pars):
         "debug_spaxel": "0 0 0",
     }
 
-    # use a mode that will give a linear wavelength range
+    # By default Prism/Clear will produce a non-linear wavelength plane.
 
     pipeline = 3
     input_model = None
@@ -206,7 +206,7 @@ def test_nirspec_cubepars_test1(tmp_cwd, nirspec_cube_pars):
 
 
 def test_nirspec_cubepars_test2(tmp_cwd, nirspec_cube_pars):
-    """Read in the nirspec cube pars file and test reading in correct parameters"""
+    """Read in the nirspec cube pars file and test reading in correct parameters for g140m/f100lp (non-prism)"""
 
     instrument_info = instrument_defaults.InstrumentInfo()
     all_channel = []
@@ -292,7 +292,7 @@ def test_nirspec_cubepars_test2(tmp_cwd, nirspec_cube_pars):
 
     assert math.isclose(this_cube.wavemin, wavemin, abs_tol=0.00001)
     assert math.isclose(this_cube.wavemax, wavemax, abs_tol=0.00001)
-    # we are testing PRISM data. Linear wavelength = False
+    # we are testing g140m/f100lp which will have a linear wavelength range.
     assert this_cube.linear_wavelength is True
 
     assert math.isclose(this_cube.weight_power, 2, abs_tol=0.00001)
@@ -343,7 +343,7 @@ def test_nirspec_cubepars_test2(tmp_cwd, nirspec_cube_pars):
     # do they match the user provided ones
     assert math.isclose(this_cube.wavemin, user_wave_min, abs_tol=0.00001)
     assert math.isclose(this_cube.wavemax, user_wave_max, abs_tol=0.00001)
-    # we are testing PRISM data
+    # we are testing g140m/f100lp  data
     assert this_cube.linear_wavelength is True
     assert math.isclose(this_cube.spatial_size, user_ascale, abs_tol=0.00001)
     assert math.isclose(this_cube.spectral_size, user_wscale, abs_tol=0.00001)

--- a/jwst/cube_build/tests/test_nirspec_cubepars.py
+++ b/jwst/cube_build/tests/test_nirspec_cubepars.py
@@ -28,11 +28,12 @@ def nirspec_cube_pars(tmp_path_factory):
 
     # make the first extension
     disp = np.array(
-        ["PRISM", "G140M", "G140M", "G140H", "G140H", "G235M", "G235H", "G395M", "G395H"]
+        ["prism", "g140m", "g140m", "g140m", "g140h", "g235m", "g235h", "g395m", "g395h"]
     )
     filt = np.array(
-        ["CLEAR", "F070LP", "F100LP", "F070LP", "F100LP", "F170LP", "F170LP", "F290LP", "F290LP"]
+        ["clear", "f070lp", "f100lp", "f070lp", "f100lp", "f170lp", "f170lp", "F290lp", "f290lp"]
     )
+
     spsize = np.array([0.10, 0.10, 0.10, 0.10, 0.10, 0.10, 0.10, 0.10, 0.10])
     wsamp = np.array([0.005, 0.001, 0.0006, 0.0002, 0.0002, 0.001, 0.0004, 0.0017, 0.0007])
 
@@ -49,16 +50,8 @@ def nirspec_cube_pars(tmp_path_factory):
     hdu1 = fits.BinTableHDU.from_columns([col1, col2, col3, col4, col5, col6])
     hdu1.header["EXTNAME"] = "CUBEPAR"
 
-    # make the second extension
-    disp = np.array(
-        ["PRISM", "G140M", "G140M", "G140H", "G140H", "G235M", "G235H", "G395M", "G395H"]
-    )
-    filt = np.array(
-        ["CLEAR", "F070LP", "F100LP", "F070LP", "F100LP", "F170LP", "F170LP", "F290LP", "F290LP"]
-    )
-
     roispat = np.array([0.201, 0.202, 0.203, 0.204, 0.205, 0.206, 0.207, 0.208, 0.209])
-    roispec = np.array([0.011, 0.0012, 0.0012, 0.0004, 0.0004, 0.002, 0.0008, 0.003, 0.0012])
+    roispec = np.array([0.011, 0.0012, 0.0013, 0.0004, 0.0004, 0.002, 0.0008, 0.003, 0.0012])
 
     power = np.array([2, 2, 2, 2, 2, 2, 2, 2, 2])
     softrad = np.array([0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01])
@@ -123,8 +116,12 @@ def nirspec_cube_pars(tmp_path_factory):
     return filename
 
 
-def test_nirspec_cubepars(tmp_cwd, nirspec_cube_pars):
-    """Read in the nirspec cube pars file"""
+def test_nirspec_cubepars_test1(tmp_cwd, nirspec_cube_pars):
+    """
+    Test nirspec cube pars file for prism/clear.
+
+    Set data type to prism clear and test values are set correctly in cube_build
+    """
 
     instrument_info = instrument_defaults.InstrumentInfo()
     all_channel = []
@@ -169,6 +166,91 @@ def test_nirspec_cubepars(tmp_cwd, nirspec_cube_pars):
     pars_cube = {
         "scalexy": 0.0,
         "scalew": 0.0,
+        "weighting": "drizzle",
+        "coord_system": "world",
+        "skip_dqflagging": False,
+        "debug_spaxel": "0 0 0",
+    }
+
+    # use a mode that will give a linear wavelength range
+
+    pipeline = 3
+    input_model = None
+    output_name_base = None
+    output_type = "band"
+    instrument = "NIRSPEC"
+    list_par1 = all_grating
+    list_par2 = all_filter
+    master_table = None
+    instrument_info = instrument_info
+    this_cube = ifu_cube.IFUCubeData(
+        pipeline,
+        input_model,
+        output_name_base,
+        output_type,
+        instrument,
+        list_par1,
+        list_par2,
+        instrument_info,
+        master_table,
+        **pars_cube,
+    )
+
+    this_cube.num_files = 1  # set in ifu cube
+    # test that the correct values read from the table are filled
+    # in in the this_cube class.
+    this_cube.determine_cube_parameters()
+
+    # we are testing PRISM data. Linear wavelength = False
+    assert this_cube.linear_wavelength is False
+
+
+def test_nirspec_cubepars_test2(tmp_cwd, nirspec_cube_pars):
+    """Read in the nirspec cube pars file and test reading in correct parameters"""
+
+    instrument_info = instrument_defaults.InstrumentInfo()
+    all_channel = []
+    all_subchannel = []
+    all_grating = []
+    all_filter = []
+    par1 = "g140m"
+    par2 = "f100lp"
+    all_grating.append(par1)
+    all_filter.append(par2)
+
+    cube_build_io_util.read_cubepars(
+        nirspec_cube_pars,
+        "NIRSPEC",
+        "msm",
+        all_channel,
+        all_subchannel,
+        all_grating,
+        all_filter,
+        instrument_info,
+    )
+
+    ascale, bscale, wscale = instrument_info.get_scale(par1, par2)
+    assert math.isclose(ascale, 0.1, abs_tol=0.00001)
+    assert math.isclose(bscale, 0.1, abs_tol=0.00001)
+    assert math.isclose(wscale, 0.0006, abs_tol=0.00001)
+
+    roiw = instrument_info.get_wave_roi(par1, par2)
+    rois = instrument_info.get_spatial_roi(par1, par2)
+    power = instrument_info.get_msm_power(par1, par2)
+    wavemin = instrument_info.get_wave_min(par1, par2)
+    wavemax = instrument_info.get_wave_max(par1, par2)
+
+    assert math.isclose(roiw, 0.0013, abs_tol=0.00001)
+    assert math.isclose(rois, 0.203, abs_tol=0.00001)
+    assert math.isclose(power, 2, abs_tol=0.00001)
+    assert math.isclose(wavemin, 0.97, abs_tol=0.00001)
+    assert math.isclose(wavemax, 1.89, abs_tol=0.00001)
+
+    # set up the ifucube class
+
+    pars_cube = {
+        "scalexy": 0.0,
+        "scalew": 0.0,
         "interpolation": "pointcloud",
         "weighting": "msm",
         "weight_power": 2,
@@ -205,17 +287,17 @@ def test_nirspec_cubepars(tmp_cwd, nirspec_cube_pars):
 
     this_cube.num_files = 1  # set in ifu cube
     # test that the correct values read from the table are filled
-    # in in the this_cube class. Also check that for this configuration
-    # linear_wavelength = 'True'
+    # in in the this_cube class.
     this_cube.determine_cube_parameters()
 
     assert math.isclose(this_cube.wavemin, wavemin, abs_tol=0.00001)
     assert math.isclose(this_cube.wavemax, wavemax, abs_tol=0.00001)
+    # we are testing PRISM data. Linear wavelength = False
     assert this_cube.linear_wavelength is True
 
     assert math.isclose(this_cube.weight_power, 2, abs_tol=0.00001)
-    assert math.isclose(this_cube.roiw, 0.011, abs_tol=0.00001)
-    rois = 0.201 * 1.5  # increase for single file
+    assert math.isclose(this_cube.roiw, 0.0013, abs_tol=0.00001)
+    rois = 0.203 * 1.5  # increase for single file
     assert math.isclose(this_cube.rois, rois, abs_tol=0.00001)
     assert math.isclose(this_cube.spatial_size, 0.1, abs_tol=0.00001)
 
@@ -261,6 +343,7 @@ def test_nirspec_cubepars(tmp_cwd, nirspec_cube_pars):
     # do they match the user provided ones
     assert math.isclose(this_cube.wavemin, user_wave_min, abs_tol=0.00001)
     assert math.isclose(this_cube.wavemax, user_wave_max, abs_tol=0.00001)
+    # we are testing PRISM data
     assert this_cube.linear_wavelength is True
     assert math.isclose(this_cube.spatial_size, user_ascale, abs_tol=0.00001)
     assert math.isclose(this_cube.spectral_size, user_wscale, abs_tol=0.00001)

--- a/jwst/cube_build/tests/test_nirspec_cubepars.py
+++ b/jwst/cube_build/tests/test_nirspec_cubepars.py
@@ -172,12 +172,44 @@ def test_nirspec_cubepars_test1(tmp_cwd, nirspec_cube_pars):
         "debug_spaxel": "0 0 0",
     }
 
-    # By default Prism/Clear will produce a non-linear wavelength plane.
+    # By default Prism/Clear will produce a linear wavelength plane.
 
     pipeline = 3
     input_model = None
     output_name_base = None
     output_type = "band"
+    instrument = "NIRSPEC"
+    list_par1 = all_grating
+    list_par2 = all_filter
+    master_table = None
+    instrument_info = instrument_info
+    this_cube = ifu_cube.IFUCubeData(
+        pipeline,
+        input_model,
+        output_name_base,
+        output_type,
+        instrument,
+        list_par1,
+        list_par2,
+        instrument_info,
+        master_table,
+        **pars_cube,
+    )
+
+    this_cube.num_files = 1  # set in ifu cube
+    # test that the correct values read from the table are filled
+    # in in the this_cube class.
+    this_cube.determine_cube_parameters()
+
+    # we are testing PRISM data. Linear wavelength = True
+    assert this_cube.linear_wavelength is True
+
+    # Add output_type = 'multi' and  Prism/Clear will produce a non-linear wavelength plane.
+
+    pipeline = 3
+    input_model = None
+    output_name_base = None
+    output_type = "multi"
     instrument = "NIRSPEC"
     list_par1 = all_grating
     list_par2 = all_filter

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -130,7 +130,7 @@ class Spec2Pipeline(Pipeline):
         self.resample_spec.suffix = "s2d"
         self.cube_build.save_results = False
         self.cube_build.skip_dqflagging = True
-        self.cube_build.pipeline = (2,)
+        self.cube_build.pipeline = 2
         self.extract_1d.save_results = self.save_results
 
         # Retrieve the input(s)

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -128,7 +128,6 @@ class Spec2Pipeline(Pipeline):
         # Setup step parameters required by the pipeline.
         self.resample_spec.save_results = self.save_results
         self.resample_spec.suffix = "s2d"
-        # self.cube_build.output_type = "multi"
         self.cube_build.save_results = False
         self.cube_build.skip_dqflagging = True
         self.extract_1d.save_results = self.save_results
@@ -387,9 +386,7 @@ class Spec2Pipeline(Pipeline):
 
         elif (exp_type in ["MIR_MRS", "NRS_IFU"]) or is_nrs_ifu_linelamp(calibrated):
             # First call pixel_replace then call cube_build step for IFU data.
-            # For cube_build always create a single cube containing multiple
-            # wavelength bands
-
+            # set the default output type for both instruments if is not set
             if exp_type == "NRS_IFU" and self.cube_build.output_type is None:
                 self.cube_build.output_type = "band"
 

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -128,7 +128,7 @@ class Spec2Pipeline(Pipeline):
         # Setup step parameters required by the pipeline.
         self.resample_spec.save_results = self.save_results
         self.resample_spec.suffix = "s2d"
-        self.cube_build.output_type = "multi"
+        # self.cube_build.output_type = "multi"
         self.cube_build.save_results = False
         self.cube_build.skip_dqflagging = True
         self.extract_1d.save_results = self.save_results
@@ -390,8 +390,11 @@ class Spec2Pipeline(Pipeline):
             # For cube_build always create a single cube containing multiple
             # wavelength bands
 
-            if exp_type == "NRS_IFU":
+            if exp_type == "NRS_IFU" and self.cube_build.output_type is None:
                 self.cube_build.output_type = "band"
+
+            if exp_type == "MIR_MRS" and self.cube_build.output_type is None:
+                self.cube_build.output_type = "multi"
             resampled = calibrated.copy()
             # interpolate pixels that have a NaN value or are flagged
             # as DO_NOT_USE or NON_SCIENCE.

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -130,6 +130,7 @@ class Spec2Pipeline(Pipeline):
         self.resample_spec.suffix = "s2d"
         self.cube_build.save_results = False
         self.cube_build.skip_dqflagging = True
+        self.cube_build.pipeline = (2,)
         self.extract_1d.save_results = self.save_results
 
         # Retrieve the input(s)
@@ -385,14 +386,17 @@ class Spec2Pipeline(Pipeline):
             resampled = self.resample_spec.run(resampled)
 
         elif (exp_type in ["MIR_MRS", "NRS_IFU"]) or is_nrs_ifu_linelamp(calibrated):
-            # First call pixel_replace then call cube_build step for IFU data.
             # set the default output type for both instruments if is not set
             if exp_type == "NRS_IFU" and self.cube_build.output_type is None:
+                self.cube_build.output_type = "band"
+
+            if is_nrs_ifu_linelamp(calibrated):
                 self.cube_build.output_type = "band"
 
             if exp_type == "MIR_MRS" and self.cube_build.output_type is None:
                 self.cube_build.output_type = "multi"
             resampled = calibrated.copy()
+            # First call pixel_replace then call cube_build step for IFU data.
             # interpolate pixels that have a NaN value or are flagged
             # as DO_NOT_USE or NON_SCIENCE.
             resampled = self.pixel_replace.run(resampled)

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -390,7 +390,7 @@ class Spec2Pipeline(Pipeline):
             if exp_type == "NRS_IFU" and self.cube_build.output_type is None:
                 self.cube_build.output_type = "band"
 
-            if is_nrs_ifu_linelamp(calibrated):
+            if is_nrs_ifu_linelamp(calibrated) and self.cube_build.output_type is None:
                 self.cube_build.output_type = "band"
 
             if exp_type == "MIR_MRS" and self.cube_build.output_type is None:

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -390,6 +390,8 @@ class Spec2Pipeline(Pipeline):
             # For cube_build always create a single cube containing multiple
             # wavelength bands
 
+            if exp_type == "NRS_IFU":
+                self.cube_build.output_type = "band"
             resampled = calibrated.copy()
             # interpolate pixels that have a NaN value or are flagged
             # as DO_NOT_USE or NON_SCIENCE.

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -87,6 +87,7 @@ class Spec3Pipeline(Pipeline):
         self.resample_spec.suffix = "s2d"
         self.resample_spec.save_results = self.save_results
         self.cube_build.suffix = "s3d"
+        self.cube_build.pipeline = (3,)
         self.cube_build.save_results = self.save_results
         self.extract_1d.suffix = "x1d"
         self.extract_1d.save_results = self.save_results

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -87,7 +87,7 @@ class Spec3Pipeline(Pipeline):
         self.resample_spec.suffix = "s2d"
         self.resample_spec.save_results = self.save_results
         self.cube_build.suffix = "s3d"
-        self.cube_build.pipeline = (3,)
+        self.cube_build.pipeline = 3
         self.cube_build.save_results = self.save_results
         self.extract_1d.suffix = "x1d"
         self.extract_1d.save_results = self.save_results

--- a/jwst/regtest/test_nirspec_cubebuild_prism.py
+++ b/jwst/regtest/test_nirspec_cubebuild_prism.py
@@ -1,0 +1,48 @@
+"""Test CubeBuildStep on NIRSpec Prims data"""
+
+import pytest
+
+from jwst.regtest.st_fitsdiff import STFITSDiff as FITSDiff
+from jwst.stpipe import Step
+
+
+@pytest.mark.bigdata
+def test_cube_build_nirspec_prism_linear(rtdata, fitsdiff_default_kwargs):
+    """Run cube_build on prism data and produce a linear wavelength"""
+    input_file = "jw01208062001_07101_00001_nrs1_cal.fits"
+    rtdata.get_data(f"nirspec/ifu/{input_file}")
+
+    args = ["jwst.cube_build.CubeBuildStep", input_file]
+    Step.from_cmdline(args)
+
+    output = input_file.replace("cal", "prism-clear_s3d")
+    rtdata.output = output
+
+    rtdata.get_truth(f"truth/test_nirspec_cubebuild_prism/{output}")
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+@pytest.mark.bigdata
+def test_cube_build_nirspec_prism_nonlinear(rtdata, fitsdiff_default_kwargs):
+    """Run cube_build on prism data and produce a non-linear wavelength"""
+    input_file = "jw01208062001_07101_00001_nrs1_cal.fits"
+    rtdata.get_data(f"nirspec/ifu/{input_file}")
+
+    output_name = "jw01208062001_07101_00001_nrs1_nonlinear"
+    args = [
+        "jwst.cube_build.CubeBuildStep",
+        input_file,
+        "--output_type=multi",
+        "--output_file=" + output_name,
+    ]
+    Step.from_cmdline(args)
+    output = output_name + "_prism-clear_s3d.fits"
+
+    rtdata.output = output
+
+    rtdata.get_truth(f"truth/test_nirspec_cubebuild_prism/{output}")
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()

--- a/jwst/regtest/test_nirspec_cubebuild_prism.py
+++ b/jwst/regtest/test_nirspec_cubebuild_prism.py
@@ -15,7 +15,7 @@ def test_cube_build_nirspec_prism_linear(rtdata, fitsdiff_default_kwargs):
     args = ["jwst.cube_build.CubeBuildStep", input_file]
     Step.from_cmdline(args)
 
-    output = input_file.replace("cal", "s3d")
+    output = input_file.replace("cal", "prism-clear_s3d")
     rtdata.output = output
 
     rtdata.get_truth(f"truth/test_nirspec_cubebuild_prism/{output}")
@@ -30,7 +30,7 @@ def test_cube_build_nirspec_prism_nonlinear(rtdata, fitsdiff_default_kwargs):
     input_file = "jw01208062001_07101_00001_nrs1_cal.fits"
     rtdata.get_data(f"nirspec/ifu/{input_file}")
 
-    output_name = "jw01208062001_07101_00001_nrs1_nonlinear"
+    output_name = "jw01208062001_07101_00001_nrs1_nonlinear_prism-clear"
     args = [
         "jwst.cube_build.CubeBuildStep",
         input_file,

--- a/jwst/regtest/test_nirspec_cubebuild_prism.py
+++ b/jwst/regtest/test_nirspec_cubebuild_prism.py
@@ -15,7 +15,7 @@ def test_cube_build_nirspec_prism_linear(rtdata, fitsdiff_default_kwargs):
     args = ["jwst.cube_build.CubeBuildStep", input_file]
     Step.from_cmdline(args)
 
-    output = input_file.replace("cal", "prism-clear_s3d")
+    output = input_file.replace("cal", "s3d")
     rtdata.output = output
 
     rtdata.get_truth(f"truth/test_nirspec_cubebuild_prism/{output}")
@@ -38,7 +38,7 @@ def test_cube_build_nirspec_prism_nonlinear(rtdata, fitsdiff_default_kwargs):
         "--output_file=" + output_name,
     ]
     Step.from_cmdline(args)
-    output = output_name + "_prism-clear_s3d.fits"
+    output = output_name + "_s3d.fits"
 
     rtdata.output = output
 

--- a/jwst/regtest/test_nirspec_cubebuild_prism.py
+++ b/jwst/regtest/test_nirspec_cubebuild_prism.py
@@ -30,7 +30,7 @@ def test_cube_build_nirspec_prism_nonlinear(rtdata, fitsdiff_default_kwargs):
     input_file = "jw01208062001_07101_00001_nrs1_cal.fits"
     rtdata.get_data(f"nirspec/ifu/{input_file}")
 
-    output_name = "jw01208062001_07101_00001_nrs1_nonlinear_prism-clear"
+    output_name = "jw01208062001_07101_00001_nrs1_nonlinear"
     args = [
         "jwst.cube_build.CubeBuildStep",
         input_file,
@@ -38,7 +38,7 @@ def test_cube_build_nirspec_prism_nonlinear(rtdata, fitsdiff_default_kwargs):
         "--output_file=" + output_name,
     ]
     Step.from_cmdline(args)
-    output = output_name + "_s3d.fits"
+    output = output_name + "_prism-clear_s3d.fits"
 
     rtdata.output = output
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4074](https://jira.stsci.edu/browse/JP-4074)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
Closes # 9699

<!-- describe the changes comprising this PR here -->
This PR addresses forces NIRSpec Prism IFU cubes to have a non-linear wavelength range

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
results of regression test:  ALL PASSED
https://github.com/spacetelescope/RegressionTests/actions/runs/17779948028