### PR TITLE
JP-4095: Fix velocity correction in WCS inverse

### DIFF
--- a/changes/9783.assign_wcs.rst
+++ b/changes/9783.assign_wcs.rst
@@ -1,0 +1,1 @@
+Add velocity correction to the inverse WCS transforms for NIRSpec spectroscopic modes to fix a round trip error.

--- a/jwst/assign_wcs/nirspec.py
+++ b/jwst/assign_wcs/nirspec.py
@@ -1410,6 +1410,7 @@ def gwa_to_ifuslit(slits, input_model, disperser, reference_files, slit_y_range)
         if velosys is not None:
             velocity_corr = velocity_correction(input_model.meta.wcsinfo.velosys)
             lgreq = lgreq | velocity_corr
+            agreq = velocity_corr.inverse & Identity(3) | agreq
             log.info(
                 f"Applied Barycentric velocity correction : {velocity_corr[1].amplitude.value}"
             )
@@ -1509,6 +1510,7 @@ def gwa_to_slit(open_slits, input_model, disperser, reference_files):
         if velosys is not None:
             velocity_corr = velocity_correction(input_model.meta.wcsinfo.velosys)
             lgreq = lgreq | velocity_corr
+            agreq = velocity_corr.inverse & Identity(3) | agreq
             log.info(
                 f"Applied Barycentric velocity correction : {velocity_corr[1].amplitude.value}"
             )

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -1446,14 +1446,15 @@ def test_in_slice(slice, wcs_ifu_grating, ifu_world_coord):
 
 
 @pytest.mark.parametrize("mode", ["IFU", "MOS", "FS"])
-def test_nrs_wcs_by_slit(mode):
+@pytest.mark.parametrize("velocity_corr", [True, False])
+def test_nrs_wcs_by_slit(mode, velocity_corr):
     pixel_tol = 0.02
     if mode == "IFU":
         hdul = create_nirspec_ifu_file("F290LP", "G140M")
         im = datamodels.IFUImageModel(hdul)
 
-        # Round trip is currently up to ~half pixel off for IFU
-        pixel_tol = 0.5
+        # Round trip is currently a little worse for IFU
+        pixel_tol = 0.12
 
     elif mode == "MOS":
         hdul = create_nirspec_mos_file()
@@ -1466,6 +1467,10 @@ def test_nrs_wcs_by_slit(mode):
     else:
         hdul = create_nirspec_fs_file(grating="G140M", filter="F100LP")
         im = datamodels.ImageModel(hdul)
+
+    # Add a significant velosys to trigger velocity correction
+    if velocity_corr:
+        im.meta.wcsinfo.velosys = 20000.0
 
     datamodel = assign_wcs_step.AssignWcsStep.call(im, nrs_ifu_slice_wcs=True)
     slit_ids = datamodel.meta.wcs.get_transform("gwa", "slit_frame").slit_ids


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4095](https://jira.stsci.edu/browse/JP-4095)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Fix a missing velocity correction in the inverse transform for NIRSpec IFU.  This seems to fix a round trip error of up to ~0.5 pixel.  Example case: jw01251004001_03107_00001_nrs2_rate.fits, with velosys = 20 km/s. 

I checked the other modes for similar errors, and found that NIRSpec MOS and FS needs the same handling.  I'm not sure if we've noted similar round trip errors for these modes, but checking MOS regression test data jw01345066001_05101_00001_nrs1_rate.fits with velosys -15 km/s, it looks like it improves round trip error from ~.08 pixel to ~.001 pixel in a quick spot check on slit 35.

For the other instruments, where the velocity_correction is used, they appear to be propagating it to the inverse correctly. ~I did note what looks like a typo in the NIRISS SOSS handling for order 2 and 3 so I fixed it here, but I can move to another PR if it needs separate review.~

Edit: typo fix for NIRISS SOSS handling moved to #9747 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
