### PR TITLE
increase asdf upper pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "asdf>=4.0,<5",
+    "asdf>=4.0,<6",
     "astropy>=6.1",
     "BayesicFitting>=3.2.2",
     "crds>=12.0.3",


### PR DESCRIPTION
asdf 5.0.0 will soon be released. It contains no changes that impact jwst. This PR raises the upper pin to "<6".

Regtests all pass with asdf main: https://github.com/spacetelescope/RegressionTests/actions/runs/17622300350
which contains all 5.0.0 code changes. I have not tagged main with a 5.0.0 tag yet to allow easier testing here.

I also added the "run extra tests" label to allow the unit tests to run with asdf main.

I also added the "no changelog" label as it's an increase in an upper pin that previously had no impact (since there is no asdf 5.0.0 yet). Let me know if a changelog would be helpful.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
