### PR TITLE
remove unused stddev

### DIFF
--- a/jwst/jump/jump_step.py
+++ b/jwst/jump/jump_step.py
@@ -94,9 +94,7 @@ class JumpStep(Step):
             # Detect jumps using a copy of the input data model.
             result = input_model.copy()
             jump_data = self._setup_jump_data(result)
-            new_gdq, new_pdq, number_crs, number_extended_events, stddev = detect_jumps_data(
-                jump_data
-            )
+            new_gdq, new_pdq, number_crs, number_extended_events, *_ = detect_jumps_data(jump_data)
 
             # Update the DQ arrays of the output model with the jump detection results
             result.groupdq = new_gdq


### PR DESCRIPTION
This PR removes assigning the last return value for `detect_jumps_data` to the unused variable `stddev`.

The change in this PR is compatible with stcal main and will allow https://github.com/spacetelescope/stcal/pull/403 to drop returning an extra `None` value (which is currently required to satisfy the number of return values expected on jwst main).

The plan is:
- merge this PR
- update https://github.com/spacetelescope/stcal/pull/403 to drop returning `None` (which will no longer break jwst tests)
- merge the updated stcal PR
- open another PR that removes the `*_` added in this PR

An alternative approach would be to:
- update https://github.com/spacetelescope/stcal/pull/403 to drop returning `None` (and no longer be able to test that PR with jwst main)
- open a PR for jwst removing `stddev` to be compatible with the stcal PR
- merge both of those PRs at the same time

Let me know which is preferred or if there are other options.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
