### PR TITLE
TST: Ignore outerspace in linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -463,6 +463,7 @@ linkcheck_retry = 5
 linkcheck_ignore = [
     "http://stsci.edu/schemas/fits-schema/",  # Old schema from CHANGES.rst
     "https://jwst-docs.stsci.edu",  # CI blocked by service provider
+    "https://outerspace.stsci.edu",  # CI blocked by service provider
     "https://jira.stsci.edu/",  # Internal access only
     r"https://github\.com/spacetelescope/jwst/(?:issues|pull)/\d+",
 ]


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR ignore outerspace in linkcheck because they probably blocked CI as spam. No need to run RT.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
