### PR TITLE
JP-4070: Fix incorrect pixel offsets fed into grism transforms for wfss_contam

### DIFF
--- a/jwst/wfss_contam/disperse.py
+++ b/jwst/wfss_contam/disperse.py
@@ -3,6 +3,7 @@ import multiprocessing as mp
 import warnings
 
 import numpy as np
+from astropy.modeling.mappings import Mapping
 from scipy import sparse
 
 from jwst.lib.winclip import get_clipped_pixels
@@ -23,8 +24,6 @@ def _determine_native_wl_spacing(
     wmin,
     wmax,
     oversample_factor=2,
-    xoffset=0,
-    yoffset=0,
 ):
     """
     Determine the wavelength spacing necessary to adequately sample the dispersed frame.
@@ -47,10 +46,6 @@ def _determine_native_wl_spacing(
         Maximum wavelength for dispersed spectra
     oversample_factor : int, optional
         Factor by which to oversample the wavelength grid
-    xoffset : int, optional
-        X offset to apply to the dispersed pixel positions
-    yoffset : int, optional
-        Y offset to apply to the dispersed pixel positions
 
     Returns
     -------
@@ -68,8 +63,8 @@ def _determine_native_wl_spacing(
     # Convert to x/y in the direct image frame
     x0_xy, y0_xy, _, _ = sky_to_imgxy(x0_sky, y0_sky, 1, order)
     # then convert to x/y in the grism image frame.
-    xwmin, ywmin = imgxy_to_grismxy(x0_xy + xoffset, y0_xy + yoffset, wmin, order)
-    xwmax, ywmax = imgxy_to_grismxy(x0_xy + xoffset, y0_xy + yoffset, wmax, order)
+    xwmin, ywmin = imgxy_to_grismxy(x0_xy, y0_xy, wmin, order)
+    xwmax, ywmax = imgxy_to_grismxy(x0_xy, y0_xy, wmax, order)
     dxw = xwmax - xwmin
     dyw = ywmax - ywmin
 
@@ -80,9 +75,7 @@ def _determine_native_wl_spacing(
     return lambdas
 
 
-def _disperse_onto_grism(
-    x0_sky, y0_sky, sky_to_imgxy, imgxy_to_grismxy, lambdas, order, xoffset=0, yoffset=0
-):
+def _disperse_onto_grism(x0_sky, y0_sky, sky_to_imgxy, imgxy_to_grismxy, lambdas, order):
     """
     Compute x/y positions in the grism image for the set of desired wavelengths.
 
@@ -100,10 +93,6 @@ def _disperse_onto_grism(
         Wavelengths at which to compute dispersed pixel values
     order : int
         Spectral order number
-    xoffset : int, optional
-        X offset to apply to the dispersed pixel positions
-    yoffset : int, optional
-        Y offset to apply to the dispersed pixel positions
 
     Returns
     -------
@@ -123,7 +112,7 @@ def _disperse_onto_grism(
 
     # Convert to x/y in grism frame.
     lambdas = np.repeat(lambdas[:, np.newaxis], x0_xy.shape[1], axis=1)
-    x0s, y0s = imgxy_to_grismxy(x0_xy + xoffset, y0_xy + yoffset, lambdas, order)
+    x0s, y0s = imgxy_to_grismxy(x0_xy, y0_xy, lambdas, order)
     # x0s, y0s now have shape (n_lam, n_pixels)
     return x0s, y0s, lambdas
 
@@ -210,8 +199,6 @@ def disperse(
     grism_wcs,
     naxis,
     oversample_factor=2,
-    xoffset=0,
-    yoffset=0,
 ):
     """
     Compute the dispersed image pixel values from the direct image.
@@ -244,10 +231,6 @@ def disperse(
         Dimensions of the grism image (naxis[0], naxis[1])
     oversample_factor : int, optional
         Factor by which to oversample the wavelength grid
-    xoffset : float, optional
-        X offset to apply to the dispersed pixel positions
-    yoffset : float, optional
-        Y offset to apply to the dispersed pixel positions
 
     Returns
     -------
@@ -269,8 +252,11 @@ def disperse(
     sky_to_imgxy = grism_wcs.get_transform("world", "detector")
     imgxy_to_grismxy = grism_wcs.get_transform("detector", "grism_detector")
 
+    # We only need the x,y outputs of imgxy_to_grismxy
+    imgxy_to_grismxy = imgxy_to_grismxy | Mapping((0, 1), n_inputs=5)
+
     # Find RA/Dec of the input pixel position in segmentation map
-    x0_sky, y0_sky = seg_wcs(x0, y0)
+    x0_sky, y0_sky = seg_wcs.get_transform("detector", "world")(x0, y0)
 
     # native spacing does not change much over the detector, so just put in one x0, y0
     lambdas = _determine_native_wl_spacing(
@@ -282,8 +268,6 @@ def disperse(
         wmin,
         wmax,
         oversample_factor=oversample_factor,
-        xoffset=xoffset,
-        yoffset=yoffset,
     )
     nlam = len(lambdas)
 
@@ -294,8 +278,6 @@ def disperse(
         imgxy_to_grismxy,
         lambdas,
         order,
-        xoffset=xoffset,
-        yoffset=yoffset,
     )
 
     # If none of the dispersed pixel indexes are within the image frame,

--- a/jwst/wfss_contam/observations.py
+++ b/jwst/wfss_contam/observations.py
@@ -117,7 +117,6 @@ class Observation:
         filter_name,
         source_id=None,
         boundaries=None,
-        offsets=None,
         max_cpu=1,
         max_pixels_per_chunk=5e4,
         oversample_factor=2,
@@ -139,8 +138,6 @@ class Observation:
             ID of source to process. If 0, all sources processed.
         boundaries : list, optional, default []
             Start/Stop coordinates of the FOV within the larger seed image.
-        offsets : list, optional, default [0,0]
-            Offset values for x and y axes
         max_cpu : int, optional, default 1
             Max number of cpu's to use when multiprocessing
         max_pixels_per_chunk : int, optional, default 1e5
@@ -150,8 +147,6 @@ class Observation:
         """
         if boundaries is None:
             boundaries = []
-        if offsets is None:
-            offsets = [0, 0]
         # Load all the info for this grism mode
         self.seg_wcs = segmap_model.meta.wcs
         self.grism_wcs = grism_wcs
@@ -164,8 +159,6 @@ class Observation:
         self.max_cpu = max_cpu
         self.max_pixels_per_chunk = max_pixels_per_chunk
         self.oversample_factor = oversample_factor
-        self.xoffset = offsets[0]
-        self.yoffset = offsets[1]
 
         # ensure the direct image has background subtracted
         self.dimage = background_subtract(direct_image)
@@ -271,8 +264,6 @@ class Observation:
                     self.grism_wcs,
                     self.naxis,
                     self.oversample_factor,
-                    self.xoffset,
-                    self.yoffset,
                 ]
             )
 

