### PR TITLE
drop opencv direct dependency

### DIFF
--- a/changes/9803.general.rst
+++ b/changes/9803.general.rst
@@ -1,0 +1,1 @@
+Remove the direct dependency on opencv as this is unused within jwst code and only indirectly used via stcal (which has opencv as a dependency).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     # "gwcs>=0.22.0,<0.23.0",
     "gwcs @ git+https://github.com/spacetelescope/gwcs.git@master",
     "numpy>=1.25",
-    "opencv-python-headless>=4.6.0.66",
     "photutils>=2.1.0",
     "pyparsing>=2.2.1",
     "requests>=2.31",


### PR DESCRIPTION
opencv is not used directly in jwst.

The jump step does use opencv but only via stcal (which [has opencv as a dependency](https://github.com/spacetelescope/stcal/blob/702c2856fff0673fb32e654506690ca20ebca643/pyproject.toml#L18)).

This PR removes opencv as a direct dependency to jwst.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/17494168542
all pass and show opencv installed "via stcal":
https://github.com/spacetelescope/RegressionTests/actions/runs/17494168542/job/49690870643#step:17:80

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
