### PR TITLE
pin python<3.14

### DIFF
--- a/changes/9840.general.rst
+++ b/changes/9840.general.rst
@@ -1,0 +1,1 @@
+Do not allow python 3.14+.

--- a/changes/9840.general.rst
+++ b/changes/9840.general.rst
@@ -1,1 +1,1 @@
-Do not allow python 3.14+.
+Require python <3.14 to exclude the currently unreleased 3.14. Once all dependencies support 3.14 and the code and results are tested with 3.14 this pin will be updated to allow 3.14.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "jwst"
 description = "Library for calibration of science observations from the James Webb Space Telescope"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 authors = [
     { name = "JWST calibration pipeline developers" },
 ]


### PR DESCRIPTION
Pin python <3.14

There will not be enough time to test with 3.14 before the next release.

This fixes the currently failing build workflows (which are attempting to and failing to build a wheel for 3.14).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