--- a/jwst/wfss_contam/tests/conftest.py
+++ b/jwst/wfss_contam/tests/conftest.py
@@ -1,15 +1,13 @@
-import warnings
-
-import asdf
 import numpy as np
 import pytest
 import stdatamodels.jwst.datamodels as dm
 from astropy.convolution import convolve
 from astropy.stats import sigma_clipped_stats
 from astropy.table import Table
-from astropy.utils.data import get_pkg_data_filename
 from photutils.datasets import make_100gaussians_image
 from photutils.segmentation import SourceFinder, make_2dgaussian_kernel
+
+from jwst.assign_wcs.tests.test_niriss import create_imaging_wcs, create_wfss_wcs
 
 DIR_IMAGE = "direct_image.fits"
 
@@ -69,18 +67,7 @@ def segmentation_map(direct_image):
 
     # turn this into a jwst datamodel
     model = dm.SegmentationMapModel(data=segm.data)
-    with warnings.catch_warnings():
-        # asdf.exceptions.AsdfPackageVersionWarning in oldestdeps job
-        warnings.filterwarnings(
-            "ignore",
-            message="File .* was created with extension URI .* which is not currently installed",
-        )
-        with asdf.open(
-            get_pkg_data_filename("data/segmentation_wcs.asdf", package="jwst.wfss_contam.tests")
-        ) as asdf_file:
-            wcsobj = asdf_file.tree["wcs"]
-            model.meta.wcs = wcsobj
-
+    model.meta.wcs = create_imaging_wcs("F200W")
     return model
 
 
