### PR TITLE
Add warning ignore for StepAxisWarning from GWCS until WCSs are updated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,10 @@ addopts = [
 ]
 xfail_strict = true
 filterwarnings = [
-    "error"
+    "error",
+    # GWCS is deprecating the use of non-coordinate axes, several of the WCSs in JWST
+    # need to update their step coordinate frames to account for the non-coordinate axes.
+    "ignore:.*:gwcs.wcs._step.StepAxisWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
spacetelescope/gwcs#614 is introducing some changes that include a deprecation warning for the use of non-coordinate axes. JWST has several WCSs that make use of these. This PR is adding the warning ignore to avoid multiple test failures due to this warning until all the WCSs involved can have their coordinate frame metadata updated. 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
