### PR TITLE
JP-4085: Fix pixel_replace crash for invalid adjacent data

### DIFF
--- a/changes/9754.pixel_replace.rst
+++ b/changes/9754.pixel_replace.rst
@@ -1,0 +1,1 @@
+Fixed a crash for an edge case in pixel replacement: a bad pixel with no valid adjacent data.

--- a/jwst/pixel_replace/pixel_replace.py
+++ b/jwst/pixel_replace/pixel_replace.py
@@ -333,6 +333,12 @@ class PixelReplacement:
             adjacent_condition = self.custom_slice(dispaxis, valid_adjacent_inds)
             profile_data = model.data[adjacent_condition]
             profile_err = model.err[adjacent_condition]
+            if profile_data.size == 0:
+                log.info(
+                    f"Profile in {self.LOG_SLICE[dispaxis - 1]} {ind} "
+                    f"has no valid adjacent values - skipping."
+                )
+                continue
 
             # Mask out bad pixels
             invalid_condition = (model.dq[adjacent_condition] & self.DO_NOT_USE).astype(bool)

--- a/jwst/pixel_replace/tests/test_pixel_replace.py
+++ b/jwst/pixel_replace/tests/test_pixel_replace.py
@@ -269,3 +269,55 @@ def test_pixel_replace_container_names(tmp_cwd, input_model_function):
 
     result.close()
     input_model.close()
+
+
+def test_pixel_replace_no_valid_data(caplog):
+    """Test pixel replace for no valid data."""
+    input_model, bad_idx = nirspec_tso()
+
+    # Set a middle region to NaN to test invalid data handling
+    input_model.data[2, :, 5:15] = np.nan
+    input_model.dq[2, 1:-1, 5:15] = 1
+
+    # Set one pixel valid in the middle with no valid data next to
+    # it to test missing adjacent data
+    input_model.data[2, 10, 10] = 1.0
+    input_model.dq[2, 10, 10] = 0
+    input_model.dq[2, :, 9] = 1
+    input_model.dq[2, :, 11] = 1
+
+    result = PixelReplaceStep.call(input_model, algorithm="fit_profile", n_adjacent_cols=1)
+
+    assert caplog.text.count("has no valid values - skipping") == 7
+    assert caplog.text.count("has no valid adjacent values - skipping") == 1
+
+    for ext in ["data", "err", "var_poisson", "var_rnoise", "var_flat"]:
+        # non-science edges are uncorrected
+        assert np.all(np.isnan(getattr(result, ext)[..., :, 1]))
+        assert np.all(np.isnan(getattr(result, ext)[..., 1, :]))
+
+        # bad pixel is replaced: input had one nan value, output does not
+        assert np.isnan(getattr(input_model, ext)[bad_idx])
+        assert getattr(result, ext)[bad_idx] == 1.0
+
+        # invalid data is left alone
+        assert np.all(np.isnan(result.data[2, 1:-1, 5:10]))
+        assert np.all(np.isnan(result.data[2, 1:-1, 11:15]))
+
+    # The DQ plane for the bad pixel is updated to remove do-not-use
+    # and add flux-estimated. The non-science edges are unchanged.
+    assert result.dq[bad_idx] == (
+        input_model.dq[bad_idx] - flags["DO_NOT_USE"] + flags["FLUX_ESTIMATED"]
+    )
+    assert np.all(result.dq[:2, :, 1] == flags["DO_NOT_USE"] + flags["NON_SCIENCE"])
+    assert np.all(result.dq[:2, 1, :] == flags["DO_NOT_USE"] + flags["NON_SCIENCE"])
+
+    # Invalid region is still marked DNU
+    assert np.all(result.dq[2, 1:-1, 5:10] == flags["DO_NOT_USE"])
+    assert np.all(result.dq[2, 1:-1, 11:15] == flags["DO_NOT_USE"])
+    assert np.all(result.dq[2, 10, 10] == 0)
+    assert np.all(result.dq[2, :, 9] == flags["DO_NOT_USE"])
+    assert np.all(result.dq[2, :, 11] == flags["DO_NOT_USE"])
+
+    result.close()
+    input_model.close()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4085](https://jira.stsci.edu/browse/JP-4085)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Fix a crash found in I&T for synthetic MIRI slitless TSO data with large invalid regions in the middle of the array.  Specifically, the edge case is a bad pixel to replace in a profile with some valid data, but no valid data in the adjacent columns/rows.  The fix is just to check earlier in the loop over profiles if there is any valid adjacent data.  I added a unit test to exercise both the condition where there is no valid data in the profile at all, as well as the edge case with no valid adjacent data.

Test case is jw00035-o017_20250807t192709_tso-spec2_00001, from Build 12.0 tests.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