@@ -121,13 +108,4 @@ def grism_wcs():
     -----
     This should probably be mocked in future updates.
     """
-    with warnings.catch_warnings():
-        # asdf.exceptions.AsdfPackageVersionWarning in oldestdeps job
-        warnings.filterwarnings(
-            "ignore",
-            message="File .* was created with extension URI .* which is not currently installed",
-        )
-        with asdf.open(
-            get_pkg_data_filename("data/grism_wcs.asdf", package="jwst.wfss_contam.tests")
-        ) as asdf_file:
-            return asdf_file.tree["wcs"]
+    return create_wfss_wcs("GR150C", pupil="F200W")

--- a/jwst/wfss_contam/tests/test_disperse.py
+++ b/jwst/wfss_contam/tests/test_disperse.py
@@ -6,24 +6,16 @@ from jwst.wfss_contam.disperse import disperse
 
 def test_disperse_oversample_same_result(grism_wcs, segmentation_map):
     """Coverage for bug where wavelength oversampling led to double-counted fluxes."""
-    x0 = np.array([300.5])
-    y0 = np.array([300.5])
+    x0 = np.array([200.5])
+    y0 = np.array([200.5])
     order = 1
     flxs = np.array([1.0])
-    source_id = np.array([0])
+    source_id = np.array([50])
     naxis = (300, 500)
     sens_waves = np.linspace(1.708, 2.28, 100)
     wmin, wmax = np.min(sens_waves), np.max(sens_waves)
     sens_resp = np.ones(100)
     seg_wcs = segmentation_map.meta.wcs
-    (
-        0,
-        (300, 500),
-        2,
-        False,
-    )
-    xoffset = 2200
-    yoffset = 1000
 
     output_images = []
     for os in [2, 3]:
@@ -41,8 +33,6 @@ def test_disperse_oversample_same_result(grism_wcs, segmentation_map):
             grism_wcs,
             naxis,
             oversample_factor=os,
-            xoffset=xoffset,
-            yoffset=yoffset,
         )
         output_images.append(src[source_id[0]]["image"])
 

--- a/jwst/wfss_contam/tests/test_observations.py
+++ b/jwst/wfss_contam/tests/test_observations.py
@@ -88,11 +88,6 @@ def test_disperse_order(observation):
     wmin, wmax = np.min(sens_waves), np.max(sens_waves)
     sens_resp = np.ones_like(sens_waves)
 
-    # manually change x,y offset because took transform from a real direct image, with different
-    # pixel 0,0 than the mock data. This puts i=1, order 1 onto the real grism image
-    obs.xoffset = 2200
-    obs.yoffset = 1200
-
     # shorten pixel list to make this test take less time
     obs.disperse_order(order, wmin, wmax, sens_waves, sens_resp)
 
@@ -105,10 +100,10 @@ def test_disperse_order(observation):
     assert type(obs.simulated_slits) == dm.MultiSlitModel
     # two of the slits fall off the detector and do not end up here
     assert len(obs.simulated_slits.slits) == 8
-    slit = obs.simulated_slits.slits[0]
+    slit = obs.simulated_slits.slits[1]
     # check metadata
-    assert slit.name == "source_50"
+    assert slit.name == "source_51"
     assert slit.data.shape == (slit.ysize, slit.xsize)
 
     # check for regression by hard-coding one value of slit.data
-    assert np.isclose(slit.data[10, 10], 5.203127)
+    assert np.isclose(slit.data[5, 60], 20.996877670288086)

--- a/jwst/wfss_contam/tests/test_wfss_contam_step.py
+++ b/jwst/wfss_contam/tests/test_wfss_contam_step.py
@@ -45,11 +45,6 @@ def multislitmodel(
         slit.ysize = slit.data.shape[0]
         model.slits.append(slit)
 
-    # manually change x,y offset because took transform from a real direct image, with different
-    # pixel 0,0 than the mock data. This puts i=1, order 1 onto the real grism image
-    model.slits[0].xstart = 2200
-    model.slits[0].ystart = 1000
-
     fname = "multislit_model.fits"
     model.save(fname)
     return fname

--- a/jwst/wfss_contam/wfss_contam.py
+++ b/jwst/wfss_contam/wfss_contam.py
@@ -325,14 +325,13 @@ def contam_corr(
     with datamodels.open(direct_file) as direct_model:
         direct_image = direct_model.data
 
-    # Get the grism WCS object and offsets from the first cutout in the input model.
+    # Get the grism WCS object from the first cutout in the input model.
     # This WCS is used to transform from direct image to grism frame for all sources
-    # in the segmentation map - the offsets are required so that we can shift
-    # each source in the segmentation map to the proper grism image location
-    # using this particular wcs, but any cutout's wcs+offsets would work.
+    # in the segmentation map.
+    # The "detector" to "grism_detector" and "world" to "detector" transforms are identical
+    # for all slits, so just use the first one. The "grism_detector" to "grism_slit"
+    # transform is not used by the step.
     grism_wcs = input_model.slits[0].meta.wcs
-    xoffset = input_model.slits[0].xstart - 1
-    yoffset = input_model.slits[0].ystart - 1
 
     # Find out how many spectral orders are defined, based on the
     # array of order values in the Wavelengthrange ref file
@@ -372,7 +371,6 @@ def contam_corr(
         grism_wcs,
         filter_name,
         boundaries=[0, 2047, 0, 2047],
-        offsets=[xoffset, yoffset],
         max_cpu=ncpus,
         source_id=selected_ids,
         max_pixels_per_chunk=max_pixels_per_chunk,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4070](https://jira.stsci.edu/browse/JP-4070)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
Closes #9694 

<!-- describe the changes comprising this PR here -->
This PR fixes an issue with the grism to detector WCS transform being used by the wfss_contam step, which was leading to multiple problems with the shapes of the spectral traces, including highly curved spectral traces in order -1 for NIRISS.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
