### PR TITLE
JP-4040: Preserve reference file names when scrubbing logs

### DIFF
--- a/jwst/stpipe/_cal_logs.py
+++ b/jwst/stpipe/_cal_logs.py
@@ -29,6 +29,14 @@ def _scrub(msg):
     scrubbed : str
         The scrubbed string
     """
+    if "/" + _USER + "/" in msg:
+        # scrub directory but preserve filenames
+        pieces = msg.split()
+        for i, piece in enumerate(pieces):
+            if "/" + _USER + "/" in piece:
+                root = piece.split("/")[-1]
+                pieces[i] = root
+        return " ".join(pieces)
     if _USER in msg:
         return ""
     if _HOSTNAME in msg:

--- a/jwst/stpipe/tests/test_cal_logs.py
+++ b/jwst/stpipe/tests/test_cal_logs.py
@@ -50,3 +50,20 @@ def test_cal_logs_pipeline():
 def test_scrub(msg, is_empty):
     target = "" if is_empty else msg
     assert _scrub(msg) == target
+
+
+@pytest.mark.parametrize(
+    "msg, expected",
+    [
+        (f"/some/path/{_FAKE_USER}/subdir/file.txt", "file.txt"),
+        (f"before /{_FAKE_USER}/file.txt after", "before file.txt after"),
+        (
+            f"/some/{_FAKE_USER}/file.txt and /another/{_FAKE_USER}/file2.txt",
+            "file.txt and file2.txt",
+        ),
+        (f"/{_FAKE_USER}/file3.txt, /{_FAKE_USER}/file4.txt", "file3.txt, file4.txt"),
+    ],
+)
+def test_abspath_replace(msg, expected):
+    scrubbed = _scrub(msg)
+    assert scrubbed == expected


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4040](https://jira.stsci.edu/browse/JP-4040)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
Closes #9581 

<!-- describe the changes comprising this PR here -->
This PR adds special handling for file paths to the cal logs scrubber.

Prior to this PR, if any line in the log was encountered that contained the username, it would be removed entirely; this was causing reference file names to be removed.  At the time of https://github.com/spacetelescope/jwst/pull/9211 this was determined not to be a serious issue, but there has been pushback on that.

This PR checks if the username is part of a file path, and if so, it removes the stem of that path but retains the root.  It still removes the entire line if the username is not determined to be part of a file path.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
