### PR TITLE
DOC: Fix more broken ref links (datamodels and friends)

### DIFF
--- a/docs/jwst/align_refs/description.rst
+++ b/docs/jwst/align_refs/description.rst
@@ -1,7 +1,7 @@
 Description
 -----------
 
-:Class: `jwst.coron.AlignRefsStep`
+:Class: `jwst.coron.align_refs_step.AlignRefsStep`
 :Alias: align_refs
 
 The ``align_refs`` step is one of the coronagraphic-specific steps in the ``coron``
@@ -22,7 +22,7 @@ shows that there are minimal drifts during an observation in line-of-sight point
 properties.
 
 Shifts between each PSF and target image are computed using the
-``scipy.optimize.leastsq`` function. A 2D mask, supplied via a PSFMASK reference file, 
+``scipy.optimize.leastsq`` function. A 2D mask, supplied via a PSFMASK reference file,
 is used to indicate pixels to ignore when performing the minimization in the
 ``leastsq`` routine. The mask acts as a weighting function in performing the fit.
 Alignment of a PSF image is performed using the ``scipy.ndimage.fourier_shift``
@@ -37,9 +37,9 @@ The ``align_refs`` step  has two optional arguments:
 
 ``--bad_bits`` (string, default="DO_NOT_USE")
   The DQ bit values from the input image DQ arrays that should be considered bad
-  and replaced with the median in a surrounding box. For example, setting to 
-  ``"OUTLIER, SATURATED"`` (or equivalently ``"16, 2"`` or ``"18"``) will treat 
-  all pixels flagged as OUTLIER or SATURATED as bad, while setting to ``""`` or  
+  and replaced with the median in a surrounding box. For example, setting to
+  ``"OUTLIER, SATURATED"`` (or equivalently ``"16, 2"`` or ``"18"``) will treat
+  all pixels flagged as OUTLIER or SATURATED as bad, while setting to ``""`` or
   ``None`` will treat all pixels as good and omit any bad pixel replacement.
 
 Inputs
@@ -48,15 +48,15 @@ Inputs
 The ``align_refs`` step takes 2 inputs: a science target exposure containing a 3D
 stack of calibrated per-integration images and a "_psfstack" product containing a 3D
 stack of reference PSF images. If the target or PSF images have any of the
-data quality flags set to those specified by the ``bad_bits`` argument, these pixels 
+data quality flags set to those specified by the ``bad_bits`` argument, these pixels
 are replaced with the median value of a region around the flagged data. The size of the
-box region to use for the replacement can also be specified. These corrected images are 
-used in the :ref:`align_refs <align_refs_step>` step and passed along for subsequent 
+box region to use for the replacement can also be specified. These corrected images are
+used in the :ref:`align_refs <align_refs_step>` step and passed along for subsequent
 processing.
 
 3D calibrated images
 ^^^^^^^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _calints
 
 One of the science target exposures specified in the ASN file used as input to the
@@ -66,7 +66,7 @@ per-integration images.
 
 3D stacked PSF images
 ^^^^^^^^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _psfstack
 
 A "_psfstack" product created by the :ref:`stack_refs <stack_refs_step>` step, which
@@ -77,7 +77,7 @@ Outputs
 
 3D aligned PSF images
 ^^^^^^^^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _psfalign
 
 The output is a CubeModel, where the 0th axis has length equal to the total number of

--- a/docs/jwst/ami_analyze/description.rst
+++ b/docs/jwst/ami_analyze/description.rst
@@ -138,7 +138,7 @@ the addition of the association candidate ID and the "_ami-oi", "_amimulti-oi", 
 
 Interferometric observables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.AmiOIModel`
+:Data model: `~stdatamodels.jwst.datamodels.AmiOIModel`
 :File suffix: _ami-oi.fits, _amimulti-oi.fits
 
 The inteferometric observables are saved as OIFITS files, a registered FITS format
@@ -161,7 +161,7 @@ the number of integrations: "PISTONS", "PIST_ERR", "VISAMP", "VISAMPERR", "VISPH
 
 LG model parameters
 ^^^^^^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.AmiLgFitModel`
+:Data model: `~stdatamodels.jwst.datamodels.AmiLgFitModel`
 :File suffix: _amilg.fits
 
 The _amilg.fits output file contains the cropped and cleaned data, model, and residuals (data - model) as well as

--- a/docs/jwst/ami_average/description.rst
+++ b/docs/jwst/ami_average/description.rst
@@ -1,14 +1,14 @@
 Description
 -----------
 
-:Class: `jwst.ami.AmiAverageStep`
+:Class: `jwst.ami.ami_average_step.AmiAverageStep`
 :Alias: ami_average
-	
-.. Attention:: 
+
+.. Attention::
 	The ``ami_average`` step has been removed from the default ami3 pipeline,
 	and is deprecated as of build 1.18.1.
-	It does not use the OIFITS-format (`~jwst.datamodels.AmiOIModel`) input that the current 
-	``ami_analyze`` step produces. It uses the deprecated `~jwst.datamodels.AmiLgModel`
+	It does not use the OIFITS-format (`~stdatamodels.jwst.datamodels.AmiOIModel`) input that the current
+	``ami_analyze`` step produces. It uses the deprecated `~stdatamodels.jwst.datamodels.AmiLgModel`
 	for both input and output.
 	It will be removed in a future release.
 
@@ -19,11 +19,11 @@ It averages the results of LG processing from the
 It computes a simple average for all 8 components of the "ami" product files from all
 input exposures.
 
-For a given association of exposures, the "ami" products created by the `ami_analyze`
-step may have `fit_image` and `resid_image` images that vary in size from one
+For a given association of exposures, the "ami" products created by the ``ami_analyze``
+step may have ``fit_image`` and ``resid_image`` images that vary in size from one
 exposure to another. If this is the case, the smallest image size of all the input
-products is used for the averaged product and the averaged `fit_image` and
-`resid_image` images are created by trimming extra rows/columns from the edges of
+products is used for the averaged product and the averaged ``fit_image`` and
+``resid_image`` images are created by trimming extra rows/columns from the edges of
 images that are larger.
 
 Arguments
@@ -35,7 +35,7 @@ Inputs
 
 LG model parameters
 ^^^^^^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.AmiLgModel`
+:Data model: `~stdatamodels.jwst.datamodels.AmiLgModel`
 :File suffix: _ami
 
 The only input to the ``ami_average`` step is a list of one or more "ami" files to be
@@ -50,7 +50,7 @@ Outputs
 
 Average LG model parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.AmiLgModel`
+:Data model: `~stdatamodels.jwst.datamodels.AmiLgModel`
 :File suffix: _amiavg or _psf-amiavg
 
 The ``ami_average`` step produces a single output file, having the same format as the input

--- a/docs/jwst/ami_normalize/description.rst
+++ b/docs/jwst/ami_normalize/description.rst
@@ -1,7 +1,7 @@
 Description
 -----------
 
-:Class: `jwst.ami.AmiNormalizeStep`
+:Class: `jwst.ami.ami_normalize_step.AmiNormalizeStep`
 :Alias: ami_normalize
 
 The ``ami_normalize`` step is one of the AMI-specific steps in the ``ami``
@@ -21,23 +21,23 @@ Inputs
 
 Interferometric Observables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.AmiOIModel`
+:Data model: `~stdatamodels.jwst.datamodels.AmiOIModel`
 :File suffix: _ami-oi.fits and/or _psf-ami-oi.fits
 
-The ``ami_normalize`` step takes two inputs: the first is the 
-interferometric observables for a science target and the second 
+The ``ami_normalize`` step takes two inputs: the first is the
+interferometric observables for a science target and the second
 is the interferometric observables for the PSF target. These should
 be the _ami-oi.fits and _psf-ami-oi.fits products resulting from the
-:ref:`ami_analyze <ami_analyze_step>` step, or two _ami-oi.fits files if the steps 
-are run independently. The inputs can be in the form of filenames or 
-`~jwst.datamodels.AmiOIModel` data models.
+:ref:`ami_analyze <ami_analyze_step>` step, or two _ami-oi.fits files if the steps
+are run independently. The inputs can be in the form of filenames or
+`~stdatamodels.jwst.datamodels.AmiOIModel` data models.
 
 Outputs
 -------
 
 Normalized Interferometric Observables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.AmiOIModel`
+:Data model: `~stdatamodels.jwst.datamodels.AmiOIModel`
 :File suffix: _aminorm-oi.fits
 
 The output is a new set of interferometric observables for the science target

--- a/docs/jwst/assign_wcs/arguments.rst
+++ b/docs/jwst/assign_wcs/arguments.rst
@@ -36,17 +36,17 @@ the behavior of the processing.
   the image frame, 0.0 is the center of the slit, and 0.5 is the nominal *bottom* edge
   of the slit open area in the image frame.
 
-  Set the `slit_y_low` value to a larger negative value to include more pixels
+  Set the ``slit_y_low`` value to a larger negative value to include more pixels
   at the *top* of a slit bounding box; a smaller negative value to to include fewer
   pixels.
 
-  Set the `slit_y_high` value to a larger positive value to include more pixels
+  Set the ``slit_y_high`` value to a larger positive value to include more pixels
   at the *bottom* of a slit bounding box; a smaller positive value to to include fewer
   pixels.
 
   For MSA slits in NIRSpec MOS mode, the slit units are relative to a single open shutter
   height, not a full "slitlet" composed of multiple shutters.  For this mode,
-  the `slit_y_low` and `slit_y_high` values determine the padding of the slitlet edges relative
+  the ``slit_y_low`` and ``slit_y_high`` values determine the padding of the slitlet edges relative
   to the centers of the edge shutters. An additional margin of half a shutter is also
   automatically added to the slit boundaries specified by these parameters, corresponding
   to a couple extra detector pixels at the top and bottom of each slitlet.

--- a/docs/jwst/assign_wcs/main.rst
+++ b/docs/jwst/assign_wcs/main.rst
@@ -74,7 +74,7 @@ oriented more nearly along the horizontal (DISPAXIS = 1) or vertical
 Using the WCS interactively
 ---------------------------
 
-Once a FITS file is opened as a `DataModel` the WCS can be accessed as an attribute
+Once a FITS file is opened as a `~stdatamodels.DataModel` the WCS can be accessed as an attribute
 of the meta object. Calling it as a function with detector positions as inputs returns the
 corresponding world coordinates. Using MIRI LRS fixed slit as an example:
 

--- a/docs/jwst/badpix_selfcal/description.rst
+++ b/docs/jwst/badpix_selfcal/description.rst
@@ -6,26 +6,26 @@ Description
 
 Overview
 --------
-The ``badpix_selfcal`` step flags bad pixels in the input data using a self-calibration 
-technique based on median filtering along the spectral axis. 
+The ``badpix_selfcal`` step flags bad pixels in the input data using a self-calibration
+technique based on median filtering along the spectral axis.
 When additional exposures are available, those are used in combination with the science
 exposure to identify bad pixels; when unavailable, the step will be skipped with a warning
 unless the ``force_single`` parameter is set True. In that case, the science data alone is
 used as its own "background".
-This correction is applied to `~jwst.datamodels.IFUImageModel` data
+This correction is applied to `~stdatamodels.jwst.datamodels.IFUImageModel` data
 directly after the :ref:`assign_wcs <assign_wcs_step>` correction has been applied
 in the :ref:`calwebb_spec2 <calwebb_spec2>` pipeline.
 
 Input details
 -------------
-The input data must be in the form of a `~jwst.datamodels.IFUImageModel` or
+The input data must be in the form of a `~stdatamodels.jwst.datamodels.IFUImageModel` or
 a `~jwst.datamodels.container.ModelContainer` containing exactly one
 science exposure and any number of additional exposures.
-A fits or association file 
+A fits or association file
 that can be read into one of these data models is also acceptable.
-Any exposure with the metadata attribute ``asn.exptype`` set to 
+Any exposure with the metadata attribute ``asn.exptype`` set to
 ``background`` or ``selfcal`` will be used in conjunction with the science
-exposure to construct the combined background image. 
+exposure to construct the combined background image.
 
 Algorithm
 ---------
@@ -33,22 +33,22 @@ The algorithm relies on the assumption that bad pixels are outliers in the data 
 the spectral axis. The algorithm proceeds as follows:
 
 * A combined background image is created. If additional (``selfcal`` or ``background``)
-  exposures are available, 
-  the pixelwise minimum of all background, selfcal, and science exposures is taken. 
-  If no additional exposures are available, the science data itself is passed in 
-  without modification, serving as the "background image" for the rest of the procedure, 
+  exposures are available,
+  the pixelwise minimum of all background, selfcal, and science exposures is taken.
+  If no additional exposures are available, the science data itself is passed in
+  without modification, serving as the "background image" for the rest of the procedure,
   i.e., true self-calibration.
 * For MIRI MRS, any residual pedestal in the effective dark current is subtracted from
   each exposure using the unilluminated region of the detector between spectral channels
   prior to performing the pixelwise minimum combination.
-* The combined background image is median-filtered, ignoring NaNs, along the spectral axis 
+* The combined background image is median-filtered, ignoring NaNs, along the spectral axis
   with a user-specified kernel size. The default kernel size is 15 pixels.
 * The difference between the original background image and the median-filtered background image
   is taken. The highest- and lowest-flux pixels in this difference image are
   flagged as bad pixels. The default fraction of pixels to flag is 0.1% of the total number of pixels
   on each of the high-flux and low-flux ends of the distribution. These fractions can be adjusted
   using the ``flagfrac_lower`` and ``flagfrac_upper`` parameters for the low- and high-flux ends
-  of the distribution, respectively. The total fraction of flagged pixels is thus 
+  of the distribution, respectively. The total fraction of flagged pixels is thus
   ``flagfrac_lower + flagfrac_upper``.
 * The bad pixels are flagged in the input data by setting the DQ flag to
   "OTHER_BAD_PIXEL" and "DO_NOT_USE".
@@ -57,7 +57,7 @@ the spectral axis. The algorithm proceeds as follows:
 
 Output product
 --------------
-The output is a new copy of the input `~jwst.datamodels.IFUImageModel`, with the
+The output is a new copy of the input `~stdatamodels.jwst.datamodels.IFUImageModel`, with the
 bad pixels flagged.  If the entire ``calwebb_spec2`` pipeline is run, the background
 exposures passed into the ``background`` step will include the flags from the
 ``badpix_selfcal`` step.

--- a/docs/jwst/barshadow/description.rst
+++ b/docs/jwst/barshadow/description.rst
@@ -17,7 +17,7 @@ Input details
 The input data must have been processed through the
 :ref:`extract_2d <extract_2d_step>` step, so that cutouts have been created
 for each of the slitlets used in the exposure. Hence the input must be in the
-form of a `~jwst.datamodels.MultiSlitModel`.
+form of a `~stdatamodels.jwst.datamodels.MultiSlitModel`.
 
 It is also assumed that the input data have been processed through the
 :ref:`srctype <srctype_step>` step, which for NIRSpec MSA exposures sets the
@@ -51,7 +51,7 @@ correction values are divided into the variance arrays.
 
 Output product
 --------------
-The output is a new copy of the input `~jwst.datamodels.MultiSlitModel`, with the
+The output is a new copy of the input `~stdatamodels.jwst.datamodels.MultiSlitModel`, with the
 corrections applied to the slit data arrays. The 2-D correction array for each slit
 is also added to the datamodel in the "BARSHADOW" extension.
 

--- a/docs/jwst/charge_migration/description.rst
+++ b/docs/jwst/charge_migration/description.rst
@@ -7,38 +7,38 @@ Description
 
 Overview
 --------
-This step corrects for an artifact seen in undersampled NIRISS images that may depress flux 
-in resampled images. The artifact is seen in dithered images where the star is centered in 
-a pixel. When the peak pixels of such stars approach the saturation level, they suffer from 
+This step corrects for an artifact seen in undersampled NIRISS images that may depress flux
+in resampled images. The artifact is seen in dithered images where the star is centered in
+a pixel. When the peak pixels of such stars approach the saturation level, they suffer from
 significant :ref:`charge migration <charge_migration>`:
-the spilling of charge from a saturated pixel into its neighboring pixels. This charge migration 
-causes group-to-group differences to decrease significantly once the signal level is greater than 
+the spilling of charge from a saturated pixel into its neighboring pixels. This charge migration
+causes group-to-group differences to decrease significantly once the signal level is greater than
 ~25,000 ADU. As a result, the last several groups of these ramps get flagged by the :ref:`jump <jump_step>`
 step.  The smaller number of groups used for these pixels in the :ref:`ramp_fitting <ramp_fitting_step>`
 step results in them having  larger read noise variances, which in turn leads to lower weights used
 during resampling. This ultimately leads to a lower than normal flux for the star in resampled images.
 
-Once a group in a ramp has been flagged as affected by charge migration, all subsequent 
-groups in the ramp are also flagged. By flagging these groups, they are not used in the 
-computation of slopes in the :ref:`ramp_fitting <ramp_fitting_step>` step. However, as described 
-in the algorithm section below, they _are_ used in the calculation of the variance of the slope 
+Once a group in a ramp has been flagged as affected by charge migration, all subsequent
+groups in the ramp are also flagged. By flagging these groups, they are not used in the
+computation of slopes in the :ref:`ramp_fitting <ramp_fitting_step>` step. However, as described
+in the algorithm section below, they _are_ used in the calculation of the variance of the slope
 due to readnoise.
 
 Input details
 -------------
-The input must be in the form of a `~jwst.datamodels.RampModel`.
+The input must be in the form of a `~stdatamodels.jwst.datamodels.RampModel`.
 
 
 Algorithm
---------- 
-The first group, and all subsequent groups, exceeding the value of the 
-``signal_threshold`` parameter is flagged as CHARGELOSS. ``signal_threshold`` is in units 
-of ADUs. These groups will also be flagged as DO_NOT_USE, and will not 
-be included in the slope calculation during the ``ramp_fitting`` step. Despite being flagged 
+---------
+The first group, and all subsequent groups, exceeding the value of the
+``signal_threshold`` parameter is flagged as CHARGELOSS. ``signal_threshold`` is in units
+of ADUs. These groups will also be flagged as DO_NOT_USE, and will not
+be included in the slope calculation during the ``ramp_fitting`` step. Despite being flagged
 as DO_NOT_USE, these CHARGELOSS groups are still included in the calculation of the
-variance due to readnoise. 
-This results in a readnoise variance for undersampled pixels that is similar to that of 
-pixels unaffected by charge migration. For the Poisson noise variance calculation in 
+variance due to readnoise.
+This results in a readnoise variance for undersampled pixels that is similar to that of
+pixels unaffected by charge migration. For the Poisson noise variance calculation in
 :ref:`ramp_fitting <ramp_fitting_step>`, the CHARGELOSS/DO_NOT_USE groups are not included.
 
 For integrations having only 1 or 2 groups, no flagging will be performed.
@@ -46,6 +46,5 @@ For integrations having only 1 or 2 groups, no flagging will be performed.
 
 Output product
 --------------
-The output is a new copy of the input `~jwst.datamodels.RampModel`, with the updated DQ flags
+The output is a new copy of the input `~stdatamodels.jwst.datamodels.RampModel`, with the updated DQ flags
 added to the GROUPDQ array.
-

--- a/docs/jwst/clean_flicker_noise/arguments.rst
+++ b/docs/jwst/clean_flicker_noise/arguments.rst
@@ -15,7 +15,7 @@ the behavior of the processing.
 
 ``--fit_by_channel`` (boolean, default=False)
   If set, flicker noise is fit independently for each detector channel.
-  Ignored for MIRI, for subarray data, and for `fit_method` = 'fft'.
+  Ignored for MIRI, for subarray data, and for ``fit_method = 'fft'``.
 
 ``--background_method`` (str, default='median')
   If 'median', the preliminary background to remove and restore
@@ -26,7 +26,7 @@ the behavior of the processing.
 
 ``--background_box_size`` (list of int, default=None)
   Box size for the data grid used by `~photutils.background.Background2D`
-  when `background_method` = 'model'. For best results, use a
+  when ``background_method = 'model'``. For best results, use a
   box size that evenly divides the input image shape. If None, the largest
   value between 1 and 32 that evenly divides the image dimension is used.
 
@@ -42,7 +42,7 @@ the behavior of the processing.
   (reference type FLAT) is required. For modes that do not provide
   FLAT files via CRDS, including all NIRSpec modes, a manually
   generated override flat is required to enable this option.
-  Use the `override_flat` parameter to provide an alternate flat image
+  Use the ``override_flat`` parameter to provide an alternate flat image
   as needed (see :ref:`overriding reference files <intro_override_reference_file>`).
 
 ``--n_sigma`` (float, default=2.0)
@@ -51,7 +51,7 @@ the behavior of the processing.
   and noise fitting processes.
 
 ``--fit_histogram`` (boolean, default=False)
-  If set, the 'sigma' used with `n_sigma` for clipping outliers
+  If set, the 'sigma' used with ``n_sigma`` for clipping outliers
   is derived from a Gaussian fit to a histogram of values.
   Otherwise, a simple iterative sigma clipping is performed.
 
@@ -65,8 +65,8 @@ the behavior of the processing.
   directly and the process of creating a scene mask in the step is
   skipped.
 
-  The mask file must contain either a `~jwst.datamodels.ImageModel`
-  or a `~jwst.datamodels.CubeModel`, with image dimensions matching
+  The mask file must contain either a `~stdatamodels.jwst.datamodels.ImageModel`
+  or a `~stdatamodels.jwst.datamodels.CubeModel`, with image dimensions matching
   the input science data.  If an ImageModel is provided, the same
   mask will be used for all integrations.  If a CubeModel is provided,
   the number of slices must equal the number of integrations in

--- a/docs/jwst/clean_flicker_noise/main.rst
+++ b/docs/jwst/clean_flicker_noise/main.rst
@@ -52,8 +52,8 @@ Note that a user may also supply their own mask image as input to the step,
 in which case the process of creating a mask is skipped. The step parameter
 ``user_mask`` is used to specify an input mask.  If specified, the input
 mask must contain a datamodel matching the shape of a 'rate' or 'rateints'
-file generated for the input science data (either `~jwst.datamodels.ImageModel`
-or `~jwst.datamodels.CubeModel`).  To generate a custom mask, it may be
+file generated for the input science data (either `~stdatamodels.jwst.datamodels.ImageModel`
+or `~stdatamodels.jwst.datamodels.CubeModel`).  To generate a custom mask, it may be
 easiest to save the mask output from a default run of the ``clean_flicker_noise``
 step on the input data, then modify it as needed.
 

--- a/docs/jwst/cube_build/main.rst
+++ b/docs/jwst/cube_build/main.rst
@@ -1,7 +1,7 @@
 Description
 ===========
 
-:Class: `jwst.cube_build.CubeBuildStep`
+:Class: `jwst.cube_build.cube_build_step.CubeBuildStep`
 :Alias: cube_build
 
 The ``cube_build`` step takes MIRI or NIRSpec IFU calibrated 2-D images and produces
@@ -13,7 +13,7 @@ The ``cube_build`` step can accept several different forms of input data, includ
 
 #. A single file containing a 2-D IFU image
 
-#. A data model (`~jwst.datamodels.IFUImageModel`) containing a 2-D IFU image
+#. A data model (`~stdatamodels.jwst.datamodels.IFUImageModel`) containing a 2-D IFU image
 
 #. An association table (in json format) containing a list of input files
 
@@ -62,7 +62,7 @@ dispersed by a prism or one of six diffraction gratings.  The NIRSpec IFU gratin
 provide high-resolution and  medium resolution  spectroscopy while the prism yields lower-resolution spectroscopy.
 The NIRSpec detector focal plane consists of two HgCdTe sensor chip assemblies (SCAs). Each SCA is a 2-D array of
 2048 x 2048 pixels.  For low or medium resolution IFU data the 30 slices are imaged on
-a single NIRSpec SCA. In high resolution mode the 30 slices are imaged on the two NIRSpec SCAs. 
+a single NIRSpec SCA. In high resolution mode the 30 slices are imaged on the two NIRSpec SCAs.
 
 
 Terminology
@@ -128,7 +128,7 @@ Linear wavelength IFU cubes are constructed from a single band of data, while no
 created from more than one band of data. If the IFU cubes have a non-linear wavelength dimension
 there will be an added binary extension table to the output fits IFU cube. This extension has
 the label WCS-TABLE and contains the wavelengths for each of the IFU cube wavelength planes. This table follows the
-FITs standard described in, *Representations of spectral coordinates in FITS*, Greisen, et al., **A & A**  446, 747-771, 2006. 
+FITs standard described in, *Representations of spectral coordinates in FITS*, Greisen, et al., **A & A**  446, 747-771, 2006.
 
 The input data to ``cube_build`` can take a variety of forms, including a single file, a data
 model passed from another pipeline step, a list of files in an association table, or a collection of exposures in a
@@ -150,7 +150,7 @@ dimension. The calwebb_spec2 pipeline calls cube_build with
 In the :ref:`calwebb_spec3 <calwebb_spec3>` pipeline, on the other hand, where
 the input can be a collection of data from multiple exposures covering multiple
 bands, the default behavior is to create a set of single-channel cubes. For MIRI,
-for example, this can mean separate cubes for channel 1, 2, 3 and 4. 
+for example, this can mean separate cubes for channel 1, 2, 3 and 4.
 depending on what's included in the input. For NIRSpec this may mean
 multiple cubes, one for each grating+filter combination contained in the input
 collection. The calwebb_spec3 pipeline calls cube_build with
@@ -215,11 +215,11 @@ The string defining the type of IFU is created according to the following rules:
 Algorithm
 ---------
 The type of output IFU cube created depends on which pipeline is being run,
-:ref:`calwebb_spec2 <calwebb_spec2>` or  :ref:`calwebb_spec3 <calwebb_spec3>`, 
+:ref:`calwebb_spec2 <calwebb_spec2>` or  :ref:`calwebb_spec3 <calwebb_spec3>`,
 and if additional
-user provided options are being set  (see the :ref:`arguments` section.). 
-Based on the pipeline setting and any user provided arguments defining the type of cubes to create, the program selects 
-the data from each exposure that should be included in the spectral cube. The  output cube is defined using the WCS 
+user provided options are being set  (see the :ref:`arguments` section.).
+Based on the pipeline setting and any user provided arguments defining the type of cubes to create, the program selects
+the data from each exposure that should be included in the spectral cube. The  output cube is defined using the WCS
 information of all the input data. The input data are mapped to the output frame based on the wcs information that is
 filled in by the :ref:`assign_wcs <assign_wcs_step>` step, this mapping includes any dither offsets.
 Therefore, the default output cube WCS defines a field-of-view that encompasses the undistorted footprints on
@@ -231,7 +231,7 @@ for each dimension for each band. If the output IFU cube contains more than one 
 output scale corresponds to the channel with the smallest scale. In the case of NIRSpec only gratings of the
 same resolution are combined together in an IFU cube. The default output spatial coordinate system is right ascension-declination.
 There is an option to create IFU cubes in the coordinate system of the NIRSpec or MIRI MIRS local ifu slicer plane (see
-:ref:`arguments`, coord_system='internal_cal'). 
+:ref:`arguments`, coord_system='internal_cal').
 
 The pixels on each exposure that are to be  included in the output are mapped to the cube coordinate system. This
 pixel mapping is determined via a series of chained mapping transformations derived from the WCS of each input image and the
@@ -359,7 +359,7 @@ where the weighting ``weighting=emsm``  is:
 
 :math:`w_i =e\frac{ -({xnormalized}_i^2 + {ynormalized}_i^2 + {znormalized}_i^2)} {scale factor}`
 
-The *scale factor* = *scale rad/cdelt1*, where *scale rad* is read in from the reference file and varies with wavelength. 
+The *scale factor* = *scale rad/cdelt1*, where *scale rad* is read in from the reference file and varies with wavelength.
 
 If the alternative weighting function (set by ``weighting = msm``) is selected then:
 
@@ -367,4 +367,3 @@ If the alternative weighting function (set by ``weighting = msm``) is selected t
 
 In this weighting function the default value for *p* is read in from the cubepar reference file. It can also be set
 by the argument ``weight_power=value``.
-

--- a/docs/jwst/data_products/nonscience_products.rst
+++ b/docs/jwst/data_products/nonscience_products.rst
@@ -57,7 +57,7 @@ Charge trap state data: ``trapsfilled``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The :ref:`persistence <persistence_step>` step in the :ref:`calwebb_detector1 <calwebb_detector1>`
 pipeline produces an image containing information on the number of filled charge traps in each
-pixel at the end of an exposure. Internally these data exist as a `~jwst.datamodels.TrapsFilledModel`
+pixel at the end of an exposure. Internally these data exist as a `~stdatamodels.jwst.datamodels.TrapsFilledModel`
 data model, which is saved to a ``trapsfilled`` FITS product. The FITS file has the following
 format:
 
@@ -103,4 +103,3 @@ technique that results in a standard imaging FITS file structure, as shown below
  - ERR: 2-D data array containing uncertainty estimates for each pixel.
  - DQ: 2-D data array containing DQ flags for each pixel.
  - ADSF: The data model meta data.
-

--- a/docs/jwst/data_products/science_products.rst
+++ b/docs/jwst/data_products/science_products.rst
@@ -778,30 +778,8 @@ Aligned PSF data: ``psfalign``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The :ref:`align_refs <align_refs_step>` step in the :ref:`calwebb_coron3 <calwebb_coron3>`
 pipeline creates a 3-D stack of PSF images that are aligned to corresponding science target
-images. The resulting ``psfalign`` product uses the `~stdatamodels.jwst.datamodels.QuadModel` data model,
-which when serialized to a FITS file has the structure and content shown below.
-
-+-----+-------------+----------+-----------+-------------------------------+
-| HDU | EXTNAME     | HDU Type | Data Type | Dimensions                    |
-+=====+=============+==========+===========+===============================+
-|  0  | N/A         | primary  | N/A       | N/A                           |
-+-----+-------------+----------+-----------+-------------------------------+
-|  1  | SCI         | IMAGE    | float32   | ncols x nrows x npsfs x nints |
-+-----+-------------+----------+-----------+-------------------------------+
-|  2  | DQ          | IMAGE    | uint32    | ncols x nrows x npsfs x nints |
-+-----+-------------+----------+-----------+-------------------------------+
-|  3  | ERR         | IMAGE    | float32   | ncols x nrows x npsfs x nints |
-+-----+-------------+----------+-----------+-------------------------------+
-|  4  | ASDF        | BINTABLE | N/A       | variable                      |
-+-----+-------------+----------+-----------+-------------------------------+
-
- - SCI: 4-D data array containing a stack of 2-D PSF images aligned to each integration
-   within a corresponding science target exposure.
-   each integration.
- - DQ: 4-D data array containing DQ flags for each PSF image.
- - ERR: 4-D data array containing a stack of 2-D uncertainty estimates for each PSF image,
-   per science target integration.
- - ADSF: The data model meta data.
+images. The resulting ``psfalign`` product uses the `~stdatamodels.jwst.datamodels.CubeModel` data model,
+which is the same as :ref:`psfstack` but shifted.
 
 .. _psfsub:
 

--- a/docs/jwst/data_products/science_products.rst
+++ b/docs/jwst/data_products/science_products.rst
@@ -777,9 +777,9 @@ structure shown below.
 Aligned PSF data: ``psfalign``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The :ref:`align_refs <align_refs_step>` step in the :ref:`calwebb_coron3 <calwebb_coron3>`
-pipeline creates a 3-D stack of PSF images that are aligned to corresponding science target
-images. The resulting ``psfalign`` product uses the `~stdatamodels.jwst.datamodels.CubeModel` data model,
-which is the same as :ref:`psfstack` but shifted.
+pipeline shifts the stack of PSF images to align them to the first science target image.
+The resulting ``psfalign`` product uses the `~stdatamodels.jwst.datamodels.CubeModel` data model,
+which has the same structure as the :ref:`psfstack` product.
 
 .. _psfsub:
 

--- a/docs/jwst/data_products/science_products.rst
+++ b/docs/jwst/data_products/science_products.rst
@@ -58,17 +58,17 @@ The FITS file structure is as follows.
  - REFOUT: The MIRI detector reference output values. Only appears in MIRI exposures.
  - ADSF: The data model meta data.
 
-This FITS file structure is the result of serializing a `~jwst.datamodels.Level1bModel`, but
-can also be read into a `~jwst.datamodels.RampModel`, in which case zero-filled
+This FITS file structure is the result of serializing a `~stdatamodels.jwst.datamodels.Level1bModel`, but
+can also be read into a `~stdatamodels.jwst.datamodels.RampModel`, in which case zero-filled
 GROUPDQ and PIXELDQ data arrays will be created and stored in the model, having array
-dimensions based on the shape of the SCI array (see `~jwst.datamodels.RampModel`).
+dimensions based on the shape of the SCI array (see `~stdatamodels.jwst.datamodels.RampModel`).
 
 .. _ramp:
 
 Ramp data: ``ramp``
 ^^^^^^^^^^^^^^^^^^^
 As raw data progress through the :ref:`calwebb_detector1 <calwebb_detector1>` pipeline
-they are stored internally in a `~jwst.datamodels.RampModel`.
+they are stored internally in a `~stdatamodels.jwst.datamodels.RampModel`.
 This type of data model is serialized to a ``ramp`` type FITS
 file on disk. The original detector pixel values (in the SCI extension) are converted
 from integer to floating-point data type. The same is true for the ZEROFRAME and REFOUT
@@ -166,7 +166,7 @@ The FITS file structure for a ``rateints`` product is as follows:
    based on read noise only.
  - ADSF: The data model meta data.
 
-These FITS files are compatible with the `~jwst.datamodels.CubeModel` data model.
+These FITS files are compatible with the `~stdatamodels.jwst.datamodels.CubeModel` data model.
 
 The FITS file structure for a ``rate`` product is as follows:
 
@@ -199,7 +199,7 @@ The FITS file structure for a ``rate`` product is as follows:
    based on read noise only.
  - ADSF: The data model meta data.
 
-These FITS files are compatible with the `~jwst.datamodels.ImageModel` data model.
+These FITS files are compatible with the `~stdatamodels.jwst.datamodels.ImageModel` data model.
 
 Note that the ``INT_TIMES`` table does not appear in ``rate`` products, because the
 data have been averaged over all integrations and hence the per-integration time stamps
@@ -750,7 +750,7 @@ Stacked PSF data: ``psfstack``
 The :ref:`stack_refs <stack_refs_step>` step in the :ref:`calwebb_coron3 <calwebb_coron3>`
 pipeline takes a collection of PSF reference image and assembles them into a 3-D stack of
 PSF images, which results in a ``psfstack`` product. The ``psfstack`` product uses the
-`~jwst.datamodels.CubeModel` data model, which when serialized to a FITS file has the
+`~stdatamodels.jwst.datamodels.CubeModel` data model, which when serialized to a FITS file has the
 structure shown below.
 
 +-----+-------------+----------+-----------+-----------------------+
@@ -778,7 +778,7 @@ Aligned PSF data: ``psfalign``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The :ref:`align_refs <align_refs_step>` step in the :ref:`calwebb_coron3 <calwebb_coron3>`
 pipeline creates a 3-D stack of PSF images that are aligned to corresponding science target
-images. The resulting ``psfalign`` product uses the `~jwst.datamodels.QuadModel` data model,
+images. The resulting ``psfalign`` product uses the `~stdatamodels.jwst.datamodels.QuadModel` data model,
 which when serialized to a FITS file has the structure and content shown below.
 
 +-----+-------------+----------+-----------+-------------------------------+
@@ -810,7 +810,7 @@ PSF-subtracted data: ``psfsub``
 The :ref:`klip <klip_step>` step in the :ref:`calwebb_coron3 <calwebb_coron3>`
 pipeline subtracts an optimized combination of PSF images from each integration in a
 science target exposure. The resulting PSF-subtracted science exposure data uses the
-`~jwst.datamodels.CubeModel` data model, which when serialized to a FITS file has the
+`~stdatamodels.jwst.datamodels.CubeModel` data model, which when serialized to a FITS file has the
 structure shown below.
 
 +-----+-------------+----------+-----------+-----------------------+
@@ -858,16 +858,16 @@ AMI derived data created by the :ref:`ami_analyze <ami_analyze_step>`
 and :ref:`ami_normalize <ami_normalize_step>` steps
 as part of the :ref:`calwebb_ami3 <calwebb_ami3>` pipeline are stored in OIFITS files.
 These are a particular type of FITS files containing several binary table extensions
-and are encapsulated within a `~jwst.datamodels.AmiOIModel` data model.
+and are encapsulated within a `~stdatamodels.jwst.datamodels.AmiOIModel` data model.
 There are two additional outputs of the :ref:`ami_analyze <ami_analyze_step>` intended
 to enable a more detailed look at the data. The ``amimulti-oi`` file contains per-integration
-interferometric observables and is also a contained in a `~jwst.datamodels.AmiOIModel`,
+interferometric observables and is also a contained in a `~stdatamodels.jwst.datamodels.AmiOIModel`,
 while the ``amilg`` product is a primarily image-based FITS file containing the
 cropped data, model, and residuals as well as the best-fit model parameters. It
-is contained in a `~jwst.datamodels.AmiLgFitModel` data model.
+is contained in a `~stdatamodels.jwst.datamodels.AmiLgFitModel` data model.
 
 The :ref:`ami_normalize <ami_normalize_step>` step produces an ``aminorm-oi`` product,
-which is also contained in a `~jwst.datamodels.AmiOIModel`. The model conforms to the standard
+which is also contained in a `~stdatamodels.jwst.datamodels.AmiOIModel`. The model conforms to the standard
 defined in `OIFITS2 standard <https://doi.org/10.1051/0004-6361/201526405>`_.
 
 In the per-integration ``amimulti-oi`` products the "OI_ARRAY", "OI_T3", "OI_VIS", "OI_VIS2", and "OI_Q4" extensions each contain 2D data columns whose second dimension equals

--- a/docs/jwst/extract_2d/main.rst
+++ b/docs/jwst/extract_2d/main.rst
@@ -10,7 +10,8 @@ The ``extract_2d`` step extracts 2D arrays from spectral images. The extractions
 are performed within all of the SCI, ERR, and DQ arrays of the input image
 model, as well as any variance arrays that may be present. It also computes an
 array of wavelengths to attach to the extracted data. The extracted arrays
-are stored as one or more ``slit`` objects in an output ``MultiSlitModel``
+are stored as one or more ``slit`` objects in an output
+`~stdatamodels.jwst.datamodels.MultiSlitModel`
 and saved as separate tuples of extensions in the output FITS file.
 
 Assumptions
@@ -63,13 +64,13 @@ The corner locations of the regions to be extracted are determined from the
 along each axis. The input coordinates are in the image frame, i.e. subarray shifts
 are accounted for.
 
-The output ``MultiSlitModel`` data model will have the meta data associated with each
+The output `~stdatamodels.jwst.datamodels.MultiSlitModel` data model will have the meta data associated with each
 slit region populated with the name and region characteristic for the slits,
 corresponding to the FITS keywords "SLTNAME", "SLTSTRT1", "SLTSIZE1",
 "SLTSTRT2", and "SLTSIZE2."  Keyword "DISPAXIS" (dispersion direction)
 will be copied from the input file to each of the output cutout images.
 
-The "SRCXPOS" and "SRCYPOS" keywords in the SCI extension header of each slitlet 
+The "SRCXPOS" and "SRCYPOS" keywords in the SCI extension header of each slitlet
 are also populated with estimates of the source
 x (dispersion) and y (cross-dispersion) location within the slitlet.
 For MOS data, these values are taken from the :ref:`MSA metadata file<msa_metadata>`.
@@ -93,7 +94,7 @@ position from the WCS information.
 NIRCam and NIRISS WFSS
 ++++++++++++++++++++++
 
-During normal, automated processing of WFSS grism images, the 
+During normal, automated processing of WFSS grism images, the
 step parameter ``grism_objects`` is left unspecified, in which case the ``extract_2d``
 step uses the source catalog that is specified in the input model's meta information,
 ``input_model.meta.source_catalog.filename`` ("SCATFILE" keyword) to define the
@@ -113,8 +114,8 @@ The ``wfss_mmag_extract`` and ``wfss_nbright`` parameters both affect which obje
 from a source catalog will be retained for extraction. The rejection or retention of
 objects proceeds as follows:
 
-1. As each object is read from the source catalog, they are immediately rejected if 
-   their isophotal_abmag > ``wfss_mmag_extract``, meaning that only objects brighter than
+1. As each object is read from the source catalog, they are immediately rejected if
+   their ``isophotal_abmag > wfss_mmag_extract``, meaning that only objects brighter than
    ``wfss_mmag_extract`` will be retained. The default ``wfss_mmag_extract`` value of
    ``None`` retains all objects.
 
@@ -139,7 +140,8 @@ for the wavelength range of each spectral order to be extracted are also require
 they are stored in the ``wavelengthrange`` reference file, which can be retrieved from CRDS.
 
 Load the grism image, which is assumed to have already been processed through ``assign_wcs``,
-into an `ImageModel` data model (used for all 2-D "images", regardless of whether
+into an `~stdatamodels.jwst.datamodels.ImageModel` data model
+(used for all 2-D "images", regardless of whether
 they actually contain imaging data or dispersed spectra):
 
 .. doctest-skip::
@@ -196,7 +198,7 @@ Create a list of grism objects for a specified spectral order and wavelength ran
 In this case we don't use the default wavelength range limits from the ``wavelengthrange``
 reference file, but instead designate custom limits via the ``wavelength_range`` parameter
 passed to the ``create_grism_bbox`` function, which is a dictionary of the form
-``{spectral_order: (wave_min, wave_max)}``. 
+``{spectral_order: (wave_min, wave_max)}``.
 Use the source ID, ``sid``, to identify the object(s) to be modified.
 The computed extraction limits are stored in the ``order_bounding`` attribute,
 which is ordered ``(y, x)``.
@@ -239,7 +241,8 @@ defined in that list:
 
   >>> result = step.call(input_model, grism_objects=grism_objects)
 
-``result`` is a ``MultiSlitModel`` data model, containing one ``SlitModel``
+``result`` is a `~stdatamodels.jwst.datamodels.MultiSlitModel` data model,
+containing one `~stdatamodels.jwst.datamodels.SlitModel`
 instance for each extracted object, which includes meta data that identify
 each object and the actual extracted data arrays, e.g.:
 
@@ -266,10 +269,10 @@ for all computations involving the extent of the spectral trace and pixel wavele
 assignments.
 
 In rare cases, it may be desirable to shift the source location in the X-direction, e.g.
-for a custom noise suppression scheme. This is achieved in the APT by specifying an 
-offset special requirement, and shows up in the header keyword "XOFFSET". The 
+for a custom noise suppression scheme. This is achieved in the APT by specifying an
+offset special requirement, and shows up in the header keyword "XOFFSET". The
 ``extract_2d`` step accounts for this offset by simply shifting the wavelength array by
-the appropriate amount. The WCS information remains unchanged. Note that offsets in the 
+the appropriate amount. The WCS information remains unchanged. Note that offsets in the
 Y-direction (cross-dispersion direction) are not supported and should not be attempted.
 
 NIRCam subarrays used for TSGRISM observations always have their "bottom" edge located
@@ -322,7 +325,7 @@ Time-Series (TSO) grism spectroscopy:
 
 ``--wfss_mmag_extract``
   float (default is ``None``). The minimum (faintest) magnitude object to extract, based on
-  the value of `isophotal_abmag` in the source catalog. Only applies to WFSS mode.
+  the value of ``isophotal_abmag`` in the source catalog. Only applies to WFSS mode.
 
 ``--wfss_nbright``
   int (default is 1000). The number of brightest source catalog objects to extract.

--- a/docs/jwst/hlsp/description.rst
+++ b/docs/jwst/hlsp/description.rst
@@ -1,7 +1,7 @@
 Description
 -----------
 
-:Class: `jwst.coron.HlspStep`
+:Class: `jwst.coron.hlsp_step.HlspStep`
 :Alias: hlsp
 
 The ``hlsp`` step is one of the coronagraphic-specific steps in the ``coron``
@@ -32,7 +32,7 @@ Inputs
 
 2D image
 ^^^^^^^^
-:Data model: `~jwst.datamodels.ImageModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`
 :File suffix: _psfsub
 
 The input is the KLIP-processed (PSF-subtracted) image to be analyzed.
@@ -42,14 +42,14 @@ Outputs
 
 2D SNR image
 ^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.ImageModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`
 :File suffix: _snr
 
 The computed SNR image.
 
 Contrast table
 ^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.ContrastModel`
+:Data model: `~stdatamodels.jwst.datamodels.ContrastModel`
 :File suffix: _contrast
 
 The table of contrast data, containing columns of radii (in pixels) and 1-sigma noise.

--- a/docs/jwst/klip/description.rst
+++ b/docs/jwst/klip/description.rst
@@ -1,7 +1,7 @@
 Description
 -----------
 
-:Class: `jwst.coron.KlipStep`
+:Class: `jwst.coron.klip_step.KlipStep`
 :Alias: klip
 
 The ``klip`` step is one of the coronagraphic-specific steps in the ``coron``
@@ -40,7 +40,7 @@ cube and a 3D aligned PSF image ("_psfalign") product.
 
 3D calibrated images
 ^^^^^^^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _calints
 
 A 3D calibrated science target product containing a stack of per-integration images.
@@ -50,7 +50,7 @@ as input to the :ref:`calwebb_coron3 <calwebb_coron3>` pipeline.
 
 3D aligned PSF images
 ^^^^^^^^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _psfalign
 
 A collection of PSF images that have been aligned to the first of the images
@@ -62,7 +62,7 @@ Outputs
 
 3D PSF-subtracted images
 ^^^^^^^^^^^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _psfsub
 
 The output is a 3D stack of PSF-subtracted images of the science target, having the same

--- a/docs/jwst/model_blender/main.rst
+++ b/docs/jwst/model_blender/main.rst
@@ -47,10 +47,10 @@ The simplest way to run model blender only requires calling a single interface:
   from jwst.model_blender import blendmeta
   blendmeta.blendmodels(product, input_list)
 
-where
+where:
 
-  - `product`: the datamodel for the already combined product
-  - `input_list`: list of input datamodels used to create the `product`
+  - ``product``: the datamodel for the already combined product
+  - ``input_list``: list of input datamodels used to create the ``product``
 
 
 The output product will end up with new metadata attribute values and a new ``hdrtab``
@@ -60,7 +60,7 @@ to disk.
 Using ModelBlender
 ------------------
 
-Alternatively, metadata blending can be done incrementally by using `ModelBlender`
+Alternatively, metadata blending can be done incrementally by using `~jwst.model_blender.ModelBlender`
 to accumulate metadata from several models and then blending the result into an
 output model.
 
@@ -72,7 +72,7 @@ output model.
        blender.accumulate(model)
    blender.finalize_model(product)
 
-This produces a ``product`` identical to a call to `blendmodels` described above.
+This produces a ``product`` identical to a call to ``blendmodels`` described above.
 
 
 Customizing the behavior

--- a/docs/jwst/nsclean/arguments.rst
+++ b/docs/jwst/nsclean/arguments.rst
@@ -11,7 +11,7 @@ the behavior of the processing.
 
 ``--fit_by_channel`` (boolean, default=False)
   If set, flicker noise is fit independently for each detector channel.
-  Ignored for subarray data and for `fit_method` = 'fft'.
+  Ignored for subarray data and for ``fit_method = 'fft'``.
 
 ``--background_method`` (str, default=None)
   If 'median', the preliminary background to remove and restore
@@ -22,7 +22,7 @@ the behavior of the processing.
 
 ``--background_box_size`` (list of int, default=(32,32))
   Box size for the data grid used by `~photutils.background.Background2D`
-  when `background_method` = 'model'. For best results, use a
+  when ``background_method = 'model'``. For best results, use a
   box size that evenly divides the input image shape.
 
 ``--mask_spectral_regions`` (boolean, default=True)
@@ -36,7 +36,7 @@ the behavior of the processing.
   and noise fitting processes.
 
 ``--fit_histogram`` (boolean, default=False)
-  If set, the 'sigma' used with `n_sigma` for clipping outliers
+  If set, the 'sigma' used with ``n_sigma`` for clipping outliers
   is derived from a Gaussian fit to a histogram of values.
   Otherwise, a simple iterative sigma clipping is performed.
 
@@ -50,8 +50,8 @@ the behavior of the processing.
   directly and the process of creating a scene mask in the step is
   skipped.
 
-  The mask file must contain either a `~jwst.datamodels.ImageModel`
-  or a `~jwst.datamodels.CubeModel`, with image dimensions matching
+  The mask file must contain either a `~stdatamodels.jwst.datamodels.ImageModel`
+  or a `~stdatamodels.jwst.datamodels.CubeModel`, with image dimensions matching
   the input science data.  If an ImageModel is provided, the same
   mask will be used for all integrations.  If a CubeModel is provided,
   the number of slices must equal the number of integrations in

--- a/docs/jwst/outlier_detection/outlier_detection_coron.rst
+++ b/docs/jwst/outlier_detection/outlier_detection_coron.rst
@@ -4,7 +4,7 @@ Coronagraphic Data
 ==================
 
 This module serves as the interface for applying ``outlier_detection`` to coronagraphic
-image observations. A :py:class:`~jwst.datamodels.CubeModel` serves as the basic format
+image observations. A :py:class:`~stdatamodels.jwst.datamodels.CubeModel` serves as the basic format
 for all processing performed by this step. This routine performs the following operations:
 
 #. Extract parameter settings from input model and merge them with any user-provided values.
@@ -14,7 +14,7 @@ for all processing performed by this step. This routine performs the following o
 #. Do not attempt resampling; data are assumed to be aligned and have an identical WCS.
    This is true automatically for a CubeModel.
 
-#. Create a median image over the `groups` (exposures, planes of cube) axis,
+#. Create a median image over the ``groups`` (exposures, planes of cube) axis,
    preserving the spatial (x,y) dimensions of the cube.
 
    * The ``maskpt`` parameter sets the percentage of the weight image values to

--- a/docs/jwst/outlier_detection/outlier_detection_imaging.rst
+++ b/docs/jwst/outlier_detection/outlier_detection_imaging.rst
@@ -107,7 +107,7 @@ Control over this memory model happens
 with the use of the ``in_memory`` parameter, which defaults to True.
 The full impact of setting this parameter to `False` includes:
 
-#. The input :py:class:`~jwst.datamodels.library.ModelLibrary` object is loaded with `on_disk=True`.
+#. The input :py:class:`~jwst.datamodels.library.ModelLibrary` object is loaded with ``on_disk=True``.
    This ensures that input models are loaded into memory one at at time,
    and saved to a temporary file when not in use; these read-write operations are handled internally by
    the :py:class:`~jwst.datamodels.library.ModelLibrary` object.

--- a/docs/jwst/outlier_detection/outlier_detection_tso.rst
+++ b/docs/jwst/outlier_detection/outlier_detection_tso.rst
@@ -8,9 +8,9 @@ series observations.
 
 Normal imaging data benefit from combining all integrations into a
 single image. TSO data's value, however, comes from looking for variations from one
-integration to the next.  The outlier detection algorithm, therefore, gets run with 
+integration to the next.  The outlier detection algorithm, therefore, gets run with
 a few variations to accommodate the nature of these 3D data.
-A :py:class:`~jwst.datamodels.CubeModel` object serves as the basic format for all
+A :py:class:`~stdatamodels.jwst.datamodels.CubeModel` object serves as the basic format for all
 processing performed by this step. This routine performs the following operations:
 
 #. Convert input data into a CubeModel (3D data array) if a ModelContainer
@@ -30,9 +30,9 @@ processing performed by this step. This routine performs the following operation
 #. If the ``save_intermediate_results`` parameter is set to True, write the rolling-median
    CubeModel to disk with the suffix ``_median.fits``.
 
-#. Perform a statistical comparison frame-by-frame between the rolling-median cube and 
+#. Perform a statistical comparison frame-by-frame between the rolling-median cube and
    the input data. The formula used is the same as for imaging data without resampling:
-   
+
    .. math:: | image\_input - image\_median | > SNR * input\_err
 
 #. Update DQ arrays with flags and set SCI, ERR, and variance arrays to NaN at the location

--- a/docs/jwst/pathloss/description.rst
+++ b/docs/jwst/pathloss/description.rst
@@ -1,7 +1,7 @@
 Description
 ===========
 
-:Class: `jwst.pathloss.PathlossStep`
+:Class: `jwst.pathloss.PathLossStep`
 :Alias: pathloss
 
 Overview
@@ -47,7 +47,7 @@ the 2-D space of the slit or IFU data and attached to the output data model
 (extensions "PATHLOSS_PS" and "PATHLOSS_UN") as a record of what was computed.
 For fixed slit data, if the ``wavecorr`` step has been run to provide wavelength
 corrections to point sources, the corrected wavelengths will be used to
-calculate the point source pathloss, whereas the uncorrected wavelengths (appropriate 
+calculate the point source pathloss, whereas the uncorrected wavelengths (appropriate
 for uniform sources) will be used to calculate the uniform source pathlosses.
 The form of the 2-D correction (point or uniform) that's appropriate for the
 data is divided into the SCI and ERR arrays and propagated into the variance
@@ -56,7 +56,7 @@ arrays of the science data.
 The MSA reference file contains 2 entries: one for a 1x1 slit and one for a 1x3 slit.
 Each entry contains the pathloss correction for point source and uniform sources.
 The former depends on the position of the target in the fiducial shutter and
-wavelength, whereas the latter depends on wavelength only.  The point source 
+wavelength, whereas the latter depends on wavelength only.  The point source
 entry consists of a 3-d array, where 2 of the dimensions map to the location
 of the source (ranging from -0.5 to 0.5 in both X and Y), while the third dimension
 carries the wavelength dependence.  The 1x3 shutter is 3 times as large in Y as in X.

--- a/docs/jwst/pipeline/calwebb_ami3.rst
+++ b/docs/jwst/pipeline/calwebb_ami3.rst
@@ -79,7 +79,7 @@ Outputs
 
 Interferometric observables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.AmiOIModel`
+:Data model: `~stdatamodels.jwst.datamodels.AmiOIModel`
 :File suffix: _ami-oi.fits
 
 For every input exposure, the interferometric observables calculated
@@ -91,7 +91,7 @@ included and the product type changed to "_ami-oi.fits", e.g.
 
 Normalized interferometric observables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.AmiOIModel`
+:Data model: `~stdatamodels.jwst.datamodels.AmiOIModel`
 :File suffix: _aminorm-oi.fits
 
 If reference PSF exposures are included in the input ASN, the AMI results
@@ -101,7 +101,6 @@ product file. This file has the same FITS table format as the "_ami-oi.fits" pro
 The file name root uses the source-based output product name given in the ASN file,
 e.g. "jw93210-a0003_t001_niriss_f480m-nrm_aminorm-oi.fits."
 
-.. note:: 
-   
-   Users may wish to run the :ref:`ami_analyze step <ami_analyze_step>` separately for access to flexible input arguments and to save additional diagnostic output products. See the step documentation for more details.
+.. note::
 
+   Users may wish to run the :ref:`ami_analyze step <ami_analyze_step>` separately for access to flexible input arguments and to save additional diagnostic output products. See the step documentation for more details.

--- a/docs/jwst/pipeline/calwebb_coron3.rst
+++ b/docs/jwst/pipeline/calwebb_coron3.rst
@@ -50,7 +50,7 @@ Inputs
 3D calibrated images
 ^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _calints
 
 The input to ``calwebb_coron3`` must be in the form of an ASN file that lists
@@ -94,7 +94,7 @@ Outputs
 CR-flagged images
 ^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _crfints
 
 If the :ref:`outlier_detection <outlier_detection_step>` step is applied, a new version of
@@ -106,7 +106,7 @@ product type suffix and include the association candidate ID, e.g.
 3D stacked PSF images
 ^^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _psfstack
 
 The data from each input PSF reference exposure are concatenated into a single
@@ -118,7 +118,7 @@ ASN file, e.g. "jw86073-a3001_t001_nircam_f140m-maskbar_psfstack.fits."
 3D aligned PSF images
 ^^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _psfalign
 
 All of the reference PSF images in the
@@ -134,7 +134,7 @@ target integration as was done in the pre-flight pipeline.
 3D PSF-subtracted images
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _psfsub
 
 For each science target exposure, the :ref:`klip <klip_step>` step applies PSF fitting and
@@ -146,7 +146,7 @@ product, using exposure-based file names, e.g.
 2D resampled image
 ^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.ImageModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`
 :File suffix: _i2d
 
 The :ref:`resample <resample_step>` step is applied to the CR-flagged products to create a

--- a/docs/jwst/pipeline/calwebb_dark.rst
+++ b/docs/jwst/pipeline/calwebb_dark.rst
@@ -36,7 +36,7 @@ pipeline, the order of steps is a bit different for MIRI exposures.
 |                                       | :ref:`rscd <rscd_step>`                 |
 +---------------------------------------+-----------------------------------------+
 
-.. [1] By default, the parameter reference `pars-darkpipeline`
+.. [1] By default, the parameter reference ``pars-darkpipeline``
    retrieved from CRDS will skip the :ref:`ipc <ipc_step>` step.
 
 Arguments
@@ -49,7 +49,7 @@ Inputs
 4D raw data
 +++++++++++
 
-:Data model: `~jwst.datamodels.RampModel`
+:Data model: `~stdatamodels.jwst.datamodels.RampModel`
 :File suffix: _uncal
 
 The input to ``DarkPipeline`` is a single raw dark exposure,
@@ -62,7 +62,7 @@ Outputs
 4D corrected ramp
 +++++++++++++++++
 
-:Data model: `~jwst.datamodels.RampModel`
+:Data model: `~stdatamodels.jwst.datamodels.RampModel`
 :File suffix: _dark
 
 Result of applying all pipeline steps listed above.

--- a/docs/jwst/pipeline/calwebb_detector1.rst
+++ b/docs/jwst/pipeline/calwebb_detector1.rst
@@ -7,7 +7,7 @@ calwebb_detector1: Stage 1 Detector Processing
 :Class: `jwst.pipeline.Detector1Pipeline`
 :Alias: calwebb_detector1
 
-The ``Detector1Pipeline`` applies basic detector-level corrections to all exposure
+The `~jwst.pipeline.Detector1Pipeline` applies basic detector-level corrections to all exposure
 types (imaging, spectroscopic, coronagraphic, etc.). It is applied to one
 exposure at a time.
 It is sometimes referred to as "ramps-to-slopes" processing, because the input raw data
@@ -22,7 +22,7 @@ Non-TSO exposures, all applicable steps are applied to the data. For TSO
 exposures, some steps are set to be skipped by default (see the list of steps in
 the table below).
 
-The list of steps applied by the ``Detector1Pipeline`` pipeline is shown in the
+The list of steps applied by the `~jwst.pipeline.Detector1Pipeline` pipeline is shown in the
 table below. Note that MIRI exposures use some instrument-specific steps and
 some of the steps are applied in a different order than for Near-IR (NIR)
 instrument exposures.
@@ -38,7 +38,7 @@ pixels that go into saturation already in the first group (see more details on
 that process in the :ref:`ramp_fitting <ramp_fitting_step>` step). In order for
 the frame zero image to be utilized during ramp fitting, it must have all of
 the same calibrations and corrections applied as the first group in the various
-``Detector1Pipeline`` steps. This includes the :ref:`saturation <saturation_step>`,
+`~jwst.pipeline.Detector1Pipeline` steps. This includes the :ref:`saturation <saturation_step>`,
 :ref:`superbias <superbias_step>`, :ref:`refpix <refpix_step>`, and
 :ref:`linearity <linearity_step>` steps. Other steps do not have a direct effect
 on either the first group or frame zero pixel values.
@@ -89,7 +89,7 @@ on either the first group or frame zero pixel values.
 .. [1] By default, this step is skipped in the ``calwebb_detector1`` pipeline
    for all instruments and modes.
 .. [2] The :ref:`persistence <persistence_step>` step is currently hardwired to be skipped in
-   the `Detector1Pipeline` module for all NIRSpec exposures.
+   the `~jwst.pipeline.Detector1Pipeline` module for all NIRSpec exposures.
 
 
 Arguments
@@ -114,19 +114,19 @@ Inputs
 4D raw data
 +++++++++++
 
-:Data model: `~jwst.datamodels.RampModel`
+:Data model: `~stdatamodels.jwst.datamodels.RampModel`
 :File suffix: _uncal
 
-The input to ``Detector1Pipeline`` is a single raw exposure,
+The input to `~jwst.pipeline.Detector1Pipeline` is a single raw exposure,
 e.g. "jw80600012001_02101_00003_mirimage_uncal.fits", which contains the
 original raw data from all of the detector readouts in the exposure
 (ncols x nrows x ngroups x nintegrations).
 
 Note that in the operational environment, the
-input will be in the form of a `~jwst.datamodels.Level1bModel`, which only
+input will be in the form of a `~stdatamodels.jwst.datamodels.Level1bModel`, which only
 contains the 4D array of detector pixel values, along with some optional
 extensions. When such a file is loaded into the pipeline, it is immediately
-converted into a `~jwst.datamodels.RampModel`, and has all additional data arrays
+converted into a `~stdatamodels.jwst.datamodels.RampModel`, and has all additional data arrays
 for Data Quality flags created and initialized to zero.
 
 The input can also contain a 3D cube of NIRCam "Frame 0" data, where
@@ -140,7 +140,7 @@ Outputs
 4D corrected ramp
 +++++++++++++++++
 
-:Data model: `~jwst.datamodels.RampModel`
+:Data model: `~stdatamodels.jwst.datamodels.RampModel`
 :File suffix: _ramp
 
 Result of applying all pipeline steps up through the :ref:`jump <jump_step>` step,
@@ -151,7 +151,7 @@ pipeline argument ``--save_calibrated_ramp`` is set to ``True`` (default is ``Fa
 2D countrate product
 ++++++++++++++++++++
 
-:Data model: `~jwst.datamodels.ImageModel` or `~jwst.datamodels.IFUImageModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel` or `~stdatamodels.jwst.datamodels.IFUImageModel`
 :File suffix: _rate
 
 All types of inputs result in a 2D countrate product,
@@ -160,12 +160,12 @@ The output file will be of type "_rate", e.g.
 "jw80600012001_02101_00003_mirimage_rate.fits". The 2D "_rate" product is passed along
 to subsequent pipeline modules for all non-TSO and non-Coronagraphic exposures.
 For MIRI MRS and NIRSpec IFU exposures, the output data model will be
-`~jwst.datamodels.IFUImageModel`, while all others will be `~jwst.datamodels.ImageModel`.
+`~stdatamodels.jwst.datamodels.IFUImageModel`, while all others will be `~stdatamodels.jwst.datamodels.ImageModel`.
 
 3D countrate product
 ++++++++++++++++++++
 
-:Data model: `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _rateints
 
 A 3D countrate product is created that contains the individual

--- a/docs/jwst/pipeline/calwebb_guider.rst
+++ b/docs/jwst/pipeline/calwebb_guider.rst
@@ -30,7 +30,7 @@ Inputs
 4D raw data
 ^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.GuiderRawModel`
+:Data model: `~stdatamodels.jwst.datamodels.GuiderRawModel`
 :File suffix: _uncal
 
 The input to ``calwebb_guider`` is a single raw guide-mode data file, which contains
@@ -44,13 +44,12 @@ Outputs
 3D calibrated data
 ^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.GuiderCalModel`
+:Data model: `~stdatamodels.jwst.datamodels.GuiderCalModel`
 :File suffix: _cal
 
 The output is a 3D (ncols x nrows x nints) countrate product that has been flat-fielded
 and has bad pixels flagged. For ID mode data, there is only 1
 countrate image produced by the :ref:`guider_cds <guider_cds_step>` step, therefore the
-length of the 3rd array axis is 1. For all other modes, there will be a stack of 
+length of the 3rd array axis is 1. For all other modes, there will be a stack of
 multiple countrate images, one per integration. See the :ref:`guider_cds <guider_cds_step>`
 step information for details on how the countrate images are produced for each mode.
-

--- a/docs/jwst/pipeline/calwebb_image2.rst
+++ b/docs/jwst/pipeline/calwebb_image2.rst
@@ -54,7 +54,7 @@ Inputs
 2D or 3D countrate data
 +++++++++++++++++++++++
 
-:Data model: `~jwst.datamodels.ImageModel` or `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel` or `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _rate or _rateints
 
 The input to ``Image2Pipeline`` is
@@ -74,7 +74,7 @@ Outputs
 2D or 3D background-subtracted data
 +++++++++++++++++++++++++++++++++++
 
-:Data model: `~jwst.datamodels.ImageModel` or `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel` or `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _bsub or _bsubints
 
 This is an intermediate product that will contain the data as output from the
@@ -86,7 +86,7 @@ saved as "_bsubints."
 2D or 3D calibrated data
 ++++++++++++++++++++++++
 
-:Data model: `~jwst.datamodels.ImageModel` or `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel` or `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _cal or _calints
 
 The output is a fully calibrated, but unrectified, exposure, using
@@ -96,7 +96,7 @@ input, e.g. "jw80600012001_02101_00003_mirimage_cal.fits".
 2D resampled image
 ++++++++++++++++++
 
-:Data model: `~jwst.datamodels.ImageModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`
 :File suffix: _i2d
 
 This is the output of the :ref:`resample <resample_step>` step and is only created

--- a/docs/jwst/pipeline/calwebb_image3.rst
+++ b/docs/jwst/pipeline/calwebb_image3.rst
@@ -6,7 +6,7 @@ calwebb_image3: Stage 3 Imaging Processing
 :Class: `jwst.pipeline.Image3Pipeline`
 :Alias: calwebb_image3
 
-Stage 3 processing for direct-imaging observations is intended for combining the 
+Stage 3 processing for direct-imaging observations is intended for combining the
 calibrated data from multiple exposures (e.g. a dither or mosaic pattern) into a
 single rectified (distortion corrected) product.
 Before being combined, the exposures receive additional corrections for the
@@ -35,7 +35,7 @@ Arguments
 ---------
 
 ``--in_memory``
-  Boolean governing whether to load all models in the input association to memory at once (faster) 
+  Boolean governing whether to load all models in the input association to memory at once (faster)
   or to save to temporary files when not in use (slower, less memory usage). Default is True.
 
 Inputs
@@ -44,7 +44,7 @@ Inputs
 2D calibrated images
 ^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.ImageModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`
 :File suffix: _cal
 
 The inputs to the ``calwebb_image3`` pipeline are one or more
@@ -61,7 +61,7 @@ Outputs
 CR-flagged exposures
 ^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.ImageModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`
 :File suffix: _crf
 
 If the :ref:`outlier_detection <outlier_detection_step>` step is applied, a new version
@@ -74,7 +74,7 @@ new field in the original product root name, e.g.
 Resampled and combined 2D image
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.ImageModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`
 :File suffix: _i2d
 
 A resampled 2D image product of type "_i2d" is created containing the
@@ -94,7 +94,7 @@ of "_cat."
 Segmentation map
 ^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.ImageModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`
 :File suffix: _segm
 
 A 2D image segmentation map produced by the :ref:`source_catalog <source_catalog_step>`

--- a/docs/jwst/pipeline/calwebb_spec2.rst
+++ b/docs/jwst/pipeline/calwebb_spec2.rst
@@ -298,13 +298,13 @@ Inputs
 2D or 3D countrate data
 +++++++++++++++++++++++
 
-:Data model: `~jwst.datamodels.ImageModel`, `~jwst.datamodels.IFUImageModel`,
-             or `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`, `~stdatamodels.jwst.datamodels.IFUImageModel`,
+             or `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _rate or _rateints
 
 The input to the ``Spec2Pipeline`` pipeline is a countrate exposure, in the form
-of either "_rate" or "_rateints" data. A single input FITS file can be processed 
-or an ASN file can be used, as long as there is only one output product specified 
+of either "_rate" or "_rateints" data. A single input FITS file can be processed
+or an ASN file can be used, as long as there is only one output product specified
 in the association.
 
 If "_rateints" products are used as input, for modes other than NIRSpec Fixed Slit,
@@ -324,7 +324,7 @@ Background subtraction for Wide-Field Slitless Spectroscopy (WFSS) exposures,
 on the other hand, is accomplished by scaling and subtracting a master background
 image contained in a CRDS reference file and hence does not require an ASN as input.
 
-The input data model type `~jwst.datamodels.IFUImageModel` is only used for MIRI MRS
+The input data model type `~stdatamodels.jwst.datamodels.IFUImageModel` is only used for MIRI MRS
 and NIRSpec IFU exposures.
 
 Outputs
@@ -333,8 +333,8 @@ Outputs
 2D or 3D background-subtracted data
 +++++++++++++++++++++++++++++++++++
 
-:Data model: `~jwst.datamodels.ImageModel`, `~jwst.datamodels.IFUImageModel`,
-              or `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`, `~stdatamodels.jwst.datamodels.IFUImageModel`,
+              or `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _bsub or _bsubints
 
 This is an intermediate product that will contain the data as output from the
@@ -346,9 +346,9 @@ If the input is a "_rate" product, this will be a "_bsub" product, while
 2D or 3D calibrated data
 ++++++++++++++++++++++++
 
-:Data model: `~jwst.datamodels.ImageModel`, `~jwst.datamodels.IFUImageModel`,
-             `~jwst.datamodels.CubeModel`,
-             `~jwst.datamodels.SlitModel`, or `~jwst.datamodels.MultiSlitModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`, `~stdatamodels.jwst.datamodels.IFUImageModel`,
+             `~stdatamodels.jwst.datamodels.CubeModel`,
+             `~stdatamodels.jwst.datamodels.SlitModel`, or `~stdatamodels.jwst.datamodels.MultiSlitModel`
 :File suffix: _cal or _calints
 
 The output is a fully calibrated, but unrectified, exposure, using the product
@@ -361,25 +361,25 @@ either :ref:`resample_spec <resample_spec_step>`, :ref:`cube_build <cube_build_s
 The output data model type can be any of the 4 listed above and is completely
 dependent on the type of input data and the observing mode. For data sets that
 do **not** go through :ref:`extract_2d <extract_2d_step>` processing, the output will be
-either a `~jwst.datamodels.ImageModel`, `~jwst.datamodels.IFUImageModel`, or
-`~jwst.datamodels.CubeModel`, matching the corresponding input data type.
+either a `~stdatamodels.jwst.datamodels.ImageModel`, `~stdatamodels.jwst.datamodels.IFUImageModel`, or
+`~stdatamodels.jwst.datamodels.CubeModel`, matching the corresponding input data type.
 
 Of the data types that do go through :ref:`extract_2d <extract_2d_step>` processing,
 the output type will consist of either a single slit model or a multi-slit model:
 
-- NIRSpec Bright-Object and NIRCam TSO Grism: `~jwst.datamodels.SlitModel`
-- NIRSpec Fixed Slit and MOS, as well as WFSS: `~jwst.datamodels.MultiSlitModel`
+- NIRSpec Bright-Object and NIRCam TSO Grism: `~stdatamodels.jwst.datamodels.SlitModel`
+- NIRSpec Fixed Slit and MOS, as well as WFSS: `~stdatamodels.jwst.datamodels.MultiSlitModel`
 
 The multi-slit model is simply an array of multiple slit models, each one
 containing the data and relevant meta data for a particular extracted slit or
-source. A `~jwst.datamodels.MultiSlitModel` product will contain multiple
+source. A `~stdatamodels.jwst.datamodels.MultiSlitModel` product will contain multiple
 tuples of SCI, ERR, DQ, WAVELENGTH, etc. arrays; one for each of the
 extracted slits/sources.
 
 2D resampled data
 +++++++++++++++++
 
-:Data model: `~jwst.datamodels.SlitModel` or `~jwst.datamodels.MultiSlitModel`
+:Data model: `~stdatamodels.jwst.datamodels.SlitModel` or `~stdatamodels.jwst.datamodels.MultiSlitModel`
 :File suffix: _s2d
 
 If the input is a 2D exposure type that gets resampled/rectified by the
@@ -388,15 +388,15 @@ is saved as a "_s2d" file. This image is intended for use as a quick-look produc
 and is not used in subsequent processing. The 2D unresampled, calibrated ("_cal")
 products are passed along as input to subsequent Stage 3 processing.
 
-If the input to the :ref:`resample_spec <resample_spec_step>` step is a `~jwst.datamodels.MultiSlitModel`,
+If the input to the :ref:`resample_spec <resample_spec_step>` step is a `~stdatamodels.jwst.datamodels.MultiSlitModel`,
 then the resampled output will be in the form of a
-`~jwst.datamodels.MultiSlitModel`, which contains an array of individual models,
-one per slit. Otherwise the output will be a single `~jwst.datamodels.SlitModel`.
+`~stdatamodels.jwst.datamodels.MultiSlitModel`, which contains an array of individual models,
+one per slit. Otherwise the output will be a single `~stdatamodels.jwst.datamodels.SlitModel`.
 
 3D resampled (IFU cube) data
 ++++++++++++++++++++++++++++
 
-:Data model: `~jwst.datamodels.IFUCubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.IFUCubeModel`
 :File suffix: _s3d
 
 If the data are NIRSpec IFU or MIRI MRS, the result of the :ref:`cube_build <cube_build_step>`
@@ -408,7 +408,7 @@ input to subsequent Stage 3 processing.
 1D extracted spectral data
 ++++++++++++++++++++++++++
 
-:Data model: `~jwst.datamodels.MultiSpecModel`
+:Data model: `~stdatamodels.jwst.datamodels.MultiSpecModel`
 :File suffix: _x1d or _x1dints
 
 All types of inputs result in a 1D extracted spectral data product, which is saved

--- a/docs/jwst/pipeline/calwebb_spec3.rst
+++ b/docs/jwst/pipeline/calwebb_spec3.rst
@@ -91,8 +91,8 @@ Inputs
 2D calibrated data
 ^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.ImageModel`, `~jwst.datamodels.IFUImageModel`,
-             `~jwst.datamodels.SlitModel`, or `~jwst.datamodels.MultiSlitModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`, `~stdatamodels.jwst.datamodels.IFUImageModel`,
+             `~stdatamodels.jwst.datamodels.SlitModel`, or `~stdatamodels.jwst.datamodels.MultiSlitModel`
 :File suffix: _cal
 
 The inputs to ``calwebb_spec3`` should be in the form of an ASN file that
@@ -116,7 +116,7 @@ Outputs
 Source-based calibrated data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.MultiExposureModel`
+:Data model: `~stdatamodels.jwst.datamodels.MultiExposureModel`
 :File suffix: _cal
 
 For NIRSpec fixed-slit and NIRSpec MOS, which have a defined
@@ -141,7 +141,7 @@ all the data for one source at a time.
 CR-flagged exposures
 ^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.ImageModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`
 :File suffix: _crf
 
 If the :ref:`outlier_detection <outlier_detection_step>` step is applied, a new version of
@@ -155,7 +155,7 @@ new field in the original product root name, e.g.
 2D resampled and combined spectral data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.SlitModel`
+:Data model: `~stdatamodels.jwst.datamodels.SlitModel`
 :File suffix: _s2d
 
 When processing non-IFU modes, a resampled/rectified 2D product of type
@@ -166,7 +166,7 @@ step.
 3D resampled and combined spectral data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.IFUCubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.IFUCubeModel`
 :File suffix: _s3d
 
 When processing IFU exposures, a resampled and combined 3D IFU cube product
@@ -175,7 +175,7 @@ created by the :ref:`cube_build <cube_build_step>` step is saved as an "_s3d" fi
 1D extracted spectral data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.MultiSpecModel`
+:Data model: `~stdatamodels.jwst.datamodels.MultiSpecModel`
 :File suffix: _x1d
 
 All types of inputs result in a 1D extracted spectral data product, which is
@@ -190,7 +190,7 @@ Those spectra are combined using the subsequent
 
 For NIRCam and NIRISS WFSS, the output ``_x1d`` product
 holds the spectra from all the sources in a single product. The data model is
-`~jwst.datamodels.WFSSMultiSpecModel`, and has one extension per
+`~stdatamodels.jwst.datamodels.WFSSMultiSpecModel`, and has one extension per
 exposure per spectral order, with each extension containing a binary table of all the spectra
 (and associated metadata) for all sources extracted from that exposure and spectral order.
 See :ref:`extract_1d <extract_1d_step>` for more details.
@@ -198,7 +198,7 @@ See :ref:`extract_1d <extract_1d_step>` for more details.
 1D combined spectral data
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.CombinedSpecModel`
+:Data model: `~stdatamodels.jwst.datamodels.CombinedSpecModel`
 :File suffix: _c1d
 
 For NIRCam and NIRISS WFSS, as well as NIRISS SOSS data, the
@@ -207,7 +207,7 @@ given source into a final spectrum, which is saved in a "_c1d" product.
 
 For NIRCam and NIRISS WFSS, the output ``_c1d`` product holds the spectra
 from all the sources in a single product. The data model is
-`~jwst.datamodels.WFSSMultiCombinedSpecModel`, and has a single
+`~stdatamodels.jwst.datamodels.WFSSMultiCombinedSpecModel`, and has a single
 binary table per spectral order containing the exposure-combined spectra for all sources
 extracted from that exposure. The data type is similar to that of the
 ``_x1d`` product, but with just one data extension per extracted spectral order

--- a/docs/jwst/pipeline/calwebb_tso3.rst
+++ b/docs/jwst/pipeline/calwebb_tso3.rst
@@ -44,7 +44,7 @@ Inputs
 3D calibrated images
 ^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _calints
 
 The input to ``calwebb_tso3`` is in the form of an ASN file that lists multiple
@@ -70,7 +70,7 @@ Outputs
 3D CR-flagged images
 ^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _crfints
 
 If the :ref:`outlier_detection <outlier_detection_step>` step is applied, a new version
@@ -92,7 +92,7 @@ source-based, using the output product name specified in the ASN file, e.g.
 
 1D extracted spectral data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.MultiSpecModel`
+:Data model: `~stdatamodels.jwst.datamodels.MultiSpecModel`
 :File suffix: _x1dints
 
 For spectroscopic TS observations, the :ref:`extract_1d <extract_1d_step>` step is applied to

--- a/docs/jwst/pipeline/calwebb_wfs-image2.rst
+++ b/docs/jwst/pipeline/calwebb_wfs-image2.rst
@@ -4,7 +4,7 @@ calwebb_wfs-image2: Stage 2 WFS&C Processing
 ============================================
 
 :Deprecated post-1.1.0:
-   
+
    The operation of the pipeline is no longer dependent on built-in configuration files.
    How `jwst.pipeline.Image2Pipeline` processes WFS&C data is determined by the CRDS
    reftype ``pars-image2pipeline``. The version of ``calwebb_wfs-image2.cfg`` delivered with
@@ -46,10 +46,10 @@ Inputs
 2D countrate data
 ^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.ImageModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`
 :File suffix: _rate
 
-The input to ``Image2Pipeline`` is a countrate exposure, in the form of "_rate" 
+The input to ``Image2Pipeline`` is a countrate exposure, in the form of "_rate"
 data. A single input file can be processed or an ASN file listing
 multiple inputs can be used, in which case the processing steps will be
 applied to each input exposure, one at a time.
@@ -60,7 +60,7 @@ Outputs
 2D calibrated data
 ^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.ImageModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`
 :File suffix: _cal
 
 The output is a fully calibrated, but unrectified, exposure, using

--- a/docs/jwst/pipeline/calwebb_wfs-image3.rst
+++ b/docs/jwst/pipeline/calwebb_wfs-image3.rst
@@ -29,7 +29,7 @@ Inputs
 2D calibrated images
 ^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.ImageModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`
 :File suffix: _cal
 
 The input to ``calwebb_wfs-image3`` is a pair of calibrated ("_cal") exposures, specified
@@ -41,7 +41,7 @@ Outputs
 2D combined image
 ^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.ImageModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`
 :File suffix: _wfscmb
 
 The output is a combined image, using the product type suffix "_wfscmb."

--- a/docs/jwst/references_general/abvegaoffset_reffile.inc
+++ b/docs/jwst/references_general/abvegaoffset_reffile.inc
@@ -4,7 +4,7 @@ ABVEGAOFFSET Reference File
 ---------------------------
 
 :REFTYPE: ABVEGAOFFSET
-:Data model: `~jwst.datamodels.ABVegaOffsetModel`
+:Data model: `~stdatamodels.jwst.datamodels.ABVegaOffsetModel`
 
 The ABVEGAOFFSET reference file contains data necessary for converting
 from AB to Vega magnitudes.

--- a/docs/jwst/references_general/area_reffile.inc
+++ b/docs/jwst/references_general/area_reffile.inc
@@ -40,7 +40,7 @@ The FITS primary HDU does not contain a data array.
 Imaging Modes
 ^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.PixelAreaModel`
+:Data model: `~stdatamodels.jwst.datamodels.PixelAreaModel`
 
 The format of imaging mode AREA reference files is as follows:
 
@@ -61,7 +61,7 @@ reference file.
 NIRSpec Fixed-Slit Mode
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.NirspecSlitAreaModel`
+:Data model: `~stdatamodels.jwst.datamodels.NirspecSlitAreaModel`
 
 The BINTABLE extension has EXTNAME='AREA' and has column characteristics
 shown below. There is one row for each of the 5 fixed slits, with ``slit_id``
@@ -70,7 +70,7 @@ area values are in units of square arcseconds and represent the nominal
 area of any pixel illuminated by the slit.
 
 ===========  =========
-Column name  Data type 
+Column name  Data type
 ===========  =========
 slit_id      char\*15
 pixarea      float
@@ -79,7 +79,7 @@ pixarea      float
 NIRSpec MOS Mode
 ^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.NirspecMosAreaModel`
+:Data model: `~stdatamodels.jwst.datamodels.NirspecMosAreaModel`
 
 The BINTABLE extension has EXTNAME='AREA' and has column characteristics
 shown below. There is one row for each shutter in each MSA quadrant. The
@@ -88,7 +88,7 @@ units of square arcseconds and represent the nominal area of any pixel
 illuminated by a given MSA shutter.
 
 ===========  =========
-Column name  Data type 
+Column name  Data type
 ===========  =========
 quadrant     integer
 shutter_x    integer
@@ -99,7 +99,7 @@ pixarea      float
 NIRSpec IFU Mode
 ^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.NirspecIfuAreaModel`
+:Data model: `~stdatamodels.jwst.datamodels.NirspecIfuAreaModel`
 
 The BINTABLE extension has EXTNAME='AREA' and has column characteristics
 shown below. There is one row for each of the 30 IFU slices, with the
@@ -108,9 +108,8 @@ area values are in units of square arcseconds and represent the nominal
 area of any pixel illuminated by a given IFU slice.
 
 ===========  =========
-Column name  Data type 
+Column name  Data type
 ===========  =========
 slice_id     integer
 pixarea      float
 ===========  =========
-

--- a/docs/jwst/references_general/barshadow_reffile.inc
+++ b/docs/jwst/references_general/barshadow_reffile.inc
@@ -4,7 +4,7 @@ BARSHADOW Reference File
 ------------------------
 
 :REFTYPE: BARSHADOW
-:Data model: `~jwst.datamodels.BarshadowModel`
+:Data model: `~stdatamodels.jwst.datamodels.BarshadowModel`
 
 .. include:: ../references_general/barshadow_selection.inc
 
@@ -50,26 +50,25 @@ and wavelength.  The initial version of the reference file has Y varying from
 An example extension header is as follows:
 
 ======== = ==================== = ==========================
-XTENSION = 'IMAGE   '           / Image extension           
-BITPIX   =                  -64 / array data type           
+XTENSION = 'IMAGE   '           / Image extension
+BITPIX   =                  -64 / array data type
 NAXIS    =                    2 / number of array dimensions
-NAXIS1   =                  101                             
-NAXIS2   =                 1001                             
-PCOUNT   =                    0 / number of parameters      
-GCOUNT   =                    1 / number of groups          
-EXTNAME  = 'DATA1x1 '           / extension name            
-BSCALE   =                  1.0                             
-BZERO    =                  0.0                             
-BUNIT    = 'UNITLESS'                                       
-CTYPE1   = 'METER   '                                       
-CTYPE2   = 'UNITLESS'                                       
-CDELT1   =              4.7E-08                             
-CDELT2   =                0.002                             
-CRPIX1   =                  1.0                             
-CRPIX2   =                  1.0                             
-CRVAL1   =                6E-07                             
-CRVAL2   =                 -1.0                             
-APERTURE = 'MOS1x1  '                                       
-HEIGHT   =           0.00020161                             
+NAXIS1   =                  101
+NAXIS2   =                 1001
+PCOUNT   =                    0 / number of parameters
+GCOUNT   =                    1 / number of groups
+EXTNAME  = 'DATA1x1 '           / extension name
+BSCALE   =                  1.0
+BZERO    =                  0.0
+BUNIT    = 'UNITLESS'
+CTYPE1   = 'METER   '
+CTYPE2   = 'UNITLESS'
+CDELT1   =              4.7E-08
+CDELT2   =                0.002
+CRPIX1   =                  1.0
+CRPIX2   =                  1.0
+CRVAL1   =                6E-07
+CRVAL2   =                 -1.0
+APERTURE = 'MOS1x1  '
+HEIGHT   =           0.00020161
 ======== = ==================== = ==========================
-

--- a/docs/jwst/references_general/bkg_reffile.inc
+++ b/docs/jwst/references_general/bkg_reffile.inc
@@ -33,7 +33,7 @@ Reference File Format
 BKG reference files are in FITS format. The content of the background references differ
 based on exposure type:
 
-:Data model: `~jwst.datamodels.WfssBkgModel`
+:Data model: `~stdatamodels.jwst.datamodels.WfssBkgModel`
 
 Wide-field slitless spectroscopy (WFSS) background files contain 3 IMAGE extensions and
 1 BINTABLE extension. The FITS primary HDU does not contain a data array.
@@ -50,7 +50,7 @@ DQ_DEF   BINTABLE    2    TFIELDS = 4     N/A
 
 .. include:: ../includes/dq_def.inc
 
-:Data model: `~jwst.datamodels.SossBkgModel`
+:Data model: `~stdatamodels.jwst.datamodels.SossBkgModel`
 
 Background reference files supporting NIRISS SOSS exposures contain three
 image extensions, each with three dimensions. The extensions contain templates

--- a/docs/jwst/references_general/camera_reffile.rst
+++ b/docs/jwst/references_general/camera_reffile.rst
@@ -6,7 +6,7 @@ CAMERA Reference File (NIRSpec only)
 ------------------------------------
 
 :REFTYPE: CAMERA
-:Data model: `~jwst.datamodels.CameraModel`
+:Data model: `~stdatamodels.jwst.datamodels.CameraModel`
 
 Reference Selection Keywords for CAMERA
 +++++++++++++++++++++++++++++++++++++++
@@ -27,4 +27,3 @@ Reference File Format
 The camera reference file contains an astropy compound model made up of polynomial models, rotations, and translations. The forward direction is from the FPA to the GWA.
 
 :model: Transform through the CAMERA.
-

--- a/docs/jwst/references_general/collimator_reffile.rst
+++ b/docs/jwst/references_general/collimator_reffile.rst
@@ -6,7 +6,7 @@ COLLIMATOR Reference File (NIRSpec only)
 ----------------------------------------
 
 :REFTYPE: COLLIMATOR
-:Data model: `~jwst.datamodels.CollimatorModel`
+:Data model: `~stdatamodels.jwst.datamodels.CollimatorModel`
 
 Reference Selection Keywords for COLLIMATOR
 +++++++++++++++++++++++++++++++++++++++++++

--- a/docs/jwst/references_general/cubepar_reffile.inc
+++ b/docs/jwst/references_general/cubepar_reffile.inc
@@ -4,7 +4,7 @@ CUBEPAR reference file
 ----------------------
 
 :REFTYPE: CUBEPAR
-:Data models: `~jwst.datamodels.MiriIFUCubeParsModel`, `~jwst.datamodels.NirspecIFUCubeParsModel`
+:Data models: `~stdatamodels.jwst.datamodels.MiriIFUCubeParsModel`, `~stdatamodels.jwst.datamodels.NirspecIFUCubeParsModel`
 
 The CUBEPAR reference file contains parameter values used to construct
 the output IFU cubes.
@@ -30,18 +30,18 @@ MIRI Reference File Format
 ++++++++++++++++++++++++++
 The MIRI CUBEPAR reference files are FITS format, with  5  BINTABLE extensions.
 The FITS primary data array is assumed to be empty.
-The format and content of the MIRI CUBEPAR reference file 
+The format and content of the MIRI CUBEPAR reference file
 
-===================  ========  ===========  
-EXTNAME              XTENSION  Dimensions   
-===================  ========  ===========  
-CUBEPAR              BINTABLE  TFIELDS = 6  
-CUBEPAR_MSM          BINTABLE  TFIELDS = 6  
-MULTICHANNEL_MSM     BINTABLE  TFIELDS = 5  
-CUBEPAR_EMSM         BINTABLE  TFIELDS = 5  
+===================  ========  ===========
+EXTNAME              XTENSION  Dimensions
+===================  ========  ===========
+CUBEPAR              BINTABLE  TFIELDS = 6
+CUBEPAR_MSM          BINTABLE  TFIELDS = 6
+MULTICHANNEL_MSM     BINTABLE  TFIELDS = 5
+CUBEPAR_EMSM         BINTABLE  TFIELDS = 5
 MULTICHANNEL_EMSM    BINTABLE  TFIELDS = 4
 MULTICHANNEL_DRIZ    BINTABLE  TFIELDS = 1
-===================  ========  ===========  
+===================  ========  ===========
 
 
 NIRSPec Reference File Format
@@ -49,7 +49,7 @@ NIRSPec Reference File Format
 The NIRSpec CUBEPAR reference files are FITS format, with 9  BINTABLE extensions.
 
 ====================  ========  ===========
-EXTNAME               XTENSION  Dimensions 
+EXTNAME               XTENSION  Dimensions
 ====================  ========  ===========
 CUBEPAR               BINTABLE  TFIELDS = 6
 CUBEPAR_MSM           BINTABLE  TFIELDS = 6
@@ -69,11 +69,11 @@ first for the MIRI  reference file and then for NIRSpec.
 
 These reference files contain tables for each wavelength band giving the spatial
 and spectral size, and the size of the region of interest (ROI) to use to
-construct an IFU cube.  If only one band is used to construct the IFU cube then the *CUBEPAR* and *CUBEPAR_MSM* or *CUBE_EMSM* tables are used. These types of cubes will have a linear - wavelength dimension.  
+construct an IFU cube.  If only one band is used to construct the IFU cube then the *CUBEPAR* and *CUBEPAR_MSM* or *CUBE_EMSM* tables are used. These types of cubes will have a linear - wavelength dimension.
 If more than one wavelength band is used to build the IFU cube then the MULTICHANNEL (MIRI)
 or MULTICHAN (NIRSPEC) tables are used o set the spectral and spatial roi size, and the wavelength dependent weighting function parameters.
 For multi-band IFU cubes  then the final
-spatial size will be the smallest one from the list of input bands and these cubes will have a non-linear wavelength dimension. 
+spatial size will be the smallest one from the list of input bands and these cubes will have a non-linear wavelength dimension.
 
 
 The MIRI reference table descriptions:
@@ -105,4 +105,3 @@ The NIRSPEC reference table descriptions:
 - **MULTICHAN_MED_EMSM** table is used for the EMSM weighting and  contains the wavelengths and associated region of interest size to use when IFU cubes are created from the medium resolution grating and the final IFU Cube output has a varying spectral scale.
 
 - **MULTICHAN_HIGH_EMSM** table is used for the EMSM weighting and  contains the wavelengths and associated region of interest size to use when IFU cubes are created from the high resolution gratings and the final IFU Cube output has a varying spectral scale.
-

--- a/docs/jwst/references_general/dark_reffile.inc
+++ b/docs/jwst/references_general/dark_reffile.inc
@@ -4,7 +4,7 @@ DARK Reference File
 -------------------
 
 :REFTYPE: DARK
-:Data models: `~jwst.datamodels.DarkModel`, `~jwst.datamodels.DarkMIRIModel`
+:Data models: `~stdatamodels.jwst.datamodels.DarkModel`, `~stdatamodels.jwst.datamodels.DarkMIRIModel`
 
 The DARK reference file contains pixel-by-pixel and frame-by-frame
 dark current values for a given detector readout mode.
@@ -14,7 +14,7 @@ dark current values for a given detector readout mode.
 .. include:: ../includes/standard_keywords.inc
 
 .. include:: ../references_general/dark_specific.inc
-             
+
 Reference File Format
 +++++++++++++++++++++
 DARK reference files are FITS format, with 3 IMAGE extensions
@@ -25,7 +25,7 @@ near-IR instruments, as shown below.
 Near-IR Detectors
 ~~~~~~~~~~~~~~~~~
 Characteristics of the three IMAGE extensions for DARK files used with
-the Near-IR instruments are as follows (see `~jwst.datamodels.DarkModel`):
+the Near-IR instruments are as follows (see `~stdatamodels.jwst.datamodels.DarkModel`):
 
 =======  =====  =======================  =========
 EXTNAME  NAXIS  Dimensions               Data type
@@ -37,14 +37,14 @@ DQ_DEF   2      TFIELDS = 4              N/A
 
 MIRI Detectors
 ~~~~~~~~~~~~~~
-The DARK reference files for the MIRI detectors depend on the integration number,  
+The DARK reference files for the MIRI detectors depend on the integration number,
 because the first integration of MIRI exposures contains effects from the detector
 reset and are slightly different from subsequent integrations. Currently the MIRI
 DARK reference files contain a correction for only two integrations: the first
 integration of the DARK is subtracted from the first integration of the science data,
 while the second DARK integration is subtracted from all subsequent science integrations.
 The format of the MIRI DARK reference files is as follows
-(see `~jwst.datamodels.DarkMIRIModel`):
+(see `~stdatamodels.jwst.datamodels.DarkMIRIModel`):
 
 =======  =====  ===============================  =========
 EXTNAME  NAXIS  Dimensions                       Data type

--- a/docs/jwst/references_general/dflat_reffile.inc
+++ b/docs/jwst/references_general/dflat_reffile.inc
@@ -4,7 +4,7 @@ DFLAT Reference File
 --------------------
 
 :REFTYPE: DFLAT
-:Data model: `~jwst.datamodels.NirspecFlatModel`
+:Data model: `~stdatamodels.jwst.datamodels.NirspecFlatModel`
 
 .. include:: ../references_general/dflat_selection.inc
 
@@ -45,4 +45,3 @@ The flat field values in this table are used to account for a wavelength-depende
 much finer scale than given by the values in the SCI array.  There is a single row in
 this table, which contains 1-D arrays of wavelength and flat-field values.
 The same wavelength-dependent value is applied to all pixels in a quadrant.
-

--- a/docs/jwst/references_general/disperser_reffile.rst
+++ b/docs/jwst/references_general/disperser_reffile.rst
@@ -6,7 +6,7 @@ DISPERSER Reference File (NIRSpec only)
 ---------------------------------------
 
 :REFTYPE: DISPERSER
-:Data model: `~jwst.datamodels.DisperserModel`
+:Data model: `~stdatamodels.jwst.datamodels.DisperserModel`
 
 Reference Selection Keywords for DISPERSER
 ++++++++++++++++++++++++++++++++++++++++++
@@ -56,4 +56,3 @@ The prism reference file has in addition the following fields:
 :tref: Temperature (in K), used to compute the change in temperature relative to the reference temperature of the glass
 :pref: Reference pressure (in ATM)
 :wbound: Min and Max wavelength (in meters) for which the model is valid
-

--- a/docs/jwst/references_general/distortion_reffile.rst
+++ b/docs/jwst/references_general/distortion_reffile.rst
@@ -6,7 +6,7 @@ DISTORTION Reference File
 -------------------------
 
 :REFTYPE: DISTORTION
-:Data model: `~jwst.datamodels.DistortionModel`, `~jwst.datamodels.DistortionMRSModel`
+:Data model: `~stdatamodels.jwst.datamodels.DistortionModel`, `~stdatamodels.jwst.datamodels.DistortionMRSModel`
 
 Reference Selection Keywords for DISTORTION
 +++++++++++++++++++++++++++++++++++++++++++

--- a/docs/jwst/references_general/emi_reffile.inc
+++ b/docs/jwst/references_general/emi_reffile.inc
@@ -4,7 +4,7 @@ EMICORR Reference File
 ----------------------
 
 :REFTYPE: EMICORR
-:Data model: `~jwst.datamodels.EmiModel`
+:Data model: `~stdatamodels.jwst.datamodels.EmiModel`
 
 The EMICORR reference file contains data necessary for removing
 noise from contaminating EMI frequencies in MIRI ramp data.

--- a/docs/jwst/references_general/extract1d_reffile.inc
+++ b/docs/jwst/references_general/extract1d_reffile.inc
@@ -4,7 +4,7 @@ EXTRACT1D Reference File
 ------------------------
 The EXTRACT1D reference file contains information needed to guide
 the 1D extraction process. It is a text file, with the information
-in JSON format for Non-IFU data and in ASDF format for IFU data. 
+in JSON format for Non-IFU data and in ASDF format for IFU data.
 
 .. include:: ../references_general/extract1d_selection.inc
 
@@ -91,7 +91,7 @@ and use this modified file in ``extract_1d`` by specifying this modified referen
 (:ref:`override in python <override_ref_python>` or :ref:`override in strun <override_ref_strun>`). The format for
 JSON files has to be exact, for example, the format of a floating-point value with a fractional portion must include
 at least one decimal digit, so "1." is invalid, while "1.0" is valid. The best practice after editing a JSON reference
-file is to run a JSON validator off-line, such as `https://jsonlint.com/`, and correct any format errors before using
+file is to run a JSON validator off-line, such as https://jsonlint.com/, and correct any format errors before using
 the JSON reference file in the pipeline.
 
 
@@ -100,14 +100,14 @@ Reference File Format IFU data
 For IFU data the reference files are stored as ASDF files. The extraction size
 varies with wavelength. The reference file contains a set of vectors defining
 the extraction size based on wavelength. These vectors are all the same size and
-are defined as follows: 
+are defined as follows:
 
-* wavelength: wavelength in microns. 
+* wavelength: wavelength in microns.
 * radius: the radius of the circular extraction aperture (arcseconds, float)
 * inner_bkg: of the inner edge of the background annulus (arcseconds, float)
 * outer_bkg: of the outer edge of the background annulus (arcseconds, float)
 
-  
+
 In addition following general keys are also in the ASDF reference file:
 
 * subtract_background: if true, subtract a background determined from an

--- a/docs/jwst/references_general/fflat_reffile.inc
+++ b/docs/jwst/references_general/fflat_reffile.inc
@@ -12,10 +12,10 @@ For each type the primary HDU does not contain a data array.
 
 *Fixed Slit*
 ++++++++++++
-:Data model: `~jwst.datamodels.NirspecFlatModel`
+:Data model: `~stdatamodels.jwst.datamodels.NirspecFlatModel`
 
 The fixed slit FFLAT files have EXP_TYPE=NRS_FIXEDSLIT, and have a single BINTABLE
-extension, labeled FAST_VARIATION. 
+extension, labeled FAST_VARIATION.
 
 The table contains four columns:
 
@@ -29,7 +29,7 @@ separate slit.
 
 *MSA Spec*
 ++++++++++++
-:Data model: `~jwst.datamodels.NirspecQuadFlatModel`
+:Data model: `~stdatamodels.jwst.datamodels.NirspecQuadFlatModel`
 
 The MSA Spec FFLAT files have EXP_TYPE=NRS_MSASPEC, and contain data pertaining
 to each of the 4 quadrants.  For each quadrant, there is a set of 5 extensions -
@@ -79,10 +79,10 @@ The same wavelength-dependent value is applied to all pixels in a quadrant.
 
 *IFU*
 +++++
-:Data model: `~jwst.datamodels.NirspecFlatModel`
+:Data model: `~stdatamodels.jwst.datamodels.NirspecFlatModel`
 
 The IFU FFLAT files have EXP_TYPE=NRS_IFU.  These have one extension,
-a BINTABLE extension labeled FAST_VARIATION. 
+a BINTABLE extension labeled FAST_VARIATION.
 
 The FAST_VARIATION table contains four columns:
 
@@ -94,5 +94,5 @@ The FAST_VARIATION table contains four columns:
 For each pixel in the science data, the wavelength of the light that fell
 on that pixel will be determined from the WAVELENGTH array in the science exposure
 (in the absence of that array, it will be computed using the WCS interface).
-The flat-field value for that pixel will then be obtained by interpolating within the 
+The flat-field value for that pixel will then be obtained by interpolating within the
 wavelength and data arrays from the FAST_VARIATION table.

--- a/docs/jwst/references_general/filteroffset_reffile.rst
+++ b/docs/jwst/references_general/filteroffset_reffile.rst
@@ -7,7 +7,7 @@ FILTEROFFSET Reference File
 ---------------------------
 
 :REFTYPE: FILTEROFFSET
-:Data model: `~jwst.datamodels.FilteroffsetModel`
+:Data model: `~stdatamodels.jwst.datamodels.FilteroffsetModel`
 
 Reference Selection Keywords for FILTEROFFSET
 +++++++++++++++++++++++++++++++++++++++++++++

--- a/docs/jwst/references_general/flat_reffile.inc
+++ b/docs/jwst/references_general/flat_reffile.inc
@@ -4,7 +4,7 @@ FLAT Reference File
 -------------------
 
 :REFTYPE: FLAT
-:Data model: `~jwst.datamodels.FlatModel`
+:Data model: `~stdatamodels.jwst.datamodels.FlatModel`
 
 The FLAT reference file contains pixel-by-pixel detector response values.
 It is used for all instrument modes except the NIRSpec spectroscopic modes.
@@ -57,4 +57,3 @@ For application to imaging data, the FITS file contains a single set of SCI,
 ERR, DQ, and DQ_DEF extensions.  Image dimensions should be 2048x2048 for the
 NIR detectors and 1032x1024 for MIRI (i.e. they include reference pixels),
 unless data were taken in subarray mode.
-

--- a/docs/jwst/references_general/fore_reffile.rst
+++ b/docs/jwst/references_general/fore_reffile.rst
@@ -6,7 +6,7 @@ FORE Reference File (NIRSpec only)
 ----------------------------------
 
 :REFTYPE: FORE
-:Data model: `~jwst.datamodels.FOREModel`
+:Data model: `~stdatamodels.jwst.datamodels.FOREModel`
 
 Reference Selection Keywords for FORE
 +++++++++++++++++++++++++++++++++++++
@@ -31,4 +31,3 @@ The compound model takes three inputs - x, y positions and wavelength.
 
 :filter: Filter name.
 :model: Transform through the Filter Wheel Assembly (FWA).
-

--- a/docs/jwst/references_general/fpa_reffile.rst
+++ b/docs/jwst/references_general/fpa_reffile.rst
@@ -6,7 +6,7 @@ FPA Reference File (NIRSpec only)
 ---------------------------------
 
 :REFTYPE: FPA
-:Data model: `~jwst.datamodels.FPAModel`
+:Data model: `~stdatamodels.jwst.datamodels.FPAModel`
 
 Reference Selection Keywords for FPA
 ++++++++++++++++++++++++++++++++++++
@@ -33,4 +33,3 @@ from the FPA to the respective SCA. The output units are in pixels.
 
 :nrs1_model: Transform for the NRS1 detector.
 :nrs2_model: Transform for the NRS2 detector.
-

--- a/docs/jwst/references_general/fringe_reffile.inc
+++ b/docs/jwst/references_general/fringe_reffile.inc
@@ -4,7 +4,7 @@ FRINGE Reference File
 ---------------------
 
 :REFTYPE: FRINGE
-:Data model: `~jwst.datamodels.FringeModel`
+:Data model: `~stdatamodels.jwst.datamodels.FringeModel`
 
 The FRINGE reference file contains pixel-by-pixel fringing correction
 values.
@@ -48,4 +48,3 @@ Because MIRI MRS exposures are always full-frame, the image dimensions
 should be 1032 x 1024.
 
 .. include:: ../includes/dq_def.inc
-

--- a/docs/jwst/references_general/fringefreq_reffile.inc
+++ b/docs/jwst/references_general/fringefreq_reffile.inc
@@ -4,7 +4,7 @@ FRINGEFREQ reference file
 -------------------------
 
 :REFTYPE: FRINGEFREQ
-:Data models: `~jwst.datamodels.FringeFreqModel`
+:Data models: `~stdatamodels.jwst.datamodels.FringeFreqModel`
 
 The FRINGEFREQ reference files contain parameter values used to correct MIRI MRS images
 for  residual fringes that remain  after applying the fringe flat.
@@ -33,21 +33,21 @@ The FRINGEFREQ reference files are FITS format, with  4  BINTABLE extensions.
 The FITS primary data array is assumed to be empty.
 The format and content of the FRINGEFREQ reference file is
 
-===================  ========  ===========  
-EXTNAME              XTENSION  Dimensions   
-===================  ========  ===========  
-RFC_FREQ_SHORT       BINTABLE  TFIELDS = 7  
-RFC_FREQ_MEDIUM      BINTABLE  TFIELDS = 7  
-RFC_FREQ_LONG        BINTABLE  TFIELDS = 7  
-MAX_AMP              BINTABLE  TFIELDS = 2  
-===================  ========  ===========  
+===================  ========  ===========
+EXTNAME              XTENSION  Dimensions
+===================  ========  ===========
+RFC_FREQ_SHORT       BINTABLE  TFIELDS = 7
+RFC_FREQ_MEDIUM      BINTABLE  TFIELDS = 7
+RFC_FREQ_LONG        BINTABLE  TFIELDS = 7
+MAX_AMP              BINTABLE  TFIELDS = 2
+===================  ========  ===========
 
 The formats of the individual table extensions are listed below.
 
 .. include:: ../references_general/fringefreq_format.inc
 
 These reference files contain tables for each MIRI band giving the
-fringe frequencies and other parameters for each band to fit and remove residual fringes. 
+fringe frequencies and other parameters for each band to fit and remove residual fringes.
 
 
 The reference table descriptions:
@@ -55,7 +55,4 @@ The reference table descriptions:
 - **RFC_FREQ_SHORT** table contains the fringe frequencies and parameters for the SHORT band.
 - **RFC_FREQ_MEDIUM** table contains the fringe frequencies and parameters for the MEDIUM band.
 - **RFC_FREQ_LONG** table contains the fringe frequencies and parameters for the LONG band.
-- **MAX_AMP** table contains a wavelength dependent maximum amplitude which is use for feature identification and fit rejection. 
-
-
-
+- **MAX_AMP** table contains a wavelength dependent maximum amplitude which is use for feature identification and fit rejection.

--- a/docs/jwst/references_general/gain_reffile.inc
+++ b/docs/jwst/references_general/gain_reffile.inc
@@ -2,7 +2,7 @@ GAIN reference file
 -------------------
 
 :REFTYPE: GAIN
-:Data model: `~jwst.datamodels.GainModel`
+:Data model: `~stdatamodels.jwst.datamodels.GainModel`
 
 The GAIN reference file contains a pixel-by-pixel gain map, which can be
 used to convert pixel values from units of DN to electrons. The gain
@@ -42,4 +42,3 @@ EXTNAME  XTENSION  NAXIS  Dimensions      Data type
 =======  ========  =====  ==============  =========
 SCI      IMAGE       2    ncols x nrows   float
 =======  ========  =====  ==============  =========
-

--- a/docs/jwst/references_general/ifufore_reffile.rst
+++ b/docs/jwst/references_general/ifufore_reffile.rst
@@ -6,7 +6,7 @@ IFUFORE Reference File (NIRSpec only)
 -------------------------------------
 
 :REFTYPE: IFUFORE
-:Data model: `~jwst.datamodels.IFUFOREModel`
+:Data model: `~stdatamodels.jwst.datamodels.IFUFOREModel`
 
 Reference Selection Keywords for IFUFORE
 ++++++++++++++++++++++++++++++++++++++++
@@ -28,4 +28,3 @@ This file provides the parameters (Paraxial and distortions coefficients)
 for the coordinate transforms from the MSA plane to the plane of the IFU slicer.
 
 :model: Compound model, Polynomials
-

--- a/docs/jwst/references_general/ifupost_reffile.rst
+++ b/docs/jwst/references_general/ifupost_reffile.rst
@@ -1,12 +1,12 @@
 :orphan:
 
 .. _ifupost_reffile:
-  
+
 IFUPOST Reference File (NIRSpec only)
 -------------------------------------
 
 :REFTYPE: IFUPOST
-:Data model: `~jwst.datamodels.IFUPostModel`
+:Data model: `~stdatamodels.jwst.datamodels.IFUPostModel`
 
 Reference Selection Keywords for IFUPOST
 ++++++++++++++++++++++++++++++++++++++++

--- a/docs/jwst/references_general/ifuslicer_reffile.rst
+++ b/docs/jwst/references_general/ifuslicer_reffile.rst
@@ -1,12 +1,12 @@
 :orphan:
 
 .. _ifuslicer_reffile:
-  
+
 IFUSLICER Reference File (NIRSpec only)
 ---------------------------------------
 
 :REFTYPE: IFUSLICER
-:Data model: `~jwst.datamodels.IFUSlicerModel`
+:Data model: `~stdatamodels.jwst.datamodels.IFUSlicerModel`
 
 Reference Selection Keywords for IFUSLICER
 ++++++++++++++++++++++++++++++++++++++++++

--- a/docs/jwst/references_general/ipc_reffile.inc
+++ b/docs/jwst/references_general/ipc_reffile.inc
@@ -4,7 +4,7 @@ IPC Reference File
 ------------------
 
 :REFTYPE: IPC
-:Data model: `~jwst.datamodels.IPCModel`
+:Data model: `~stdatamodels.jwst.datamodels.IPCModel`
 
 The IPC reference file contains a deconvolution kernel.
 

--- a/docs/jwst/references_general/linearity_reffile.inc
+++ b/docs/jwst/references_general/linearity_reffile.inc
@@ -4,7 +4,7 @@ LINEARITY Reference File
 -------------------------
 
 :REFTYPE: LINEARITY
-:Data model: `~jwst.datamodels.LinearityModel`
+:Data model: `~stdatamodels.jwst.datamodels.LinearityModel`
 
 The LINEARITY reference file contains pixel-by-pixel polynomial correction
 coefficients.

--- a/docs/jwst/references_general/mask_reffile.inc
+++ b/docs/jwst/references_general/mask_reffile.inc
@@ -4,7 +4,7 @@ MASK Reference File
 -------------------
 
 :REFTYPE: MASK
-:Data model: `~jwst.datamodels.MaskModel`
+:Data model: `~stdatamodels.jwst.datamodels.MaskModel`
 
 The MASK reference file contains pixel-by-pixel DQ flag values that indicate
 problem conditions.

--- a/docs/jwst/references_general/mrsptcorr_reffile.inc
+++ b/docs/jwst/references_general/mrsptcorr_reffile.inc
@@ -4,12 +4,12 @@ MRSPTCORR reference file
 --------------------------
 
 :REFTYPE: MRSPTCORR
-:Data models: `~jwst.datamodels.MirMrsPtCorrModel`
+:Data models: `~stdatamodels.jwst.datamodels.MirMrsPtCorrModel`
 
 The MRSPTCORR reference file contains parameter values used to subtract
 the MRS 12 micron spectral leak in the spectral leak step. It also contains parameters
 to correct point sources, in future enhancements,  for  across-slice corrections and
-throughput variations. 
+throughput variations.
 
 .. include:: ../references_general/mrsptcorr_selection.inc
 
@@ -34,15 +34,15 @@ The MIRI MRSPTCORR reference files are FITS format, with  5  BINTABLE extensions
 The FITS primary data array is assumed to be empty.
 The format and content of the MIRI MRSPTCORR reference file
 
-===================  ========  ===========  
-EXTNAME              XTENSION  Dimensions   
-===================  ========  ===========  
+===================  ========  ===========
+EXTNAME              XTENSION  Dimensions
+===================  ========  ===========
 LEAKCOR              BINTABLE  TFIELDS = 3
 TRACOR               BINTABLE  TFIELDS = 7
 WAVCORR_OPTICAL      BINTABLE  TFIELDS = 6
 WAVCORR_XSLICE       BINTABLE  TFIELDS = 2
 WAVCORR_SHIFT        BINTABLE  TFIELDS = 3
-===================  ========  ===========  
+===================  ========  ===========
 
 The formats of the individual table extensions are listed below.
 
@@ -50,5 +50,4 @@ The formats of the individual table extensions are listed below.
 
 This reference file contains the relative spectrophotometric response function for the MRS 12 micron
 spectral leak, along with tables of across-slice wavelength and throughput variations for point
-sources in each of the MRS bands. Currently, only the LEAKCOR table is use in the jwst pipeline. 
-
+sources in each of the MRS bands. Currently, only the LEAKCOR table is use in the jwst pipeline.

--- a/docs/jwst/references_general/mrsxartcorr_reffile.inc
+++ b/docs/jwst/references_general/mrsxartcorr_reffile.inc
@@ -4,7 +4,7 @@ MRSXARTCORR reference file
 --------------------------
 
 :REFTYPE: MRSXARTCORR
-:Data models: `~jwst.datamodels.MirMrsXArtCorrModel`
+:Data models: `~stdatamodels.jwst.datamodels.MirMrsXArtCorrModel`
 
 The MRSXARTCORR reference file contains parameter values used to model and subtract
 the cross-artifact in the straylight step.
@@ -32,9 +32,9 @@ The MIRI MRSXARTCORR reference files are FITS format, with  12  BINTABLE extensi
 The FITS primary data array is assumed to be empty.
 The format and content of the MIRI MRSXARTCORR reference file
 
-===================  ========  ===========  
-EXTNAME              XTENSION  Dimensions   
-===================  ========  ===========  
+===================  ========  ===========
+EXTNAME              XTENSION  Dimensions
+===================  ========  ===========
 1A                   BINTABLE  TFIELDS = 7
 1B                   BINTABLE  TFIELDS = 7
 1C                   BINTABLE  TFIELDS = 7
@@ -47,7 +47,7 @@ EXTNAME              XTENSION  Dimensions
 4A                   BINTABLE  TFIELDS = 7
 4B                   BINTABLE  TFIELDS = 7
 4C                   BINTABLE  TFIELDS = 7
-===================  ========  ===========  
+===================  ========  ===========
 
 The formats of the individual table extensions are listed below.
 

--- a/docs/jwst/references_general/msa_reffile.rst
+++ b/docs/jwst/references_general/msa_reffile.rst
@@ -1,12 +1,12 @@
 :orphan:
 
 .. _msa_reffile:
-  
+
 MSA Reference File (NIRSpec only)
 ---------------------------------
 
 :REFTYPE: MSA
-:Data model: `~jwst.datamodels.MSAModel`
+:Data model: `~stdatamodels.jwst.datamodels.MSAModel`
 
 Reference Selection Keywords for MSA
 ++++++++++++++++++++++++++++++++++++
@@ -57,4 +57,3 @@ The MSA reference file has 5 fields, named
    :data: Reference data for the fixed slits and the IFU, same as in 1, except NO is 6 rows (1-6)
           and the mapping is 1 - S200A1, 2 - S200A1, 3 - S400A1, 4 - S200B1, 5 - S1600A1, 6 - IFU
    :model: Transform from relative positions within eac aperture to absolute positions within the MSA
-

--- a/docs/jwst/references_general/nrm_reffile.inc
+++ b/docs/jwst/references_general/nrm_reffile.inc
@@ -4,7 +4,7 @@ NRM Reference File
 ^^^^^^^^^^^^^^^^^^
 
 :REFTYPE: NRM
-:Data model: `~jwst.datamodels.NRMModel`
+:Data model: `~stdatamodels.jwst.datamodels.NRMModel`
 
 The NRM reference file contains a 2-D model of the pupil mask.
 
@@ -39,5 +39,5 @@ NRM      IMAGE       2    1024 x 1024     float
 =======  ========  =====  ==============  =========
 
 The ``NRM`` array contains the 2-D image representing the geometry
-of the non-redundant mask in the pupil wheel of NIRISS. This mask 
+of the non-redundant mask in the pupil wheel of NIRISS. This mask
 enables the Aperture Masking Interferometry (AMI) mode.

--- a/docs/jwst/references_general/ote_reffile.rst
+++ b/docs/jwst/references_general/ote_reffile.rst
@@ -1,12 +1,12 @@
 :orphan:
 
 .. _ote_reffile:
-  
+
 OTE Reference File (NIRSpec only)
 ---------------------------------
 
 :REFTYPE: OTE
-:Data model: `~jwst.datamodels.OTEModel`
+:Data model: `~stdatamodels.jwst.datamodels.OTEModel`
 
 Reference Selection Keywords for OTE
 ++++++++++++++++++++++++++++++++++++

--- a/docs/jwst/references_general/pathloss_reffile.inc
+++ b/docs/jwst/references_general/pathloss_reffile.inc
@@ -4,7 +4,7 @@ PATHLOSS Reference File
 -----------------------
 
 :REFTYPE: PATHLOSS
-:Data model: `~jwst.datamodels.PathlossModel`, `~jwst.datamodels.MirLrsPathlossModel`
+:Data model: `~stdatamodels.jwst.datamodels.PathlossModel`, `~stdatamodels.jwst.datamodels.MirLrsPathlossModel`
 
 The PATHLOSS reference file contains correction factors as functions of
 source position in the aperture and wavelength.
@@ -73,10 +73,10 @@ slices. The structure of the FITS file is as follows:
 ==== =======  ==========  =============  ==========
 HDU  EXTNAME  XTENSION     Dimensions    Data type
 ==== =======  ==========  =============  ==========
-1    PS       ImageHDU     21 x 21 x 21  float64   
-2    PSVAR    ImageHDU     21 x 21 x 21  float64   
-3    UNI      ImageHDU     21            float64   
-4    UNIVAR   ImageHDU     21            float64   
+1    PS       ImageHDU     21 x 21 x 21  float64
+2    PSVAR    ImageHDU     21 x 21 x 21  float64
+3    UNI      ImageHDU     21            float64
+4    UNIVAR   ImageHDU     21            float64
 ==== =======  ==========  =============  ==========
 
 NIRSpec Fixed Slit
@@ -86,24 +86,24 @@ The NIRSpec Fixed Slit reference file has the following FITS structure:
 ==== ======= ====== ========== =============  ==========
 HDU  EXTNAME EXTVER XTENSION    Dimensions    Data type
 ==== ======= ====== ========== =============  ==========
-1    PS        1    ImageHDU    21 x 21 x 21  float64   
-2    PSVAR     1    ImageHDU    21 x 21 x 21  float64   
-3    UNI       1    ImageHDU    21            float64   
-4    UNIVAR    1    ImageHDU    21            float64   
-5    PS        2    ImageHDU    21 x 21 x 21  float64   
-6    PSVAR     2    ImageHDU    21 x 21 x 21  float64   
-7    UNI       2    ImageHDU    21            float64   
-8    UNIVAR    2    ImageHDU    21            float64   
-9    PS        3    ImageHDU    21 x 21 x 21  float64   
-10   PSVAR     3    ImageHDU    21 x 21 x 21  float64   
-11   UNI       3    ImageHDU    21            float64   
-12   UNIVAR    3    ImageHDU    21            float64   
-13   PS        4    ImageHDU    21 x 21 x 21  float64   
-14   PSVAR     4    ImageHDU    21 x 21 x 21  float64   
-15   UNI       4    ImageHDU    21            float64   
-16   UNIVAR    4    ImageHDU    21            float64   
+1    PS        1    ImageHDU    21 x 21 x 21  float64
+2    PSVAR     1    ImageHDU    21 x 21 x 21  float64
+3    UNI       1    ImageHDU    21            float64
+4    UNIVAR    1    ImageHDU    21            float64
+5    PS        2    ImageHDU    21 x 21 x 21  float64
+6    PSVAR     2    ImageHDU    21 x 21 x 21  float64
+7    UNI       2    ImageHDU    21            float64
+8    UNIVAR    2    ImageHDU    21            float64
+9    PS        3    ImageHDU    21 x 21 x 21  float64
+10   PSVAR     3    ImageHDU    21 x 21 x 21  float64
+11   UNI       3    ImageHDU    21            float64
+12   UNIVAR    3    ImageHDU    21            float64
+13   PS        4    ImageHDU    21 x 21 x 21  float64
+14   PSVAR     4    ImageHDU    21 x 21 x 21  float64
+15   UNI       4    ImageHDU    21            float64
+16   UNIVAR    4    ImageHDU    21            float64
 ==== ======= ====== ========== =============  ==========
- 
+
 HDU's 1--4 are for the S200A1 aperture, 5--8 are for S200A2,
 9--12 are for S200B1, and 13--16 are for S1600A1.  Currently there is
 no reference data for the S400A1 aperture.
@@ -118,14 +118,14 @@ The FITS file has the following structure:
 ==== ======= ====== ========== =============  ==========
 HDU  EXTNAME EXTVER XTENSION    Dimensions    Data type
 ==== ======= ====== ========== =============  ==========
-1    PS        1    ImageHDU    21 x 63 x 21  float64   
-2    PSVAR     1    ImageHDU    21 x 63 x 21  float64   
-3    UNI       1    ImageHDU    21            float64   
-4    UNIVAR    1    ImageHDU    21            float64   
-5    PS        2    ImageHDU    21 x 63 x 21  float64   
-6    PSVAR     2    ImageHDU    21 x 63 x 21  float64   
-7    UNI       2    ImageHDU    21            float64   
-8    UNIVAR    2    ImageHDU    21            float64   
+1    PS        1    ImageHDU    21 x 63 x 21  float64
+2    PSVAR     1    ImageHDU    21 x 63 x 21  float64
+3    UNI       1    ImageHDU    21            float64
+4    UNIVAR    1    ImageHDU    21            float64
+5    PS        2    ImageHDU    21 x 63 x 21  float64
+6    PSVAR     2    ImageHDU    21 x 63 x 21  float64
+7    UNI       2    ImageHDU    21            float64
+8    UNIVAR    2    ImageHDU    21            float64
 ==== ======= ====== ========== =============  ==========
 
 NIRISS SOSS
@@ -136,7 +136,7 @@ The structure of the FITS file is as follows:
 ==== ======= ========== =============  ==========
 HDU  EXTNAME XTENSION    Dimensions    Data type
 ==== ======= ========== =============  ==========
-1    PS      ImageHDU   17 x 2040 x 1  float32   
+1    PS      ImageHDU   17 x 2040 x 1  float32
 ==== ======= ========== =============  ==========
 
 The PS extension contains a 3-D array of correction values.

--- a/docs/jwst/references_general/persat_reffile.inc
+++ b/docs/jwst/references_general/persat_reffile.inc
@@ -4,7 +4,7 @@ PERSAT Reference File
 ---------------------
 
 :REFTYPE: PERSAT
-:Data model: `~jwst.datamodels.PersistenceSatModel`
+:Data model: `~stdatamodels.jwst.datamodels.PersistenceSatModel`
 
 The PERSAT reference file contains a pixel-by-pixel map of the
 persistence saturation (full well) threshold.

--- a/docs/jwst/references_general/photom_reffile.inc
+++ b/docs/jwst/references_general/photom_reffile.inc
@@ -36,7 +36,7 @@ The FITS primary HDU does not contain a data array.
 The contents of the table extension vary a bit for different
 instrument modes, as shown in the tables below.
 
-:Data model: `~jwst.datamodels.FgsImgPhotomModel`
+:Data model: `~stdatamodels.jwst.datamodels.FgsImgPhotomModel`
 
 +------------+-------+----------------+-----------+------------+------------------------+
 | Instrument | Mode  | Column name    | Data type | Dimensions | Units                  |
@@ -46,7 +46,7 @@ instrument modes, as shown in the tables below.
 |            |       | uncertainty    | float     | scalar     | MJy/steradian/(DN/sec) |
 +------------+-------+----------------+-----------+------------+------------------------+
 
-:Data model: `~jwst.datamodels.MirImgPhotomModel`
+:Data model: `~stdatamodels.jwst.datamodels.MirImgPhotomModel`
 
 +------------+-------+----------------+-----------+------------+------------------------+
 | Instrument | Mode  | Column name    | Data type | Dimensions | Units                  |
@@ -64,13 +64,13 @@ The MIRI Imager PHOTOM reference file can contain an optional BINTABLE extension
 named "TIMECOEFF", containing coefficients for an time-dependent correction. The format
 of this additional table extension is as follows:
 
-==========  ========  =====  ===========  =========  
+==========  ========  =====  ===========  =========
 EXTNAME     XTENSION  NAXIS  Dimensions   Data type
 ==========  ========  =====  ===========  =========
 TIMECOEFF   BINTABLE    2    TFIELDS = 3  float32
 ==========  ========  =====  ===========  =========
 
-:Data model: `~jwst.datamodels.MirLrsPhotomModel`
+:Data model: `~stdatamodels.jwst.datamodels.MirLrsPhotomModel`
 
 +------------+-------+----------------+-----------+------------+------------------------+
 | Instrument | Mode  | Column name    | Data type | Dimensions | Units                  |
@@ -92,7 +92,7 @@ TIMECOEFF   BINTABLE    2    TFIELDS = 3  float32
 |            |       | reluncertainty | float     | array      | unitless               |
 +------------+-------+----------------+-----------+------------+------------------------+
 
-:Data model: `~jwst.datamodels.NrcImgPhotomModel`
+:Data model: `~stdatamodels.jwst.datamodels.NrcImgPhotomModel`
 
 +------------+-------+----------------+-----------+------------+------------------------+
 | Instrument | Mode  | Column name    | Data type | Dimensions | Units                  |
@@ -106,7 +106,7 @@ TIMECOEFF   BINTABLE    2    TFIELDS = 3  float32
 |            |       | uncertainty    | float     | scalar     | MJy/steradian/(DN/sec) |
 +------------+-------+----------------+-----------+------------+------------------------+
 
-:Data model: `~jwst.datamodels.NrcWfssPhotomModel`
+:Data model: `~stdatamodels.jwst.datamodels.NrcWfssPhotomModel`
 
 +------------+-------+----------------+-----------+------------+------------------------+
 | Instrument | Mode  | Column name    | Data type | Dimensions | Units                  |
@@ -130,7 +130,7 @@ TIMECOEFF   BINTABLE    2    TFIELDS = 3  float32
 |            |       | reluncertainty | float     | array      | unitless               |
 +------------+-------+----------------+-----------+------------+------------------------+
 
-:Data model: `~jwst.datamodels.NisImgPhotomModel`
+:Data model: `~stdatamodels.jwst.datamodels.NisImgPhotomModel`
 
 +------------+-------+----------------+-----------+------------+------------------------+
 | Instrument | Mode  | Column name    | Data type | Dimensions | Units                  |
@@ -144,7 +144,7 @@ TIMECOEFF   BINTABLE    2    TFIELDS = 3  float32
 |            |       | uncertainty    | float     | scalar     | MJy/steradian/(DN/sec) |
 +------------+-------+----------------+-----------+------------+------------------------+
 
-:Data model: `~jwst.datamodels.NisSossPhotomModel`
+:Data model: `~stdatamodels.jwst.datamodels.NisSossPhotomModel`
 
 +------------+-------+----------------+-----------+------------+------------------------+
 | Instrument | Mode  | Column name    | Data type | Dimensions | Units                  |
@@ -168,7 +168,7 @@ TIMECOEFF   BINTABLE    2    TFIELDS = 3  float32
 |            |       | reluncertainty | float     | array      | unitless               |
 +------------+-------+----------------+-----------+------------+------------------------+
 
-:Data model: `~jwst.datamodels.NisWfssPhotomModel`
+:Data model: `~stdatamodels.jwst.datamodels.NisWfssPhotomModel`
 
 +------------+-------+----------------+-----------+------------+------------------------+
 | Instrument | Mode  | Column name    | Data type | Dimensions | Units                  |
@@ -192,7 +192,7 @@ TIMECOEFF   BINTABLE    2    TFIELDS = 3  float32
 |            |       | reluncertainty | float     | array      | unitless               |
 +------------+-------+----------------+-----------+------------+------------------------+
 
-:Data model: `~jwst.datamodels.NrsFsPhotomModel`
+:Data model: `~stdatamodels.jwst.datamodels.NrsFsPhotomModel`
 
 +------------+-------+----------------+-----------+------------+------------------------+
 | Instrument | Mode  | Column name    | Data type | Dimensions | Units                  |
@@ -216,7 +216,7 @@ TIMECOEFF   BINTABLE    2    TFIELDS = 3  float32
 |            |       | reluncertainty | float     | array      | unitless               |
 +------------+-------+----------------+-----------+------------+------------------------+
 
-:Data model: `~jwst.datamodels.NrsMosPhotomModel`
+:Data model: `~stdatamodels.jwst.datamodels.NrsMosPhotomModel`
 
 +------------+-------+----------------+-----------+------------+------------------------+
 | Instrument | Mode  | Column name    | Data type | Dimensions | Units                  |
@@ -271,14 +271,14 @@ square arcseconds, respectively.
 MIRI MRS Photom Reference File Format
 +++++++++++++++++++++++++++++++++++++
 
-:Data model: `~jwst.datamodels.MirMrsPhotomModel`
+:Data model: `~stdatamodels.jwst.datamodels.MirMrsPhotomModel`
 
 For MIRI MRS, the PHOTOM file contains 2-D arrays of conversion factors in
 IMAGE extensions.
 The FITS primary HDU does not contain a data array.
 The format and content of the MIRI MRS PHOTOM reference file is as follows:
 
-==================  ========  =====  ===========  =========  
+==================  ========  =====  ===========  =========
 EXTNAME             XTENSION  NAXIS  Dimensions   Data type
 ==================  ========  =====  ===========  =========
 SCI                 IMAGE       2    1032 x 1024  float
@@ -314,7 +314,7 @@ product header by the photom step.
 
 The TIMECOEFF_CH tables contain the parameters to correct the MRS time-dependent
 throughput loss. If these tables do not exist in the reference file, then the MIRI
-MRS time-dependent correction is skipped. 
+MRS time-dependent correction is skipped.
 
 Constructing a PHOTOM Reference File
 ------------------------------------

--- a/docs/jwst/references_general/psf_reffile.inc
+++ b/docs/jwst/references_general/psf_reffile.inc
@@ -4,7 +4,7 @@ PSF Reference File
 ^^^^^^^^^^^^^^^^^^
 
 :REFTYPE: PSF
-:Data model: `~jwst.datamodels.SpecPsfModel`
+:Data model: `~stdatamodels.jwst.datamodels.SpecPsfModel`
 
 The PSF reference file contains a model of the 1-D point spread function
 by wavelength, intended to support spectral modeling and extraction.

--- a/docs/jwst/references_general/psfmask_reffile.inc
+++ b/docs/jwst/references_general/psfmask_reffile.inc
@@ -4,7 +4,7 @@ PSFMASK Reference File
 ^^^^^^^^^^^^^^^^^^^^^^
 
 :REFTYPE: PSFMASK
-:Data model: `~jwst.datamodels.PsfMaskModel`
+:Data model: `~stdatamodels.jwst.datamodels.PsfMaskModel`
 
 The PSFMASK reference file contains a 2-D mask that's used as a weight
 function when computing shifts between images.

--- a/docs/jwst/references_general/readnoise_reffile.inc
+++ b/docs/jwst/references_general/readnoise_reffile.inc
@@ -2,7 +2,7 @@ READNOISE Reference File
 ------------------------
 
 :REFTYPE: READNOISE
-:Data model: `~jwst.datamodels.ReadnoiseModel`
+:Data model: `~stdatamodels.jwst.datamodels.ReadnoiseModel`
 
 The READNOISE reference file contains a pixel-by-pixel map of read noise,
 which is used in estimating the expected noise in each pixel.
@@ -46,4 +46,3 @@ EXTNAME  XTENSION  NAXIS  Dimensions      Data type
 =======  ========  =====  ==============  =========
 SCI      IMAGE       2    ncols x nrows   float
 =======  ========  =====  ==============  =========
-

--- a/docs/jwst/references_general/references_general.rst
+++ b/docs/jwst/references_general/references_general.rst
@@ -339,41 +339,41 @@ The required Keywords Documenting Contents of Reference Files are:
 ========  ==================================================================================
 Keyword   Comment
 ========  ==================================================================================
-REFTYPE   `BKG        Required values are listed in the discussion of each pipeline step.`
-DESCRIP   `Summary of file content and/or reason for delivery`
-AUTHOR    `Fred Jones     Person(s) who created the file`
-USEAFTER  `YYYY-MM-DDThh:mm:ss Date and time after the reference files will
+REFTYPE   ``BKG        Required values are listed in the discussion of each pipeline step.``
+DESCRIP   ``Summary of file content and/or reason for delivery``
+AUTHOR    ``Fred Jones     Person(s) who created the file``
+USEAFTER  ``YYYY-MM-DDThh:mm:ss Date and time after the reference files will
           be used. The T is required. Time string may NOT be omitted;
-          use T00:00:00 if no meaningful value is available.`
-PEDIGREE  `Options are
+          use T00:00:00 if no meaningful value is available.``
+PEDIGREE  ``Options are
           'SIMULATION'
           'GROUND'
           'DUMMY'
-          'INFLIGHT YYYY-MM-DD YYYY-MM-DD'`
-HISTORY   `Description of Reference File Creation`
-HISTORY   `DOCUMENT: Name of document describing the strategy and algorithms
-          used to create file.`
-HISTORY   `SOFTWARE: Description, version number, location of software used
-          to create file.`
-HISTORY   `DATA USED: Data used to create file`
-HISTORY   `DIFFERENCES: How is this version different from the one that
-          it replaces?`
-HISTORY   `If your text spills over to the next line,
-          begin it with another HISTORY keyword, as in this example.`
-TELESCOP  `JWST   Name of the telescope/project.`
-INSTRUME  `FGS   Instrument name. Allowed values: FGS, NIRCAM, NIRISS,
-          NIRSPEC, MIRI`
-SUBARRAY  `FULL, GENERIC, SUBS200A1, ...   (XXX abstract technical description
-          of SUBARRAY)`
-SUBSTRT1  `1        Starting pixel index along axis 1 (1-indexed)`
-SUBSIZE1  `2048     Size of subarray along axis 1`
-SUBSTRT2  `1        Starting pixel index along axis 2 (1-indexed)`
-SUBSIZE2  `2048     Size of subarray along axis 2`
-FASTAXIS  `1        Fast readout direction relative to image axes for
+          'INFLIGHT YYYY-MM-DD YYYY-MM-DD'``
+HISTORY   ``Description of Reference File Creation``
+HISTORY   ``DOCUMENT: Name of document describing the strategy and algorithms
+          used to create file.``
+HISTORY   ``SOFTWARE: Description, version number, location of software used
+          to create file.``
+HISTORY   ``DATA USED: Data used to create file``
+HISTORY   ``DIFFERENCES: How is this version different from the one that
+          it replaces?``
+HISTORY   ``If your text spills over to the next line,
+          begin it with another HISTORY keyword, as in this example.``
+TELESCOP  ``JWST   Name of the telescope/project.``
+INSTRUME  ``FGS   Instrument name. Allowed values: FGS, NIRCAM, NIRISS,
+          NIRSPEC, MIRI``
+SUBARRAY  ``FULL, GENERIC, SUBS200A1, ...   (XXX abstract technical description
+          of SUBARRAY)``
+SUBSTRT1  ``1        Starting pixel index along axis 1 (1-indexed)``
+SUBSIZE1  ``2048     Size of subarray along axis 1``
+SUBSTRT2  ``1        Starting pixel index along axis 2 (1-indexed)``
+SUBSIZE2  ``2048     Size of subarray along axis 2``
+FASTAXIS  ``1        Fast readout direction relative to image axes for
           Amplifier #1 (1 = +x axis, 2 = +y axis, -1 = -x axis, -2 = -y axis)
-          SEE NOTE BELOW.`
-SLOWAXIS  `2        Slow readout direction relative to image axes for
-          all amplifiers (1 = +x axis, 2 = +y axis, -1 = -x axis, -2 = -y axis)`
+          SEE NOTE BELOW.``
+SLOWAXIS  ``2        Slow readout direction relative to image axes for
+          all amplifiers (1 = +x axis, 2 = +y axis, -1 = -x axis, -2 = -y axis)``
 ========  ==================================================================================
 
 
@@ -683,9 +683,9 @@ bit flags that should be summed to obtain the final "good" bits. For example,
 both "4,8" and "4+8" are equivalent to a setting of "12".
 
 Finally, instead of integers, the JWST mnemonics, as defined above, may be used.
-For example, all the following specifications are equivalent:
+For example, all the following specifications are equivalent::
 
-`"12" == "4+8" == "4, 8" == "JUMP_DET, DROPOUT"`
+    "12" == "4+8" == "4, 8" == "JUMP_DET, DROPOUT"
 
 .. note::
  The default value (0) will make *all* non-zero

--- a/docs/jwst/references_general/refpix_reffile.inc
+++ b/docs/jwst/references_general/refpix_reffile.inc
@@ -4,7 +4,7 @@ REFPIX Reference File
 ---------------------
 
 :REFTYPE: REFPIX
-:Data model: `~jwst.datamodels.IRS2Model`
+:Data model: `~stdatamodels.jwst.datamodels.IRS2Model`
 
 The REFPIX reference file contains the complex coefficients
 for the correction.

--- a/docs/jwst/references_general/regions_reffile.rst
+++ b/docs/jwst/references_general/regions_reffile.rst
@@ -1,12 +1,12 @@
 :orphan:
 
 .. _regions_reffile:
-  
+
 REGIONS Reference File (MIRI only)
 ----------------------------------
 
 :REFTYPE: REGIONS
-:Data model: `~jwst.datamodels.RegionsModel`
+:Data model: `~stdatamodels.jwst.datamodels.RegionsModel`
 
 Reference Selection Keywords for REGIONS
 ++++++++++++++++++++++++++++++++++++++++

--- a/docs/jwst/references_general/reset_reffile.inc
+++ b/docs/jwst/references_general/reset_reffile.inc
@@ -4,14 +4,14 @@ RESET Reference File
 --------------------
 
 :REFTYPE: RESET
-:Data model: `~jwst.datamodels.ResetModel`
+:Data model: `~stdatamodels.jwst.datamodels.ResetModel`
 
 .. include:: ../includes/standard_keywords.inc
 
 Reference File Format
 +++++++++++++++++++++
 The reset reference files are FITS files with 3 IMAGE extensions and 1 BINTABLE
-extension. The FITS primary data array is assumed to be empty. The 
+extension. The FITS primary data array is assumed to be empty. The
 characteristics of the three image extension are as follows:
 
 =======  =====  ============================== =========
@@ -24,10 +24,10 @@ DQ       2      ncols x nrows                  integer
 
 .. include:: ../includes/dq_def.inc
 
-The SCI and ERR data arrays are 4-D, with dimensions of ncols x nrows x 
+The SCI and ERR data arrays are 4-D, with dimensions of ncols x nrows x
 ngroups X nints, where ncols x nrows matches the dimensions of the raw detector
-readout mode for which the reset applies. The reference file contains the 
+readout mode for which the reset applies. The reference file contains the
 number of NGroups planes required for the correction to be zero on
 the last plane Ngroups plane.  The correction for the first few
 integrations varies and eventually settles down to a constant correction
-independent of integration number.  
+independent of integration number.

--- a/docs/jwst/references_general/rscd_reffile.inc
+++ b/docs/jwst/references_general/rscd_reffile.inc
@@ -4,11 +4,11 @@ RSCD Reference File
 -------------------
 
 :REFTYPE: RSCD
-:Data model: `~jwst.datamodels.RSCDModel`
+:Data model: `~stdatamodels.jwst.datamodels.RSCDModel`
 
 The RSCD reference file contains the number of groups to flag as 'DO_NOT_USE' based on
 readout mode and subarray size. Integrations two and higher are flagged; the first integration
-groups values are not flagged. 
+groups values are not flagged.
 
 .. include:: ../references_general/rscd_selection.inc
 
@@ -46,5 +46,4 @@ group_skip   int         number of initial groups in an integration to flag
 The entries in the first two columns of the table are used as selection criteria, matching
 the exposure properties of the data. The last column contains the
 number of initial groups in an integration to flag as 'DO_NOT_USE' for integrations 2 and higher.
-These initial groups are affected by the RSCD effect.  The groups in the first integration are not flagged. 
-
+These initial groups are affected by the RSCD effect.  The groups in the first integration are not flagged.

--- a/docs/jwst/references_general/saturation_reffile.inc
+++ b/docs/jwst/references_general/saturation_reffile.inc
@@ -4,7 +4,7 @@ SATURATION Reference File
 -------------------------
 
 :REFTYPE: SATURATION
-:Data model: `jwst.datamodels.SaturationModel`
+:Data model: `~stdatamodels.jwst.datamodels.SaturationModel`
 
 The SATURATION reference file contains pixel-by-pixel saturation threshold
 values.

--- a/docs/jwst/references_general/sflat_reffile.inc
+++ b/docs/jwst/references_general/sflat_reffile.inc
@@ -4,7 +4,7 @@ SFLAT Reference File
 --------------------
 
 :REFTYPE: SFLAT
-:Data model: `~jwst.datamodels.NirspecFlatModel`
+:Data model: `~stdatamodels.jwst.datamodels.NirspecFlatModel`
 
 There are 3 types of NIRSpec SFLAT reference files: fixed slit, MSA spec, and IFU.
 For each type the primary HDU does not contain a data array.

--- a/docs/jwst/references_general/sirskernel_reffile.inc
+++ b/docs/jwst/references_general/sirskernel_reffile.inc
@@ -4,7 +4,7 @@ SIRSKERNEL Reference File
 -------------------------
 
 :REFTYPE: SIRSKERNEL
-:Data model: `~jwst.datamodels.SIRSKernelModel`
+:Data model: `~stdatamodels.jwst.datamodels.SIRSKernelModel`
 
 The SIRSKERNEL reference file contains Fourier coefficients for an
 optimized convolution kernel, used for correcting 1/f noise from
@@ -16,10 +16,10 @@ Reference File Format
 +++++++++++++++++++++
 SIRSKERNEL reference files are in ASDF format.  They contain a dictionary with
 keys corresponding to lower-case detector names.  Each detector entry contains
-two arrays, `gamma` and `zeta`, which contain the complex Fourier coefficients
+two arrays, ``gamma`` and ``zeta``, which contain the complex Fourier coefficients
 required to apply the Simple Improved Reference Subtraction (SIRS) algorithm
 for reference pixel correction.
 
 The first dimension of the array holds the sector index (amplifier output,
 4 per detector).  The second dimension matches the height of the sector, plus one.
-The data type for both arrays is `complex64`.
+The data type for both arrays is ``complex64``.

--- a/docs/jwst/references_general/specwcs_reffile.rst
+++ b/docs/jwst/references_general/specwcs_reffile.rst
@@ -1,12 +1,12 @@
 :orphan:
 
 .. _specwcs_reffile:
-  
+
 SPECWCS Reference File
 ----------------------
 
 :REFTYPE: SPECWCS
-:Data model: `~jwst.datamodels.SpecwcsModel`
+:Data model: `~stdatamodels.jwst.datamodels.SpecwcsModel`
 
 Reference Selection Keywords for SPECWCS
 ++++++++++++++++++++++++++++++++++++++++
@@ -77,4 +77,3 @@ For NIRISS WFSS mode the SPECWCS file is in ASDF format with the following struc
 :invdispl: The inverse wavelength transform models
 :fwcpos_ref: The reference filter wheel position in degrees
 :orders: a list of order numbers that the models relate to, in the same order as the models
-

--- a/docs/jwst/references_general/superbias_reffile.inc
+++ b/docs/jwst/references_general/superbias_reffile.inc
@@ -4,7 +4,7 @@ SUPERBIAS Reference File
 ------------------------
 
 :REFTYPE: SUPERBIAS
-:Data model: `~jwst.datamodels.SuperBiasModel`
+:Data model: `~stdatamodels.jwst.datamodels.SuperBiasModel`
 
 The SUPERBIAS reference file contains a 2-D image of the detector bias
 ("zeroth" read) structure.
@@ -53,4 +53,3 @@ The ``SCI`` array contains the super-bias image of the detector. The
 image.
 
 .. include:: ../includes/dq_def.inc
-

--- a/docs/jwst/references_general/throughput_reffile.inc
+++ b/docs/jwst/references_general/throughput_reffile.inc
@@ -4,7 +4,7 @@ THROUGHPUT Reference File
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :REFTYPE: THROUGHPUT
-:Data model: `~jwst.datamodels.ThroughputModel`
+:Data model: `~stdatamodels.jwst.datamodels.ThroughputModel`
 
 The THROUGHPUT reference file contains throughput data for the filter used
 in the AMI image.

--- a/docs/jwst/references_general/trapdensity_reffile.inc
+++ b/docs/jwst/references_general/trapdensity_reffile.inc
@@ -4,7 +4,7 @@ TRAPDENSITY Reference File
 --------------------------
 
 :REFTYPE: TRAPDENSITY
-:Data model: `~jwst.datamodels.TrapDensityModel`
+:Data model: `~stdatamodels.jwst.datamodels.TrapDensityModel`
 
 The TRAPDENSITY reference file contains a pixel-by-pixel map of the
 trap density.

--- a/docs/jwst/references_general/trappars_reffile.inc
+++ b/docs/jwst/references_general/trappars_reffile.inc
@@ -4,7 +4,7 @@ TRAPPARS Reference File
 -----------------------
 
 :REFTYPE: TRAPPARS
-:Data model: `~jwst.datamodels.TrapParsModel`
+:Data model: `~stdatamodels.jwst.datamodels.TrapParsModel`
 
 The TRAPPARS reference file contains default parameter values
 used in the persistence correction.
@@ -58,4 +58,3 @@ if the persistence step is run on MIRI or NIRSpec data, in which case
 the input will be returned unchanged,
 except that the primary header keyword S_PERSIS will will have been
 set to 'SKIPPED'.
-

--- a/docs/jwst/references_general/tsophot_reffile.inc
+++ b/docs/jwst/references_general/tsophot_reffile.inc
@@ -4,7 +4,7 @@ TSOPHOT Reference File
 ----------------------
 
 :REFTYPE: TSOPHOT
-:Data model: `~jwst.datamodels.TsoPhotModel`
+:Data model: `~stdatamodels.jwst.datamodels.TsoPhotModel`
 
 The TSOPHOT reference file contains photometry aperture radii for
 TSO imaging observation modes.

--- a/docs/jwst/references_general/wavecorr_reffile.inc
+++ b/docs/jwst/references_general/wavecorr_reffile.inc
@@ -4,7 +4,7 @@ WAVECORR Reference File
 -----------------------
 
 :REFTYPE: WAVECORR
-:Data model: `~jwst.datamodels.WaveCorrModel`
+:Data model: `~stdatamodels.jwst.datamodels.WaveCorrModel`
 
 The WAVECORR reference file contains pixel offset values as a function of
 wavelength and source offset within a NIRSpec slit.
@@ -34,5 +34,4 @@ EXP_TYPE   model.meta.exposure.type
 Reference File Format
 +++++++++++++++++++++
 WAVECORR reference files are in ASDF format, with the format and contents
-specified by the `~jwst.datamodels.WaveCorrModel` data model schema.
-
+specified by the `~stdatamodels.jwst.datamodels.WaveCorrModel` data model schema.

--- a/docs/jwst/references_general/wavelengthrange_reffile.inc
+++ b/docs/jwst/references_general/wavelengthrange_reffile.inc
@@ -2,7 +2,7 @@ WAVELENGTHRANGE Reference File
 ------------------------------
 
 :REFTYPE: WAVELENGTHRANGE
-:Data model: `~jwst.datamodels.WavelengthrangeModel`
+:Data model: `~stdatamodels.jwst.datamodels.WavelengthrangeModel`
 
 The WAVELENGTHRANGE reference file contains information on the minimum and
 maximum wavelengths of various spectroscopic modes, which can be
@@ -34,7 +34,7 @@ These keywords are used as CRDS selectors
 Reference File Format
 +++++++++++++++++++++
 WAVELENGTHRANGE reference files are in ASDF format, with the format and contents
-specified by the `~jwst.datamodels.WavelengthrangeModel` data model schema.
+specified by the `~stdatamodels.jwst.datamodels.WavelengthrangeModel` data model schema.
 The exact content varies a bit depending on instrument mode, as explained in the
 following sections.
 
@@ -68,4 +68,3 @@ and filters that are valid with the file.
 :wavelengthrange: A list containing the list of [order, filter, wavelength min, wavelength max]
 :waverange_selector: The list of FILTER names available
 :extract_orders: A list containing the list of orders to extract for each filter
-

--- a/docs/jwst/resample/main.rst
+++ b/docs/jwst/resample/main.rst
@@ -55,10 +55,10 @@ sum.  The process is:
 
 #. Square the resampled read noise to make a variance array.
 
-   a. If the resampling `weight_type` is an inverse variance map (`ivm`), weight
+   a. If the resampling ``weight_type`` is an inverse variance map (``ivm``), weight
       the resampled variance by the square of its own inverse.
 
-   #. If the `weight_type` is the exposure time (`exptime`), weight the
+   #. If the ``weight_type`` is the exposure time (``exptime``), weight the
       resampled variance by the square of the exposure time for the image.
 
 #. Add the weighted, resampled read noise variance to a running sum across all
@@ -143,8 +143,7 @@ context array ``con``, one can do something like this:
     >>> np.flatnonzero([v & (1 << k) for v in con[:, y, x] for k in range(32)])
 
 For convenience, this functionality was implemented in the
-:py:func:`~drizzle.utils.decode_context` function.
-
+:func:`~drizzle.utils.decode_context` function.
 
 References
 ----------

--- a/docs/jwst/resample_spec/index.rst
+++ b/docs/jwst/resample_spec/index.rst
@@ -14,4 +14,4 @@ Resampling Spectral Data
    resample_spec.rst
 
 See the :ref:`resample step <resample_step>` for full API documentation
-for the the `resample` module.
+for the the ``resample`` module.

--- a/docs/jwst/residual_fringe/main.rst
+++ b/docs/jwst/residual_fringe/main.rst
@@ -1,7 +1,7 @@
 Description
 ===========
 
-:Class: `jwst.residual_fringe.ResidualFringeStep`
+:Class: `jwst.residual_fringe.residual_fringe_step.ResidualFringeStep`
 :Alias: residual_fringe
 
 The JWST pipeline contains multiple steps to mitigate the impact of fringing on science spectra, which
@@ -31,15 +31,15 @@ The ``residual_fringe`` step can accept several different forms of input data, i
 
 #. a single file containing a 2-D IFU image
 
-#. a data model (`~jwst.datamodels.IFUImageModel`) containing a 2-D IFU image
+#. a data model (`~stdatamodels.jwst.datamodels.IFUImageModel`) containing a 2-D IFU image
 
 #. an association table (in json format) containing a single input file
-   
+
 The second of the residual fringe correction steps is a 1-D correction  that can be applied to one-dimensional
 spectra extracted from MRS data cubes by setting the optional parameter ``extract_1d.ifu_rfcorr = True``
 in the :ref:`extract_1d <extract_1d_step>` step.  Empirically, the 1-D correction step has been found to work
 better than the 2-D correction step if it is applied to per-band spectra.
-For more details on this step see :ref:`extract_1d <extract_1d_step>` step. 
+For more details on this step see :ref:`extract_1d <extract_1d_step>` step.
 
 
 Assumptions
@@ -67,6 +67,3 @@ The residual fringes are corrected for by fitting and removing sinusoidal gain t
 While the fringe frequencies are well known, amplitudes can vary due to beating between the different fringe components
 and additionally are sensitive to the detailed location and intensity of objects within a given astronomical scene.
 Fringing thus cannot be corrected in its entirety for an arbitrary astronomical scene without forward modeling.
-
-
-

--- a/docs/jwst/stack_refs/description.rst
+++ b/docs/jwst/stack_refs/description.rst
@@ -21,7 +21,7 @@ Inputs
 
 3D calibrated images
 ^^^^^^^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _calints
 
 The inputs to the ``stack_refs`` step are multiple calibrated products for the PSF
@@ -34,7 +34,7 @@ It is assumed that the ``stack_refs`` step will be called from the
 specifying one or more PSF target exposures.
 The actual input passed to the ``stack_refs`` step will be a `~jwst.datamodels.container.ModelContainer`
 created by the :ref:`calwebb_coron3 <calwebb_coron3>` pipeline, containing a
-`~jwst.datamodels.CubeModel` data model for each PSF "_calints" exposure listed in the
+`~stdatamodels.jwst.datamodels.CubeModel` data model for each PSF "_calints" exposure listed in the
 ASN file. See :ref:`calwebb_coron3 <calwebb_coron3>` for more details on the contents of
 the ASN file.
 
@@ -43,7 +43,7 @@ Outputs
 
 3D PSF image stack
 ^^^^^^^^^^^^^^^^^^
-:Data model: `~jwst.datamodels.CubeModel`
+:Data model: `~stdatamodels.jwst.datamodels.CubeModel`
 :File suffix: _psfstack
 
 The output of the ``stack_refs`` step will be a single 3D product containing a stack of

--- a/docs/jwst/stpipe/devel_io_design.rst
+++ b/docs/jwst/stpipe/devel_io_design.rst
@@ -127,7 +127,7 @@ is expected to accept other object types as well.
 
 A ``Step``'s primary argument is expected to be either a string containing
 the file path to a data file, or a JWST
-:class:`~jwst.datamodels.JwstDataModel` object. The method
+:class:`~stdatamodels.jwst.datamodels.JwstDataModel` object. The method
 :meth:`~stpipe.Step.open_model` handles either type of
 input, returning a ``DataModel`` from the specified file or a shallow
 copy of the ``DataModel`` that was originally passed to it. A typical

--- a/docs/jwst/wfs_combine/main.rst
+++ b/docs/jwst/wfs_combine/main.rst
@@ -71,7 +71,7 @@ Inputs
 2D calibrated images
 ^^^^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.ImageModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`
 :File suffix: _cal
 
 The input to ``wfs_combine`` is a pair of calibrated ("_cal") exposures, specified
@@ -84,7 +84,7 @@ Outputs
 2D combined image
 ^^^^^^^^^^^^^^^^^
 
-:Data model: `~jwst.datamodels.ImageModel`
+:Data model: `~stdatamodels.jwst.datamodels.ImageModel`
 :File suffix: _wfscmb
 
 The output is the combined image, using the product type suffix "_wfscmb."

--- a/docs/jwst/wfss_contam/description.rst
+++ b/docs/jwst/wfss_contam/description.rst
@@ -87,7 +87,7 @@ Outputs
 There is one primary output and two optional outputs from the step:
 
 1. The primary output is the contamination-corrected grism data, in the form of a
-   `~jwst.datamodels.MultiSlitModel` data model. In the :ref:`calwebb_spec2 <calwebb_spec2>`
+   `~stdatamodels.jwst.datamodels.MultiSlitModel` data model. In the :ref:`calwebb_spec2 <calwebb_spec2>`
    pipeline flow, this data model is passed along to the :ref:`photom <photom_step>` step
    for further processing.
 2. If the step argument ``--save_simulated_image`` is set to `True`, the full-frame

--- a/jwst/ami/ami_average_step.py
+++ b/jwst/ami/ami_average_step.py
@@ -49,7 +49,7 @@ class AmiAverageStep(Step):
 
         Returns
         -------
-        result : `~jwst.datamodels.AmiLgModel`
+        result : `~stdatamodels.jwst.datamodels.AmiLgModel`
             Averaged AMI data model
         """
         # Input may be a simple list if run in interactive environment,

--- a/jwst/ami/ami_normalize_step.py
+++ b/jwst/ami/ami_normalize_step.py
@@ -21,14 +21,14 @@ class AmiNormalizeStep(Step):
 
         Parameters
         ----------
-        target : str or `~jwst.datamodels.JwstDataModel`
+        target : str or `~stdatamodels.jwst.datamodels.JwstDataModel`
             Target input
-        reference : str or `~jwst.datamodels.JwstDataModel`
+        reference : str or `~stdatamodels.jwst.datamodels.JwstDataModel`
             Reference input
 
         Returns
         -------
-        result : `~jwst.datamodels.AmiOIModel`
+        result : `~stdatamodels.jwst.datamodels.AmiOIModel`
             AMI data model that's been normalized
         """
         # Open the target and reference input models

--- a/jwst/assign_wcs/niriss.py
+++ b/jwst/assign_wcs/niriss.py
@@ -61,7 +61,7 @@ def niriss_soss_set_input(model, order_number):
 
     Parameters
     ----------
-    model : `~jwst.datamodels.ImageModel`
+    model : `~stdatamodels.jwst.datamodels.ImageModel`
         An instance of an ImageModel
     order_number : int
         The spectral order

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -1056,7 +1056,7 @@ def update_fits_wcsinfo(
 
     Parameters
     ----------
-    datamodel : `~jwst.datamodels.ImageModel`
+    datamodel : `~stdatamodels.jwst.datamodels.ImageModel`
         The input data model for imaging or WFSS mode whose ``meta.wcsinfo``
         field should be updated from GWCS. By default, ``datamodel.meta.wcs``
         is used to compute FITS WCS + SIP approximation. When ``imwcs`` is

--- a/jwst/datamodels/library.py
+++ b/jwst/datamodels/library.py
@@ -92,7 +92,7 @@ class ModelLibrary(AbstractModelLibrary):
 
         Notes
         -----
-        Library does NOT need to be open (i.e., this can be called outside the `with` context)
+        Library does NOT need to be open (i.e., this can be called outside the ``with`` context)
         """
         return [
             i

--- a/jwst/datamodels/source_container.py
+++ b/jwst/datamodels/source_container.py
@@ -15,8 +15,8 @@ class SourceModelContainer(ModelContainer):
 
     The ``MultiExposureModel.exposures`` list contains the data for each exposure
     from a common slit id. Though the information is the same, the structures
-    are not true `~jwst.datamodels.SlitModel` instances. This container creates a
-    `~jwst.datamodels.SlitModel`
+    are not true `~stdatamodels.jwst.datamodels.SlitModel` instances. This container creates a
+    `~stdatamodels.jwst.datamodels.SlitModel`
     wrapper around each exposure, such that pipeline code can treat each
     as a `~stdatamodels.DataModel`.
     """
@@ -60,7 +60,7 @@ class SourceModelContainer(ModelContainer):
 
         Returns
         -------
-        `~jwst.datamodels.MultiExposureModel`
+        `~stdatamodels.jwst.datamodels.MultiExposureModel`
             The MultiExposureModel being wrapped, be updated with any new data in the container.
         """
         # Reapply models back to the exposures

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1469,7 +1469,8 @@ def create_extraction(
     are determined collectively, then multiple integrations, if present,
     are each extracted separately.
 
-    The output model must be a `MultiSpecModel` or `TSOMultiSpecModel`,
+    The output model must be a `~stdatamodels.jwst.datamodels.MultiSpecModel`
+    or `~stdatamodels.jwst.datamodels.TSOMultiSpecModel`,
     created before calling this function, and passed as ``output_model``.
     It is updated in place, with new spectral tables appended as they are created.
 
@@ -1495,7 +1496,7 @@ def create_extraction(
        5. Set a DQ array, with DO_NOT_USE flags set where the
           flux is NaN.
        6. Create a spectral table to contain all extracted values
-          and store it in a `SpecModel`.
+          and store it in a `~stdatamodels.jwst.datamodels.SpecModel`.
        7. Apply the aperture correction to the spectral table, if
           available.
        8. Append the new SpecModel to the output_model.

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -340,13 +340,13 @@ class Extract1dStep(Step):
 
         Parameters
         ----------
-        input_data : DataModel
+        input_data : `~stdatamodels.DataModel`
             The input model.
 
         Returns
         -------
-        DataModel
-            This will be `input_model` if the step was skipped; otherwise,
+        `~stdatamodels.DataModel`
+            This will be input model if the step was skipped; otherwise,
             it will be a model containing 1-D extracted spectra.
         """
         # Open the input and figure out what type of model it is

--- a/jwst/extract_1d/psf_profile.py
+++ b/jwst/extract_1d/psf_profile.py
@@ -214,7 +214,7 @@ def psf_profile(
     subtraction.  The location of the positive trace should be provided in the
     `trace` input parameter; the negative trace location will be guessed from
     the input metadata. If a negative trace is modeled, it is recommended that
-    `optimize_shifts` also be set to True, to improve the initial guess for the
+    ``optimize_shifts`` also be set to True, to improve the initial guess for the
     trace location.
 
     Parameters
@@ -234,7 +234,7 @@ def psf_profile(
     optimize_shifts : bool, optional
         If True, the spatial location of the trace will be optimized by
         minimizing the residuals in a scene model compared to the data in
-        the first integration of `input_model`.
+        the first integration of ``input_model``.
     model_nod_pair : bool, optional
         If True, and if background subtraction has taken place, a negative
         PSF will be modeled at the mirrored spatial location of the positive

--- a/jwst/extract_1d/soss_extract/pastasoss.py
+++ b/jwst/extract_1d/soss_extract/pastasoss.py
@@ -537,12 +537,12 @@ def get_soss_wavemaps(
 
     Returns
     -------
-    wavemaps : np.ndarray
+    wavemaps : ndarray
         The 2D wavemaps. Will have shape (n_orders, array_x, array_y) with orders 1, 2, etc. being
         the elements of the first dimension. Wavemaps for all orders defined in the reference file
         will be returned.
-    traces : np.ndarray, optional
-        The corresponding 1D traces (if `spectraces` is True).
+    traces : ndarray, optional
+        The corresponding 1D traces (if ``spectraces`` is True).
     """
     if refmodel is None:
         refmodel = retrieve_default_pastasoss_model()

--- a/jwst/extract_1d/source_location.py
+++ b/jwst/extract_1d/source_location.py
@@ -102,16 +102,16 @@ def location_from_wcs(input_model, slit, make_trace=True):
 
     Parameters
     ----------
-    input_model : DataModel
+    input_model : `~stdatamodels.DataModel`
         The input science model containing metadata information.
-    slit : DataModel or None
+    slit : `~stdatamodels.DataModel` or None
         One slit from a MultiSlitModel (or similar), or None.
-        The WCS and target coordinates will be retrieved from `slit`
-        unless `slit` is None. In that case, they will be retrieved
-        from `input_model`.
+        The WCS and target coordinates will be retrieved from ``slit``
+        unless ``slit`` is None. In that case, they will be retrieved
+        from ``input_model``.
     make_trace : bool, optional
         If True, the source position will be calculated for each
-        dispersion element and returned in `trace`.  If False,
+        dispersion element and returned in ``trace``.  If False,
         None is returned.
 
     Returns
@@ -122,9 +122,9 @@ def location_from_wcs(input_model, slit, make_trace=True):
         bounding box.  This is the point at which to determine the
         nominal extraction location, in case it varies along the
         spectrum.  The offset will then be the difference between
-        `location` (below) and the nominal location.
+        ``location`` (below) and the nominal location.
     middle_wl : float or None
-        The wavelength at pixel `middle`.
+        The wavelength at pixel ``middle``.
     location : float or None
         Pixel coordinate in the cross-dispersion direction within the
         spectral image that is at the planned target location.
@@ -133,7 +133,7 @@ def location_from_wcs(input_model, slit, make_trace=True):
         An array of source positions, one per dispersion element, corresponding
         to the location at each point in the wavelength array. If the
         input data is resampled, the trace corresponds directly to the
-        location. If the trace could not be generated, or `make_trace` is
+        location. If the trace could not be generated, or ``make_trace`` is
         False, None is returned.
     """
     if slit is not None:

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -476,10 +476,10 @@ class TransformParameters:
     #: If no telemetry can be found during the observation,
     #: the time, in seconds, beyond the observation time to search for telemetry.
     tolerance: float = 60.0
-    #: The date of observation (`jwst.datamodels.JwstDataModel.meta.date`)
+    #: The date of observation (``stdatamodels.jwst.datamodels.JwstDataModel.meta.date``)
     useafter: str | None = None
     #: V3 position angle at Guide Star
-    # (`jwst.datamodels.JwstDataModel.meta.guide_star.gs_v3_pa_science`)
+    # (``stdatamodels.jwst.datamodels.JwstDataModel.meta.guide_star.gs_v3_pa_science``)
     v3pa_at_gs: float | None = None
 
     def as_reprdict(self):
@@ -532,10 +532,12 @@ def add_wcs(
     allow_any_file : bool
         Attempt to add the WCS information to any type of file.
         The default, `False`, only allows modifications of files that contain
-        known datamodels of `Level1bmodel`, `ImageModel`, or `CubeModel`.
+        known datamodels of `~stdatamodels.jwst.datamodels.Level1bModel`,
+        `~stdatamodels.jwst.datamodels.ImageModel`, or
+        `~stdatamodels.jwst.datamodels.CubeModel`.
 
     force_level1bmodel : bool
-        If not `allow_any_file`, and the input file model is unknown,
+        If not ``allow_any_file``, and the input file model is unknown,
         open the input file as a Level1bModel regardless.
 
     default_pa_v3 : float
@@ -543,11 +545,11 @@ def add_wcs(
         is not found.
 
     siaf_path : str or file-like object or None
-        The path to the SIAF database. See `SiafDb` for more information.
+        The path to the SIAF database. See ``SiafDb`` for more information.
 
     prd : str
-        The PRD version from the `pysiaf` to use.
-        `siaf_path` overrides this value.
+        The PRD version from the ``pysiaf`` to use.
+        ``siaf_path`` overrides this value.
 
     engdb_url : str or None
         URL of the engineering telemetry database REST interface.
@@ -584,7 +586,7 @@ def add_wcs(
     allowed to be updated. These have the suffixes of "uncal", "rate", and
     "rateints" representing datamodels Level1bModel, ImageModel, and CubeModel.
     Any higher level product, from Stage 2b and beyond, that has had the
-    `assign_wcs` step applied, have improved WCS information. Running
+    ``assign_wcs`` step applied, have improved WCS information. Running
     this task on such files will potentially corrupt the WCS.
 
     It starts by populating the headers with values from the SIAF database.
@@ -739,7 +741,7 @@ def update_wcs(
     """
     Update WCS pointing information.
 
-    Given a `jwst.datamodels.JwstDataModel`, determine the simple WCS parameters
+    Given a `~stdatamodels.jwst.datamodels.JwstDataModel`, determine the simple WCS parameters
     from the SIAF keywords in the model and the engineering parameters
     that contain information about the telescope pointing.
 
@@ -747,7 +749,7 @@ def update_wcs(
 
     Parameters
     ----------
-    model : `~jwst.datamodels.JwstDataModel`
+    model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The model to update.
 
     default_roll_ref : float
@@ -755,11 +757,11 @@ def update_wcs(
         use this as the roll ref angle.
 
     siaf_path : str or Path-like object
-        The path to the SIAF database. See `SiafDb` for more information.
+        The path to the SIAF database. See ``SiafDb`` for more information.
 
     prd : str
-        The PRD version from the `pysiaf` to use.
-        `siaf_path` overrides this value.
+        The PRD version from the ``pysiaf`` to use.
+        ``siaf_path`` overrides this value.
 
     engdb_url : str or None
         URL of the engineering telemetry database REST interface.
@@ -789,7 +791,7 @@ def update_wcs(
         The parameters and transforms calculated. May be
         None for either if telemetry calculations were not
         performed. In particular, FGS GUIDER data does
-        not need `transforms`.
+        not need ``transforms``.
     """
     t_pars = transforms = None  # Assume telemetry is not used.
 
@@ -847,7 +849,7 @@ def update_wcs_from_fgs_guiding(
 
     Parameters
     ----------
-    model : `~jwst.datamodels.JwstDataModel`
+    model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The model to update.
 
     t_pars : `TransformParameters`
@@ -893,7 +895,7 @@ def update_wcs_from_telem(model, t_pars: TransformParameters):
     """
     Update WCS pointing information.
 
-    Given a `jwst.datamodels.JwstDataModel`, determine the simple WCS parameters
+    Given a `~stdatamodels.jwst.datamodels.JwstDataModel`, determine the simple WCS parameters
     from the SIAF keywords in the model and the engineering parameters
     that contain information about the telescope pointing.
 
@@ -901,7 +903,7 @@ def update_wcs_from_telem(model, t_pars: TransformParameters):
 
     Parameters
     ----------
-    model : `~jwst.datamodels.JwstDataModel`
+    model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The model to update. The update is done in-place.
 
     t_pars : `TransformParameters`
@@ -1014,7 +1016,7 @@ def update_s_region(model, siaf):
 
     Parameters
     ----------
-    model : `~jwst.datamodels.JwstDataModel`
+    model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The model to update in-place.
     siaf : namedtuple
         The ``SIAF`` tuple with values populated from the PRD database.

--- a/jwst/lib/v1_calculate.py
+++ b/jwst/lib/v1_calculate.py
@@ -21,13 +21,13 @@ def v1_calculate_from_models(sources, siaf_path=None, **calc_wcs_from_time_kwarg
     Returns a table of V1 pointings for all input models.
     The table has the following columns:
 
-    * source (`jwst.datamodels.JwstDataModel`): The model.
+    * source (`~stdatamodels.jwst.datamodels.JwstDataModel`): The model.
     * obstime (`astropy.time.Time`): The observation time.
     * v1 (float, float, float): 3-tuple or RA, dec, and position angle.
 
     Parameters
     ----------
-    sources : [File-like or jwst.datamodels.Datamodel[...]]
+    sources : [File-like or stdatamodels.DataModel[...]]
         The datamodels to get timings other header parameters from.
 
     siaf_path : None or file-like

--- a/jwst/master_background/master_background_mos_step.py
+++ b/jwst/master_background/master_background_mos_step.py
@@ -77,21 +77,21 @@ class MasterBackgroundMosStep(Pipeline):
                 The master background information from a previous invocation of the step.
                 Keys are:
 
-                - "masterbkg_1d": `~jwst.datamodels.CombinedSpecModel`
+                - "masterbkg_1d": `~stdatamodels.jwst.datamodels.CombinedSpecModel`
                     The 1D version of the master background.
-                - "masterbkg_2d": `~jwst.datamodels.MultiSlitModel`
+                - "masterbkg_2d": `~stdatamodels.jwst.datamodels.MultiSlitModel`
                     The 2D slit-based version of the master background.
             use_correction_pars : bool
                 Use the corrections stored in `correction_pars`.
 
         Parameters
         ----------
-        data : `~jwst.datamodels.MultiSlitModel`
+        data : `~stdatamodels.jwst.datamodels.MultiSlitModel`
             The data to operate on.
 
         Returns
         -------
-        result : `~jwst.datamodels.MultiSlitModel`
+        result : `~stdatamodels.jwst.datamodels.MultiSlitModel`
             The background corrected data.
 
         Notes
@@ -214,7 +214,7 @@ class MasterBackgroundMosStep(Pipeline):
 
         Parameters
         ----------
-        data : `~jwst.datamodels.MultiSlitModel`
+        data : `~stdatamodels.jwst.datamodels.MultiSlitModel`
             The data to operate on.
 
         Returns
@@ -239,9 +239,9 @@ class MasterBackgroundMosStep(Pipeline):
 
         Parameters
         ----------
-        data : `~jwst.datamodels.MultiSlitModel`
+        data : `~stdatamodels.jwst.datamodels.MultiSlitModel`
             The data to operate on.
-        user_background : None, str, or `~jwst.datamodels.CombinedSpecModel`
+        user_background : None, str, or `~stdatamodels.jwst.datamodels.CombinedSpecModel`
             Optional user-supplied master background 1D spectrum, path to file
             or opened datamodel
         sigma_clip : None or float
@@ -253,13 +253,13 @@ class MasterBackgroundMosStep(Pipeline):
 
         Returns
         -------
-        masterbkg_1d : `~jwst.datamodels.CombinedSpecModel`
+        masterbkg_1d : `~stdatamodels.jwst.datamodels.CombinedSpecModel`
             The master background in 1d multislit format.
             None is returned when a master background could not be determined.
-        masterbkg_2d : `~jwst.datamodels.MultiSlitModel`
+        masterbkg_2d : `~stdatamodels.jwst.datamodels.MultiSlitModel`
             The master background in 2d, multislit format.
             None is returned when a master background could not be determined.
-        bkg_x1d_spectra : `~jwst.datamodels.MultiSlitModel`
+        bkg_x1d_spectra : `~stdatamodels.jwst.datamodels.MultiSlitModel`
             The 1D extracted background spectra used to determine the master background.
             Returns None when a user_background is provided.
         """

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -35,14 +35,16 @@ class MasterBackgroundStep(Step):
 
         Parameters
         ----------
-        input_data : `~jwst.datamodels.ImageModel`, `~jwst.datamodels.IFUImageModel`, \
+        input_data : `~stdatamodels.jwst.datamodels.ImageModel`, \
+                     `~stdatamodels.jwst.datamodels.IFUImageModel`, \
                      `~jwst.datamodels.container.ModelContainer`, str
             Input target datamodel(s) or association file to which master background
             subtraction is to be applied.
 
         Returns
         -------
-        result : `~jwst.datamodels.ImageModel`,  `~jwst.datamodels.IFUImageModel`, \
+        result : `~stdatamodels.jwst.datamodels.ImageModel`, \
+                 `~stdatamodels.jwst.datamodels.IFUImageModel`, \
                  `~jwst.datamodels.container.ModelContainer`
             The background-subtracted science datamodel(s)
         """
@@ -327,16 +329,18 @@ def subtract_2d_background(source, background):
 
     Parameters
     ----------
-    source : `~jwst.datamodels.JwstDataModel` or `~jwst.datamodels.container.ModelContainer`
+    source : `~stdatamodels.jwst.datamodels.JwstDataModel` or \
+             `~jwst.datamodels.container.ModelContainer`
         The input science data.
-    background : `~jwst.datamodels.JwstDataModel`
+    background : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The input background data.  Must be the same datamodel type as `source`.
-        For a `~jwst.datamodels.container.ModelContainer`, the source and background
+        For a `~jwst.datamodels.container.ModelContainer`,
+        the source and background
         models in the input containers must match one-to-one.
 
     Returns
     -------
-    `~jwst.datamodels.JwstDataModel`
+    `~stdatamodels.jwst.datamodels.JwstDataModel`
         Background subtracted from source.
     """
 

--- a/jwst/model_blender/blender.py
+++ b/jwst/model_blender/blender.py
@@ -58,7 +58,7 @@ class ModelBlender:
 
         Parameters
         ----------
-        model : `jwst.datamodels.JwstDataModel`
+        model : `~stdatamodels.jwst.datamodels.JwstDataModel`
             The datamodel to blend.
         """
         if self._first_header_meta is None:
@@ -133,7 +133,7 @@ class ModelBlender:
 
         Parameters
         ----------
-        model : `jwst.datamodels.JwstDataModel`
+        model : `~stdatamodels.jwst.datamodels.JwstDataModel`
             A datamodel that will have its metadata set
             to the blended metadata and have the metadata
             table assigned to the "hdrtab" attribute.

--- a/jwst/nsclean/nsclean_step.py
+++ b/jwst/nsclean/nsclean_step.py
@@ -41,12 +41,14 @@ class NSCleanStep(Step):
 
         Parameters
         ----------
-        input_data : `~jwst.datamodels.ImageModel`, `~jwst.datamodels.IFUImageModel`
+        input_data : `~stdatamodels.jwst.datamodels.ImageModel`, \
+                     `~stdatamodels.jwst.datamodels.IFUImageModel`
             Input datamodel to be corrected.
 
         Returns
         -------
-        output_model : `~jwst.datamodels.ImageModel`, `~jwst.datamodels.IFUImageModel`
+        output_model : `~stdatamodels.jwst.datamodels.ImageModel`, \
+                       `~stdatamodels.jwst.datamodels.IFUImageModel`
             The 1/f corrected datamodel.
         """
         message = (

--- a/jwst/pipeline/calwebb_coron3.py
+++ b/jwst/pipeline/calwebb_coron3.py
@@ -24,12 +24,12 @@ def to_container(model):
 
     Parameters
     ----------
-    model : CubeModel
+    model : `~stdatamodels.jwst.datamodels.CubeModel`
         The input model to convert
 
     Returns
     -------
-    container : ModelContainer
+    container : `~jwst.datamodels.container.ModelContainer`
         The container of ImageModels
     """
     container = ModelContainer()
@@ -96,7 +96,7 @@ class Coron3Pipeline(Pipeline):
 
         Parameters
         ----------
-        user_input : str, Level3 Association, or `~jwst.datamodels.JwstDataModel`
+        user_input : str, Level3 Association, or `~stdatamodels.jwst.datamodels.JwstDataModel`
             The exposure or association of exposures to process
         """
         log.info("Starting calwebb_coron3 ...")

--- a/jwst/pipeline/calwebb_dark.py
+++ b/jwst/pipeline/calwebb_dark.py
@@ -58,7 +58,7 @@ class DarkPipeline(Pipeline):
 
         Parameters
         ----------
-        input_data : str or `~jwst.datamodels.RampModel`
+        input_data : str or `~stdatamodels.jwst.datamodels.RampModel`
             The input data to process. If a string, it is assumed
             to be a filename pointing to a RampModel.
 

--- a/jwst/pipeline/calwebb_detector1.py
+++ b/jwst/pipeline/calwebb_detector1.py
@@ -79,12 +79,12 @@ class Detector1Pipeline(Pipeline):
 
         Parameters
         ----------
-        input_data : str or `~jwst.datamodels.RampModel`
+        input_data : str or `~stdatamodels.jwst.datamodels.RampModel`
             The input data to process.
 
         Returns
         -------
-        `~jwst.datamodels.JwstDataModel`
+        `~stdatamodels.jwst.datamodels.JwstDataModel`
             The calibrated data model.
         """
         log.info("Starting calwebb_detector1 ...")
@@ -187,7 +187,7 @@ class Detector1Pipeline(Pipeline):
 
         Parameters
         ----------
-        input_data : `~jwst.datamodels.JwstDataModel`
+        input_data : `~stdatamodels.jwst.datamodels.JwstDataModel`
             The output data product from the Detector1 pipeline
         """
         if input_data is None:

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -105,12 +105,13 @@ class Spec2Pipeline(Pipeline):
 
         Parameters
         ----------
-        data : str, Level2 Association, or `~jwst.datamodels.JwstDataModel`
+        data : str, Level2 Association, or \
+               `~stdatamodels.jwst.datamodels.JwstDataModel`
             The exposure or association of exposures to process
 
         Returns
         -------
-        list[JWSTDataModel]
+        list of `~stdatamodels.jwst.datamodels.JwstDataModel`
             The calibrated data models.
         """
         log.info("Starting calwebb_spec2 ...")
@@ -198,7 +199,7 @@ class Spec2Pipeline(Pipeline):
 
         Returns
         -------
-        JWSTDataModel
+        `~stdatamodels.jwst.datamodels.JwstDataModel`
             The final calibrated product.
         """
         # Find all the member types in the product
@@ -467,7 +468,7 @@ class Spec2Pipeline(Pipeline):
         ----------
         exp_type : str
             The exposure type of the data.
-        science : JWSTDataModel
+        science : `~stdatamodels.jwst.datamodels.JwstDataModel`
             The input science data model.
         members_by_type : dict
             Dictionary of members in the association, keyed by type.
@@ -596,12 +597,12 @@ class Spec2Pipeline(Pipeline):
 
         Parameters
         ----------
-        data : JWSTDataModel
+        data : `~stdatamodels.jwst.datamodels.JwstDataModel`
             The input science data model.
 
         Returns
         -------
-        JWSTDataModel
+        `~stdatamodels.jwst.datamodels.JwstDataModel`
             The calibrated data model.
         """
         # Apply flat-field correction
@@ -667,12 +668,12 @@ class Spec2Pipeline(Pipeline):
 
         Parameters
         ----------
-        data : JWSTDataModel
+        data : `~stdatamodels.jwst.datamodels.JwstDataModel`
             The input science data model.
 
         Returns
         -------
-        JWSTDataModel
+        `~stdatamodels.jwst.datamodels.JwstDataModel`
             The calibrated data model.
         """
         calibrated = self.extract_2d.run(data)
@@ -702,12 +703,12 @@ class Spec2Pipeline(Pipeline):
 
         Parameters
         ----------
-        data : JWSTDataModel
+        data : `~stdatamodels.jwst.datamodels.JwstDataModel`
             The input science data model.
 
         Returns
         -------
-        JWSTDataModel
+        `~stdatamodels.jwst.datamodels.JwstDataModel`
             The calibrated data model
         """
         calibrated = self.extract_2d.run(data)
@@ -784,12 +785,12 @@ class Spec2Pipeline(Pipeline):
 
         Parameters
         ----------
-        data : JWSTDataModel
+        data : `~stdatamodels.jwst.datamodels.JwstDataModel`
             The input science data model.
 
         Returns
         -------
-        JWSTDataModel
+        `~stdatamodels.jwst.datamodels.JwstDataModel`
             The calibrated data model
         """
         calibrated = self.srctype.run(data)
@@ -807,12 +808,12 @@ class Spec2Pipeline(Pipeline):
 
         Parameters
         ----------
-        data : JWSTDataModel
+        data : `~stdatamodels.jwst.datamodels.JwstDataModel`
             The input science data model.
 
         Returns
         -------
-        JWSTDataModel
+        `~stdatamodels.jwst.datamodels.JwstDataModel`
             The calibrated data model
         """
         calibrated = self.srctype.run(data)
@@ -832,12 +833,12 @@ class Spec2Pipeline(Pipeline):
 
         Parameters
         ----------
-        resampled : JWSTDataModel
+        resampled : `~stdatamodels.jwst.datamodels.JwstDataModel`
             The resampled data model from which to update the metadata of the output
 
         Returns
         -------
-        MultiSpecModel
+        `~stdatamodels.jwst.datamodels.MultiSpecModel`
             The extracted 1D spectra
         """
         # Check for fixed slits mixed in with MSA spectra:

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -73,7 +73,8 @@ class Spec3Pipeline(Pipeline):
 
         Parameters
         ----------
-        input_data : str, Level3 Association, or `~jwst.datamodels.JwstDataModel`
+        input_data : str, Level3 Association, or \
+                     `~stdatamodels.jwst.datamodels.JwstDataModel`
             The exposure or association of exposures to process
         """
         log.info("Starting calwebb_spec3 ...")
@@ -412,11 +413,11 @@ class Spec3Pipeline(Pipeline):
 
         Parameters
         ----------
-        wfss_model : ~datamodels.WfssMultiExposureModel
+        wfss_model : `~stdatamodels.jwst.datamodels.WFSSMultiSpecModel`
             The newly generated WfssMultiExposureModel made as part of
             the save operation for spec3 processing of WFSS data.
 
-        cal_model_list : list(~datamodels.MultiSlitModel)
+        cal_model_list : list of `~stdatamodels.jwst.datammodels.MultiSlitModel`
             The list of input_models provided to Spec3Pipeline by the
             input association.
         """

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -63,7 +63,7 @@ class ResampleImage(Resample):
         Parameters
         ----------
         input_models : `~jwst.datamodels.library.ModelLibrary`
-            A ``~jwst.datamodels.library.ModelLibrary`-based object allowing iterating over
+            A `~jwst.datamodels.library.ModelLibrary`-based object allowing iterating over
             all contained models of interest.
 
         pixfrac : float, optional
@@ -133,9 +133,9 @@ class ResampleImage(Resample):
 
             Finally, instead of integers, ``good_bits`` can be a string of
             comma-separated mnemonics. For example, for JWST, all the following
-            specifications are equivalent:
+            specifications are equivalent::
 
-            ``"12" == "4+8" == "4, 8" == "JUMP_DET, DROPOUT"``
+                "12" == "4+8" == "4, 8" == "JUMP_DET, DROPOUT"
 
             In order to "translate" mnemonic code to integer bit flags,
             ``Resample.dq_flag_name_map`` attribute must be set to either

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -62,8 +62,8 @@ class ResampleImage(Resample):
 
         Parameters
         ----------
-        input_models : ModelLibrary
-            A `ModelLibrary`-based object allowing iterating over
+        input_models : `~jwst.datamodels.library.ModelLibrary`
+            A ``~jwst.datamodels.library.ModelLibrary`-based object allowing iterating over
             all contained models of interest.
 
         pixfrac : float, optional
@@ -135,7 +135,7 @@ class ResampleImage(Resample):
             comma-separated mnemonics. For example, for JWST, all the following
             specifications are equivalent:
 
-            `"12" == "4+8" == "4, 8" == "JUMP_DET, DROPOUT"`
+            ``"12" == "4+8" == "4, 8" == "JUMP_DET, DROPOUT"``
 
             In order to "translate" mnemonic code to integer bit flags,
             ``Resample.dq_flag_name_map`` attribute must be set to either
@@ -156,7 +156,7 @@ class ResampleImage(Resample):
             pixels will be assigned zero weight and thus these pixels
             will not contribute to the output resampled data array.
 
-            Set `good_bits` to `None` to turn off the use of model's DQ
+            Set ``good_bits`` to `None` to turn off the use of model's DQ
             array.
 
             For more details, see documentation for
@@ -372,12 +372,12 @@ class ResampleImage(Resample):
 
         Parameters
         ----------
-        ref_input_model : `~jwst.datamodels.JwstDataModel`, optional
+        ref_input_model : `~stdatamodels.jwst.datamodels.JwstDataModel`, optional
             The reference input model from which to copy meta data.
 
         Returns
         -------
-        ImageModel
+        `~stdatamodels.jwst.datamodels.ImageModel`
             A new blank model with updated meta data.
         """
         output_model = datamodels.ImageModel(None)  # tuple(self.output_wcs.array_shape))
@@ -475,11 +475,12 @@ class ResampleImage(Resample):
 
     def reset_arrays(self, n_input_models=None):
         """
-        Initialize/reset between finalize() and add_model() calls.
+        Initialize/reset between ``finalize()`` and ``add_model()`` calls.
 
-        Resets or re-initializes `Drizzle` objects, `ModelBlender`, output model
+        Resets or re-initializes `~drizzle.resample.Drizzle` objects,
+        `~jwst.model_blender.blender.ModelBlender`, output model
         and arrays, and time counters. Output WCS and shape are not modified
-        from `Resample` object initialization. This method needs to be called
+        from ``Resample`` object initialization. This method needs to be called
         before calling :py:meth:`add_model` for the first time after
         :py:meth:`finalize` was previously called.
 
@@ -569,7 +570,7 @@ class ResampleImage(Resample):
         """
         Resample many inputs to many outputs where outputs have a common frame.
 
-        Coadd only different detectors of the same exposure, i.e. map NRCA5 and
+        Coadd only different detectors of the same exposure, i.e., map NRCA5 and
         NRCB5 onto the same output image, as they image different areas of the
         sky.
 
@@ -578,15 +579,17 @@ class ResampleImage(Resample):
         Parameters
         ----------
         in_memory : bool, optional
-            Indicates whether to return a `ModelLibrary` with resampled models
+            Indicates whether to return a
+            `~jwst.datamodels.library.ModelLibrary` with resampled models
             loaded in memory or whether to serialize resampled models to
-            files on disk and return a `ModelLibrary` with only the associacion
-            info. See https://stpipe.readthedocs.io/en/latest/model_library.html#on-disk-mode
+            files on disk and return a `~jwst.datamodels.library.ModelLibrary`
+            with only the association
+            info. See :ref:`stpipe:library_on_disk`
             for more details.
 
         Returns
         -------
-        ModelLibrary
+        `~jwst.datamodels.library.ModelLibrary`
             A library of resampled models.
         """
         output_models = []
@@ -623,7 +626,7 @@ class ResampleImage(Resample):
 
         Returns
         -------
-        ImageModel
+        `~stdatamodels.jwst.datamodels.ImageModel`
             The resampled and coadded image.
         """
         log.info("Resampling science and variance data")
@@ -646,7 +649,7 @@ class ResampleImage(Resample):
 
         Parameters
         ----------
-        model : ImageModel
+        model : `~stdatamodels.jwst.datamodels.ImageModel`
             The resampled image
         """
         # Delete any SIP-related keywords first

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -37,15 +37,15 @@ class ResampleSpec(ResampleImage):
 
     Notes
     -----
-    This routine performs the following operations::
+    This routine performs the following operations:
 
-      1. Extracts parameter settings from input model, such as pixfrac,
-         weight type, exposure time (if relevant), and kernel, and merges
-         them with any user-provided values.
-      2. Creates output WCS based on input images and define mapping function
-         between all input arrays and the output array.
-      3. Updates output data model with output arrays from drizzle, including
-         a record of metadata from all input models.
+    1. Extracts parameter settings from input model, such as pixfrac,
+       weight type, exposure time (if relevant), and kernel, and merges
+       them with any user-provided values.
+    2. Creates output WCS based on input images and define mapping function
+       between all input arrays and the output array.
+    3. Updates output data model with output arrays from drizzle, including
+       a record of metadata from all input models.
     """
 
     def __init__(self, input_models, good_bits=0, output_wcs=None, wcs_pars=None, **kwargs):
@@ -216,12 +216,12 @@ class ResampleSpec(ResampleImage):
 
         Parameters
         ----------
-        ref_input_model : `~jwst.datamodels.JwstDataModel`, optional
+        ref_input_model : `~stdatamodels.jwst.datamodels.JwstDataModel`, optional
             The reference input model from which to copy meta data.
 
         Returns
         -------
-        SlitModel
+        `~stdatamodels.jwst.datamodels.SlitModel`
             A new blank model with updated meta data.
         """
         output_model = datamodels.SlitModel(None)
@@ -237,7 +237,7 @@ class ResampleSpec(ResampleImage):
 
         Parameters
         ----------
-        model : SlitModel
+        model : `~stdatamodels.jwst.datamodels.SlitModel`
             The output model to be updated.
         info_dict : dict
             A dictionary containing information about the resampling process.
@@ -280,13 +280,13 @@ class ResampleSpec(ResampleImage):
 
         Frames available in the output WCS are:
 
-            - `detector`: image x, y
-            - `slit_frame`: slit x, slit y, wavelength
-            - `world`: RA, Dec, wavelength
+        - ``detector``: image x, y
+        - ``slit_frame``: slit x, slit y, wavelength
+        - ``world``: RA, Dec, wavelength
 
         Parameters
         ----------
-        refmodel : `~jwst.datamodels.JwstDataModel`, optional
+        refmodel : `~stdatamodels.jwst.datamodels.JwstDataModel`, optional
             The reference input image from which the fiducial WCS is created.
             If not specified, the first image in input_models. If the
             first model is empty (all-NaN or all-zero), the first non-empty
@@ -579,8 +579,8 @@ class ResampleSpec(ResampleImage):
 
         Frames available in the output WCS are:
 
-            - `detector`: image x, y
-            - `world`: RA, Dec, wavelength
+        - ``detector``: image x, y
+        - ``world``: RA, Dec, wavelength
 
         Parameters
         ----------
@@ -847,8 +847,8 @@ class ResampleSpec(ResampleImage):
 
         Frames available in the output WCS are:
 
-            - `detector`: image x, y
-            - `world`: MSA x, MSA y, wavelength
+        - ``detector``: image x, y
+        - ``world``: MSA x, MSA y, wavelength
 
         Parameters
         ----------

--- a/jwst/resample/resample_step.py
+++ b/jwst/resample/resample_step.py
@@ -51,15 +51,18 @@ class ResampleStep(Step):
 
         Parameters
         ----------
-        input_data : str, ImageModel, or any asn-type input loadable into ModelLibrary
-            Filename pointing to an ImageModel or an association, or the ImageModel or
-            association itself.
+        input_data : str, `~stdatamodels.jwst.datamodels.ImageModel`, \
+                     or any asn-type input loadable into \
+                     `~jwst.datamodels.library.ModelLibrary`
+            Filename pointing to an `~stdatamodels.jwst.datamodels.ImageModel`
+            or an association, or the object itself.
 
         Returns
         -------
-        ModelLibrary or ImageModel
-            The final output data. If the `single` parameter is set to True, then this
-            is a single ImageModel; otherwise, it is a ModelLibrary.
+        `~jwst.datamodels.library.ModelLibrary` or `~stdatamodels.jwst.datamodels.ImageModel`
+            The final output data. If the ``single`` parameter is set to True, then this
+            is a single `~jwst.datamodels.library.ModelLibrary`; otherwise, it is a
+            `~jwst.datamodels.library.ModelLibrary`.
 
         Notes
         -----

--- a/jwst/source_catalog/source_catalog_step.py
+++ b/jwst/source_catalog/source_catalog_step.py
@@ -81,8 +81,8 @@ class SourceCatalogStep(Step):
 
         Parameters
         ----------
-        input_model : str or `ImageModel`
-            A FITS filename or an `ImageModel` of a drizzled image.
+        input_model : str or `~stdatamodels.jwst.datamodels.ImageModel`
+            A FITS filename or an `~stdatamodels.jwst.datamodels.ImageModel` of a drizzled image.
 
         Returns
         -------

--- a/jwst/stpipe/utilities.py
+++ b/jwst/stpipe/utilities.py
@@ -136,11 +136,12 @@ def folder_traverse(folder_path, basename_regex=".+", path_exclude_regex="^$"):
 
 def record_step_status(datamodel, cal_step, success=True):
     """
-    Record whether or not a step completed in meta.cal_step.
+    Record whether or not a step completed in ``meta.cal_step``.
 
     Parameters
     ----------
-    datamodel : `~jwst.datamodels.JwstDataModel`, `~jwst.datamodels.container.ModelContainer`, \
+    datamodel : `~stdatamodels.jwst.datamodels.JwstDataModel`, \
+                `~jwst.datamodels.container.ModelContainer`, \
                 `~jwst.datamodels.library.ModelLibrary`
         This is the datamodel or container of datamodels to modify in place
 
@@ -173,12 +174,14 @@ def query_step_status(datamodel, cal_step):
     """
     Query the status of a step in meta.cal_step.
 
-    For container types (ModelContainer and ModelLibrary), only
+    For container types (`~jwst.datamodels.container.ModelContainer`
+    and `~jwst.datamodels.library.ModelLibrary`), only
     the first datamodel in the container is checked.
 
     Parameters
     ----------
-    datamodel : `~jwst.datamodels.JwstDataModel`, `~jwst.datamodels.container.ModelContainer`, \
+    datamodel : `~stdatamodels.jwst.datamodels.JwstDataModel`, \
+                `~jwst.datamodels.container.ModelContainer`, \
                 `~jwst.datamodels.library.ModelLibrary`
         The datamodel or container of datamodels to check
 
@@ -188,7 +191,7 @@ def query_step_status(datamodel, cal_step):
     Returns
     -------
     status : str
-        The status of the step in meta.cal_step, typically 'COMPLETE' or 'SKIPPED'
+        The status of the step in ``meta.cal_step``, typically 'COMPLETE' or 'SKIPPED'
 
     Notes
     -----

--- a/jwst/tso_photometry/tso_photometry_step.py
+++ b/jwst/tso_photometry/tso_photometry_step.py
@@ -34,12 +34,12 @@ class TSOPhotometryStep(Step):
 
     def process(self, input_data):
         """
-        Do the tso photometry processing.
+        Do the TSO photometry processing.
 
         Parameters
         ----------
-        input_data : str or CubeModel
-            Filename for a FITS image, or a `CubeModel`.
+        input_data : str or `~stdatamodels.jwst.datamodels.CubeModel`
+            Filename for a FITS image, or a `~stdatamodels.jwst.datamodels.CubeModel`.
 
         Returns
         -------
@@ -178,6 +178,22 @@ class TSOPhotometryStep(Step):
 
 
 def get_ref_data(reffile, pupil="ANY"):
+    """
+    Get reference data for TSO photometry.
+
+    Parameters
+    ----------
+    reffile : str
+        TSO photometry model reference file.
+
+    pupil : str
+        Pupil of interest.
+
+    Returns
+    -------
+    radius, radius_inner, radius_outer : float
+        Radii of associated with the given query.
+    """
     ref_model = TsoPhotModel(reffile)
     radii = ref_model.radii
     value = None

--- a/jwst/tweakreg/tweakreg_catalog.py
+++ b/jwst/tweakreg/tweakreg_catalog.py
@@ -345,8 +345,8 @@ def make_tweakreg_catalog(
 
     Parameters
     ----------
-    model : `~jwst.datamodels.ImageModel`
-        The input `~jwst.datamodels.ImageModel` of a single image.  The input image is
+    model : `~stdatamodels.jwst.datamodels.ImageModel`
+        The input `~stdatamodels.jwst.datamodels.ImageModel` of a single image.  The input image is
         assumed to be background subtracted.
     snr_threshold : float
         The signal-to-noise ratio per pixel above the ``background`` for

--- a/jwst/tweakreg/utils.py
+++ b/jwst/tweakreg/utils.py
@@ -128,9 +128,11 @@ def transfer_wcs_correction(to_image, from_image, matrix=None, shift=None):
     transformations in a reference tangent plane.
 
     .. warning::
-        Upon return, if the ``to_image`` argument is an `~jwst.datamodels.ImageModel` it will be
+        Upon return, if the ``to_image`` argument is an
+        `~stdatamodels.jwst.datamodels.ImageModel` it will be
         modified in-place with an updated ``ImageModel.meta.wcs`` WCS model.
-        If ``to_image`` argument is a file name of an `~jwst.datamodels.ImageModel`, that
+        If ``to_image`` argument is a file name of an
+        `~stdatamodels.jwst.datamodels.ImageModel`, that
         model will be read in, its WCS will be updated, and the updated model
         will be written out to the same file. BACKUP the file in ``to_image``
         argument before calling this function.
@@ -142,14 +144,14 @@ def transfer_wcs_correction(to_image, from_image, matrix=None, shift=None):
 
     Parameters
     ----------
-    to_image : str, `~jwst.datamodels.ImageModel`
+    to_image : str, `~stdatamodels.jwst.datamodels.ImageModel`
         Image model to which the correction should be applied/transferred to.
 
         .. warning::
             If it is a string file name then, upon return, this file
             will be **overwritten** with a data model with an updated WCS.
 
-    from_image : str, `~jwst.datamodels.ImageModel`, `gwcs.wcs.WCS`
+    from_image : str, `~stdatamodels.jwst.datamodels.ImageModel`, `gwcs.wcs.WCS`
         A data model whose WCS was previously corrected.
         This data model plays two roles: 1) it is the reference WCS which
         provides a tangent plane in which corrections have been defined, and

--- a/jwst/wfss_contam/wfss_contam_step.py
+++ b/jwst/wfss_contam/wfss_contam_step.py
@@ -34,12 +34,12 @@ class WfssContamStep(Step):
 
         Parameters
         ----------
-        input_model : `~jwst.datamodels.MultiSlitModel`
+        input_model : `~stdatamodels.jwst.datamodels.MultiSlitModel`
             The input data model containing 2-D cutouts for each identified source.
 
         Returns
         -------
-        output_model : `~jwst.datamodels.MultiSlitModel`
+        output_model : `~stdatamodels.jwst.datamodels.MultiSlitModel`
             A copy of the input_model with contamination removed
         """
         with datamodels.open(input_model) as dm:


### PR DESCRIPTION
This PR addresses a little bit of https://github.com/spacetelescope/jwst/issues/9383 , as seen in https://github.com/spacetelescope/jwst/pull/9666 . This round was focused on broken datamodels links but I also have other drive-by fixes.

Probably no need for RT?

## TODO

- [x] Go through the rest of the local doc build log.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
