### PR TITLE
DOC: Fix assocations refs, expose more API docstrings

### DIFF
--- a/docs/jwst/associations/association_api.rst
+++ b/docs/jwst/associations/association_api.rst
@@ -4,3 +4,4 @@
    :skip: main
 
 .. automodapi:: jwst.associations.lib.keyvalue_registry
+   :no-inheritance-diagram:

--- a/docs/jwst/associations/association_api.rst
+++ b/docs/jwst/associations/association_api.rst
@@ -2,3 +2,5 @@
 
 .. automodapi:: jwst.associations
    :skip: main
+
+.. automodapi:: jwst.associations.lib.keyvalue_registry

--- a/docs/jwst/associations/lib_dmsbase.rst
+++ b/docs/jwst/associations/lib_dmsbase.rst
@@ -1,3 +1,5 @@
 .. _asn-lib-dmsbase-api:
 
 .. automodapi:: jwst.associations.lib.dms_base
+
+.. automodapi:: jwst.associations.lib.acid

--- a/docs/jwst/associations/lib_dmsbase.rst
+++ b/docs/jwst/associations/lib_dmsbase.rst
@@ -3,3 +3,4 @@
 .. automodapi:: jwst.associations.lib.dms_base
 
 .. automodapi:: jwst.associations.lib.acid
+   :no-inheritance-diagram:

--- a/docs/jwst/associations/registry.rst
+++ b/docs/jwst/associations/registry.rst
@@ -3,12 +3,12 @@
 Association Registry
 ====================
 
-The :class:`~jwst.associations.registry.AssociationRegistry` is the
-rule organizer. An `AssociationRegistry` is instantiated with the
+The :class:`~jwst.associations.AssociationRegistry` is the
+rule organizer. An `~jwst.associations.AssociationRegistry` is instantiated with the
 files containing the desired rules. The
-:meth:`~jwst.associations.registry.AssociationRegistry.match` method
+:meth:`~jwst.associations.AssociationRegistry.match` method
 is used to find associations that a member belongs to.
 
-``AssociationRegistry`` is a subclass of :py:obj:`dict` and supports all of
-its methods. In particular, multiple ``AssociationRegistry``'s can be
+`~jwst.associations.AssociationRegistry` is a subclass of :py:obj:`dict` and supports all of
+its methods. In particular, multiple `~jwst.associations.AssociationRegistry` instances can be
 combined using the :py:meth:`~dict.update` method.

--- a/docs/jwst/associations/rules_level2.rst
+++ b/docs/jwst/associations/rules_level2.rst
@@ -1,3 +1,6 @@
 .. _asn-rules-level2-api:
 
 .. automodapi:: jwst.associations.lib.rules_level2b
+
+.. automodapi:: jwst.associations.lib.rules_level2_base
+    :skip: DMSAttrConstraint

--- a/docs/jwst/associations/rules_level2.rst
+++ b/docs/jwst/associations/rules_level2.rst
@@ -1,6 +1,8 @@
 .. _asn-rules-level2-api:
 
 .. automodapi:: jwst.associations.lib.rules_level2b
+   :no-inheritance-diagram:
 
 .. automodapi:: jwst.associations.lib.rules_level2_base
-    :skip: DMSAttrConstraint
+   :skip: DMSAttrConstraint
+   :no-inheritance-diagram:

--- a/docs/jwst/associations/rules_level3.rst
+++ b/docs/jwst/associations/rules_level3.rst
@@ -1,6 +1,8 @@
 .. _asn-rules-level3-api:
 
 .. automodapi:: jwst.associations.lib.rules_level3
+   :no-inheritance-diagram:
 
 .. automodapi:: jwst.associations.lib.rules_level3_base
-    :skip: DMSAttrConstraint, ListCategory, SimpleConstraint
+   :skip: DMSAttrConstraint, ListCategory, SimpleConstraint
+   :no-inheritance-diagram:

--- a/docs/jwst/associations/rules_level3.rst
+++ b/docs/jwst/associations/rules_level3.rst
@@ -1,3 +1,6 @@
 .. _asn-rules-level3-api:
 
 .. automodapi:: jwst.associations.lib.rules_level3
+
+.. automodapi:: jwst.associations.lib.rules_level3_base
+    :skip: DMSAttrConstraint, ListCategory, SimpleConstraint

--- a/jwst/associations/asn_from_list.py
+++ b/jwst/associations/asn_from_list.py
@@ -18,7 +18,7 @@ def asn_from_list(items, rule=DMS_Level3_Base, **kwargs):
     ----------
     items : [object [, ...]]
         List of items to add.
-    rule : `Association` rule
+    rule : `~jwst.associations.Association` rule
         The association rule to use.
     **kwargs : dict
         Other named parameters required or pertinent to adding
@@ -26,7 +26,7 @@ def asn_from_list(items, rule=DMS_Level3_Base, **kwargs):
 
     Returns
     -------
-    association : `Association`-based instance
+    association : `~jwst.associations.Association`-based instance
         The association with the items added.
 
     Notes
@@ -41,20 +41,20 @@ def asn_from_list(items, rule=DMS_Level3_Base, **kwargs):
 
 
 class Main:
-    """Command-line interface for asn_from_list."""
+    """
+    Command-line interface for :func:`~jwst.associations.asn_from_list.asn_from_list`.
+
+    Parameters
+    ----------
+    args : list of str or None
+        The command line arguments. Can be one of:
+
+        - `None`: Command line arguments are then used.
+        - List of str: A list of strings which create the command line
+          with the similar structure as ``sys.argv``
+    """
 
     def __init__(self, args=None):
-        """
-        Initialize the class for asn_from_list.
-
-        Parameters
-        ----------
-        args : list or None
-            The command line arguments. Can be one of
-                - `None`: `sys.argv` is then used.
-                - `[str, ...]`: A list of strings which create the command line
-                  with the similar structure as `sys.argv`
-        """
         self.configure(args)
 
     def asn_from_list(self):
@@ -71,15 +71,16 @@ class Main:
 
         Parameters
         ----------
-        args : list or None
-            The command line arguments. Can be one of
-                - `None`: `sys.argv` is then used.
-                - `[str, ...]`: A list of strings which create the command line
-                  with the similar structure as `sys.argv`
+        args : list of str or None
+            The command line arguments. Can be one of:
+
+            - `None`: Command line arguments are then used.
+            - List of str: A list of strings which create the command line
+              with the similar structure as ``sys.argv``
 
         Returns
         -------
-        ~jwst.associations.association.Association
+        `~jwst.associations.Association`
             The association created from the list.
         """
         association = cls(args=args)
@@ -89,15 +90,16 @@ class Main:
 
     def configure(self, args=None):
         """
-        Configure the asn_from_list CLI object.
+        Configure the :func:`~jwst.associations.asn_from_list.asn_from_list` CLI object.
 
         Parameters
         ----------
-        args : list or None
-            The command line arguments. Can be one of
-                - `None`: `sys.argv` is then used.
-                - `[str, ...]`: A list of strings which create the command line
-                  with the similar structure as `sys.argv`
+        args : list of str or None
+            The command line arguments. Can be one of:
+
+            - `None`: Command line arguments are then used.
+            - List of str: A list of strings which create the command line
+              with the similar structure as ``sys.argv``
         """
         if args is None:
             args = sys.argv[1:]
@@ -174,11 +176,11 @@ def main(args=None):
 
     Parameters
     ----------
-    args : list or None
-        The command line arguments. Can be one of
+    args : list of str or None
+        The command line arguments. Can be one of:
 
-        - `None`: `sys.argv` is then used.
-        - `[str, ...]`: A list of strings which create the command line
-          with the similar structure as `sys.argv`
+        - `None`: Command line arguments are then used.
+        - List of str: A list of strings which create the command line
+          with the similar structure as ``sys.argv``
     """
     Main.cli(args=args)

--- a/jwst/associations/association.py
+++ b/jwst/associations/association.py
@@ -26,13 +26,19 @@ _TIMESTAMP_TEMPLATE = "%Y%m%dt%H%M%S"
 
 class Association(MutableMapping):
     """
-    Association Base Class.
+    Association base class.
+
+    Parameters
+    ----------
+    version_id : str or None
+        Version ID to use in the name of this association.
+        If None, nothing is added.
 
     Attributes
     ----------
     instance : dict-like
         The instance is the association data structure.
-        See `data` below
+        See ``data`` below.
 
     meta : dict
         Information about the association.
@@ -48,7 +54,7 @@ class Association(MutableMapping):
 
     Raises
     ------
-    AssociationError
+    jwst.associations.AssociationError
         If an item doesn't match.
     """
 
@@ -78,15 +84,6 @@ class Association(MutableMapping):
     """The association IO registry"""
 
     def __init__(self, version_id=None):
-        """
-        Initialize an Association.
-
-        Parameters
-        ----------
-        version_id : str or None
-            Version ID to use in the name of this association.
-            If None, nothing is added.
-        """
         self.data = {}
         self.run_init_hook = True
         self.meta = {}
@@ -128,11 +125,12 @@ class Association(MutableMapping):
 
         Returns
         -------
-        (association, reprocess_list)
+        tuple
             2-tuple consisting of:
-                - association or None: The association or, if the item does not
-                  match this rule, None
-                - [ProcessList[, ...]]: List of items to process again.
+
+            - Association or None: The association or, if the item does not
+              match this rule, None
+            - [ProcessList[, ...]]: List of items to process again.
         """
         asn = cls(version_id=version_id)
         matches, reprocess = asn.add(item)
@@ -189,11 +187,11 @@ class Association(MutableMapping):
         Returns
         -------
         valid : bool
-            True if valid. Otherwise the `AssociationNotValidError` is raised
+            True if valid. Otherwise the `~jwst.associations.AssociationNotValidError` is raised.
 
         Raises
         ------
-        AssociationNotValidError
+        jwst.associations.AssociationNotValidError
             If there is some reason validation failed.
 
         Notes
@@ -256,10 +254,10 @@ class Association(MutableMapping):
 
         Raises
         ------
-        AssociationError
+        jwst.associations.AssociationError
             If the operation cannot be done
 
-        AssociationNotValidError
+        jwst.associations.AssociationNotValidError
             If the given association does not validate.
         """
         if fmt is None:
@@ -286,7 +284,7 @@ class Association(MutableMapping):
             Validate against the class' defined schema, if any.
 
         **kwargs : dict
-            Other arguments to pass to the `load` method
+            Other arguments to pass to the ``load`` method.
 
         Returns
         -------
@@ -295,14 +293,14 @@ class Association(MutableMapping):
 
         Raises
         ------
-        AssociationNotValidError
+        jwst.associations.AssociationNotValidError
             Cannot create or validate the association.
 
         Notes
         -----
-        The `serialized` object can be in any format
+        The serialized object can be in any format
         supported by the registered I/O routines. For example, for
-        `json` and `yaml` formats, the input can be either a string or
+        JSON and YAML formats, the input can be either a string or
         a file object containing the string.
         """
         if fmt is None:
@@ -359,10 +357,11 @@ class Association(MutableMapping):
 
         Returns
         -------
-        (match, reprocess_list)
+        tuple
             2-tuple consisting of:
-                - bool : True if match
-                - [ProcessList[, ...]]: List of items to process again.
+
+            - bool : True if match
+            - [ProcessList[, ...]]: List of items to process again.
         """
         if self.is_item_member(item):
             return True, []
@@ -401,10 +400,11 @@ class Association(MutableMapping):
 
         Returns
         -------
-        (match, reprocess)
+        tuple
             2-tuple consisting of:
-                - bool : Did constraint match?
-                - [ProcessItem[, ...]]: List of items to process again.
+
+            - bool : Did constraint match?
+            - [ProcessItem[, ...]]: List of items to process again.
         """
         self.constraints.preserve()
         match, reprocess = self.constraints.check_and_set(item)
@@ -433,10 +433,11 @@ class Association(MutableMapping):
 
         Returns
         -------
-        (matches, reprocess_list)
+        tuple
             2-tuple consisting of:
-                - bool : True if the all constraints are satisfied
-                - [ProcessList[, ...]]: List of items to process again.
+
+            - bool : True if the all constraints are satisfied
+            - [ProcessList[, ...]]: List of items to process again.
         """
         reprocess = []
         evaled_str = conditions["inputs"](item)
@@ -548,7 +549,7 @@ class Association(MutableMapping):
 
         Returns
         -------
-        dict_keys
+        dict_keys : iter
             The keys of the data dictionary.
         """
         return self.data.keys()
@@ -559,7 +560,7 @@ class Association(MutableMapping):
 
         Returns
         -------
-        dict_items
+        dict_items : iter
             The items of the data dictionary.
         """
         return self.data.items()
@@ -570,7 +571,7 @@ class Association(MutableMapping):
 
         Returns
         -------
-        dict_values
+        dict_values : iter
             The values of the data dictionary.
         """
         return self.data.values()
@@ -579,7 +580,7 @@ class Association(MutableMapping):
 # Utilities
 def finalize(asns):
     """
-    Finalize associations by calling their `finalize_hook` method.
+    Finalize associations by calling their ``finalize_hook`` method.
 
     Parameters
     ----------
@@ -607,6 +608,14 @@ def finalize(asns):
 
 
 def make_timestamp():
+    """
+    Timestamp of current time in UTC.
+
+    Returns
+    -------
+    timestamp : str
+        UTC time in pre-determined format.
+    """
     timestamp = datetime.now(UTC).strftime(_TIMESTAMP_TEMPLATE)
     return timestamp
 

--- a/jwst/associations/lib/acid.py
+++ b/jwst/associations/lib/acid.py
@@ -5,7 +5,7 @@ from ast import literal_eval
 
 from jwst.associations.lib.counter import Counter
 
-__all__ = ["ACID"]
+__all__ = ["ACID", "ACIDMixin"]
 
 # Start of the discovered association ids.
 _DISCOVERED_ID_START = 3001
@@ -15,30 +15,32 @@ class ACID:
     """
     Association Candidate Identifier.
 
+    Parameters
+    ----------
+    inits : str or tuple of str
+        String representation or 2-tuple containing the candidate ID
+        and TYPE. The string should be itself the 2-tuple representation
+        when evaluated. The 2-tuple will have the form ``(id, type)``.
+
     Attributes
     ----------
     id : str
-        The id number.
+        The ID number.
 
     type : str
         The type of candidate. Some, but not all
         possibilities include 'OBSERVATION',
         'MOSAIC', 'DISCOVERED'
 
-    __str__ : str
-        The DMS-specified string representation of
-        a candidate identifier. Possibilities include
-        'oXXX' for OBSERVATION, 'c1XXX' for 'MOSAIC' or
-        other PPS-defined candidates, and 'a3XXX' for
-        'DISCOVERED' associations.
-
     Notes
     -----
-    The initialization with uses a string representation or
-    2-tuple containing the candidate ID and TYPE. The string
-    should be itself the 2-tuple representation when evaluated.
-    The 2-tuple will have the form:
-        (id, type)
+    ``str(obj)`` returns the DMS-specified string representation of
+    a candidate identifier. Possibilities include:
+
+    * 'oXXX' for OBSERVATION
+    * 'c1XXX' for 'MOSAIC'
+    * other PPS-defined candidates
+    * 'a3XXX' for 'DISCOVERED' associations
     """
 
     def __init__(self, inits):
@@ -66,7 +68,7 @@ class ACIDMixin:
 
         Returns
         -------
-        ACID
+        acid : `~jwst.associations.lib.acid.ACID`
             Association candidate identifier from constraints.
         """
         for constraint in self.constraints:

--- a/jwst/associations/lib/keyvalue_registry.py
+++ b/jwst/associations/lib/keyvalue_registry.py
@@ -15,14 +15,13 @@ class KeyValueRegistry(UserDict):
     Provide a dict-like registry.
 
     Differences from just a `dict`:
-        - Can be given single item or a 2-tuple.
-          If an item, attempts to read the `__name__` attribute
-          and use that as the key.
 
-        - If None is given as a key, a default key can
-          be specified.
-
-        - Instances can be used as decorators.
+    - Can be given single item or a 2-tuple.
+      If an item, attempts to read the ``__name__`` attribute
+      and use that as the key.
+    - If None is given as a key, a default key can
+      be specified.
+    - Instances can be used as decorators.
 
     Parameters
     ----------
@@ -30,7 +29,7 @@ class KeyValueRegistry(UserDict):
         Initializing items.
 
     default : str or object
-        The default to use when key is `None`
+        The default to use when key is `None`.
     """
 
     def __init__(self, items=None, default=None):
@@ -102,14 +101,14 @@ def make_dict(item):
     Create a dict from an item.
 
     Items may be a dict, a 2-tuple or an object. Objects are most
-    often a file format class from ~jwst.associations.association_io - `json` or `yaml`.
+    often a file format class from `~jwst.associations.association_io` - JSON or YAML.
 
     Parameters
     ----------
     item : object or (name, object) or dict
         If dict, just return dict.
         If 2-tuple, return dict with the key/value pair
-        If just object, use `__name__` as key
+        If just object, use ``__name__`` as key
 
     Returns
     -------

--- a/jwst/associations/lib/rules_level2_base.py
+++ b/jwst/associations/lib/rules_level2_base.py
@@ -125,12 +125,12 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
             The pool entry to determine the exposure type of
         default : str or None
             The default exposure type.
-            If None, routine will raise LookupError
+            If None, routine will raise LookupError.
 
         Returns
         -------
-        exposure_type
-            Always what is defined as `default`
+        exposure_type : str
+            Always what is defined as ``default``
         """
         self.original_exposure_type = super(DMSLevel2bBase, self).get_exposure_type(
             item, default=default
@@ -145,7 +145,7 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
 
         Returns
         -------
-        list
+        list of str
             List of members.
         """
         member_type = member_type.lower()
@@ -276,14 +276,16 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
         meta : dict
             A dict to be merged into the association meta information.
             The following are suggested to be assigned:
-                - `asn_type`
+
+                - ``asn_type``
                     The type of association.
-                - `asn_rule`
+                - ``asn_rule``
                     The rule which created this association.
-                - `asn_pool`
+                - ``asn_pool``
                     The pool from which the exposures came from
-                - `program`
+                - ``program``
                     Originating observing program
+
         product_name_func : func
             Used if product name is 'undefined' using
             the class's procedures.
@@ -298,11 +300,11 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
         by-passed, resulting in a potentially unusable association.
 
         `product_name_func` is used to define the product names instead of
-        the default methods. The call signature is:
+        the default methods. The call signature is::
 
             product_name_func(item, idx)
 
-        where `item` is each item being added and `idx` is the count of items.
+        where ``item`` is each item being added and ``idx`` is the count of items.
         """
         if meta is None:
             meta = {}
@@ -365,7 +367,7 @@ class DMSLevel2bBase(DMSBaseMixin, Association):
 
         Parameters
         ----------
-        _member : member
+        _member : Member
             Member being added; ignored.
 
         Returns
@@ -561,10 +563,11 @@ class Utility:
         Notes
         -----
         The current definition of candidates allows strictly alphabetical
-        sorting:
-        aXXXX > cXXXX > oXXX
+        sorting::
 
-        If this changes, a comparison function will need be implemented
+            aXXXX > cXXXX > oXXX
+
+        If this changes, a comparison function will need be implemented.
         """
         return sorted(asns, key=lambda asn: asn["asn_id"])
 
@@ -807,31 +810,29 @@ class Constraint_Single_Science(Constraint):
     """
     Allow only single science exposure.
 
+    Parameters
+    ----------
+    has_science_fn : func
+        Function to determine whether the association has a science member already.
+        No arguments are provided
+
+    exposure_type_fn : func
+        Function to determine the association exposure type of the item.
+        Should take a single argument of item.
+
+    **sc_kwargs : dict
+        Keyword arguments to pass to the parent class
+        `~jwst.associations.lib.constraint.Constraint`.
+
     Notes
     -----
-    The `has_science_fn` is further wrapped in a lambda function
+    The ``has_science_fn`` is further wrapped in a lambda function
     to provide a closure. Otherwise if the function is a bound method,
     that method may end up pointing to an instance that is not calling
     this constraint.
     """
 
     def __init__(self, has_science_fn, exposure_type_fn, **sc_kwargs):
-        """
-        Initialize a new single science constraint.
-
-        Parameters
-        ----------
-        has_science_fn : func
-            Function to determine whether the association has a science member already.
-            No arguments are provided
-
-        exposure_type_fn : func
-            Function to determine the association exposure type of the item.
-            Should take a single argument of item.
-
-        **sc_kwargs : dict
-            Keyword arguments to pass to the parent class `Constraint`
-        """
         super(Constraint_Single_Science, self).__init__(
             [
                 SimpleConstraint(
@@ -885,7 +886,7 @@ class Constraint_Spectral_Science(Constraint):
 
 
 class Constraint_Target(Constraint):
-    """Select on target id."""
+    """Select on target ID."""
 
     def __init__(self):
         constraints = [
@@ -1068,15 +1069,15 @@ class AsnMixin_Lv2Nod:
 
         Parameters
         ----------
-        science_item : member
+        science_item : Member
             The science member.
-        background_item : member
+        background_item : Member
             The background member.
 
         Returns
         -------
         bool
-            True if overlap is present, false otherwise.
+            True if overlap is present, False otherwise.
         """
         # Get exp_type, needed for any data:
         # if not present, return False
@@ -1180,9 +1181,9 @@ class AsnMixin_Lv2Nod:
         nodded, such that the object is in a different position in the
         slitlet. The association creation simply groups these all
         together as a single association, all exposures marked as
-        `science`. When complete, this method will create separate
+        ``science``. When complete, this method will create separate
         associations each exposure becoming the single science
-        exposure, and the other exposures then become `background`.
+        exposure, and the other exposures then become ``background``.
 
         Returns
         -------
@@ -1278,12 +1279,12 @@ class AsnMixin_Lv2Special:
             The pool entry to determine the exposure type of
         default : str or None
             The default exposure type.
-            If None, routine will raise LookupError
+            If None, routine will raise LookupError.
 
         Returns
         -------
-        exposure_type
-            Always what is defined as `default`
+        exposure_type : str
+            Always what is defined as ``default``
         """
         self.original_exposure_type = super(AsnMixin_Lv2Special, self).get_exposure_type(
             item, default=default
@@ -1372,7 +1373,7 @@ class AsnMixin_Lv2WFSS:
 
         Parameters
         ----------
-        item : member
+        item : Member
             The item to pull exposure type from.
         default : str
             The default value if no exposure type is present, defaults to "science".
@@ -1436,15 +1437,16 @@ class AsnMixin_Lv2WFSS:
 
         Returns
         -------
-        opt_elem: str
+        opt_elem : str
             The Level3 Product name representation
             of the optical elements.
 
         Notes
         -----
-        This is an override for the method in `DMSBaseMixin`.
+        This is an override for the method in
+        `~jwst.associations.lib.dms_base.DMSBaseMixin`.
         The optical element is retrieved from the chosen direct image
-        found in `self.direct_image`, determined in the `self.finalize`
+        found in ``self.direct_image``, determined in the ``self.finalize``
         method.
         """
         item = self.direct_image.item

--- a/jwst/associations/lib/rules_level2b.py
+++ b/jwst/associations/lib/rules_level2b.py
@@ -74,6 +74,7 @@ class Asn_Lv2CoronAsRate(AsnMixin_Lv2Image, DMSLevel2bBase):
     Create normal rate products for some coronographic data.
 
     Characteristics;
+
         - Association type: ``image2``
         - Pipeline: ``calwebb_image2``
         - NIRCam Coronagraphic
@@ -118,7 +119,7 @@ class Asn_Lv2CoronAsRate(AsnMixin_Lv2Image, DMSLevel2bBase):
         """
         Override to always return false.
 
-        The override will force `make_member` to create a "rate"
+        The override will force ``make_member`` to create a "rate"
         product instead of a "rateints" product.
 
         Returns
@@ -135,6 +136,7 @@ class Asn_Lv2Image(AsnMixin_Lv2Image, DMSLevel2bBase):
     Level2b Non-TSO Science Image Association.
 
     Characteristics:
+
         - Association type: ``image2``
         - Pipeline: ``calwebb_image2``
         - Image-based science exposures
@@ -176,6 +178,7 @@ class Asn_Lv2ImageNonScience(AsnMixin_Lv2Special, AsnMixin_Lv2Image, DMSLevel2bB
     Level2b Non-science Image Association.
 
     Characteristics:
+
         - Association type: ``image2``
         - Pipeline: ``calwebb_image2``
         - Image-based non-science exposures, such as target acquisitions
@@ -202,6 +205,7 @@ class Asn_Lv2ImageSpecial(AsnMixin_Lv2Special, AsnMixin_Lv2Image, DMSLevel2bBase
     Level2b Auxiliary Science Image Association.
 
     Characteristics:
+
         - Association type: ``image2``
         - Pipeline: ``calwebb_image2``
         - Image-based science exposures that are to be used as background or PSF exposures
@@ -231,6 +235,7 @@ class Asn_Lv2ImageTSO(AsnMixin_Lv2Image, DMSLevel2bBase):
     Level2b Time Series Science Image Association.
 
     Characteristics:
+
         - Association type: ``tso-image2``
         - Pipeline: ``calwebb_tso-image2``
         - Image-based Time Series exposures
@@ -264,6 +269,7 @@ class Asn_Lv2FGS(AsnMixin_Lv2Image, DMSLevel2bBase):
     Level2b FGS Association.
 
     Characteristics:
+
         - Association type: ``image2``
         - Pipeline: ``calwebb_image2``
         - Image-based FGS science exposures
@@ -294,6 +300,7 @@ class Asn_Lv2Spec(AsnMixin_Lv2Spectral, AsnMixin_Lv2Imprint, DMSLevel2bBase):
     Level2b Science Spectral Association.
 
     Characteristics:
+
         - Association type: ``spec2``
         - Pipeline: ``calwebb_spec2``
         - Spectral-based single target science exposures
@@ -363,6 +370,7 @@ class Asn_Lv2SpecImprint(AsnMixin_Lv2Special, AsnMixin_Lv2Spectral, DMSLevel2bBa
     Level2b Treat Imprint/Leakcal as science.
 
     Characteristics:
+
         - Association type: ``spec2``
         - Pipeline: ``calwebb_spec2``
         - Only handles Imprint/Leakcal exposures
@@ -398,6 +406,7 @@ class Asn_Lv2SpecSpecial(
     Level2b Auxiliary Science Spectral Association.
 
     Characteristics:
+
         - Association type: ``spec2``
         - Pipeline: ``calwebb_spec2``
         - Spectral-based single target science exposures that are background exposures
@@ -437,6 +446,7 @@ class Asn_Lv2SpecTSO(AsnMixin_Lv2Spectral, DMSLevel2bBase):
     Level2b Time Series Science Spectral Association.
 
     Characteristics:
+
         - Association type: ``tso-spec2``
         - Pipeline: ``calwebb_tso-spec2``
         - Spectral-based single target time series exposures
@@ -527,6 +537,7 @@ class Asn_Lv2MIRLRSFixedSlitNod(AsnMixin_Lv2Spectral, DMSLevel2bBase):
     Level2b MIRI LRS Fixed Slit background nods Association.
 
     Characteristics:
+
         - Association type: ``spec2``
         - Pipeline: ``calwebb_spec2``
         - MIRI LRS Fixed slit
@@ -599,8 +610,8 @@ class Asn_Lv2MIRLRSFixedSlitNod(AsnMixin_Lv2Spectral, DMSLevel2bBase):
         Modify exposure type depending on dither pointing index.
 
         Behaves as the superclass method. However, if the constraint
-        `is_current_patt_num` is True, mark the exposure type as
-        `background`.
+        ``is_current_patt_num`` is True, mark the exposure type as
+        ``background``.
 
         Parameters
         ----------
@@ -627,6 +638,7 @@ class Asn_Lv2NRSLAMPImage(AsnMixin_Lv2Image, AsnMixin_Lv2Special, DMSLevel2bBase
     Level2b NIRSpec image Lamp Calibrations Association.
 
     Characteristics:
+
         - Association type: ``image2``
         - Pipeline: ``calwebb_image2``
         - Image-based calibration exposures
@@ -654,6 +666,7 @@ class Asn_Lv2NRSLAMPSpectral(AsnMixin_Lv2Special, DMSLevel2bBase):
     Level2b NIRSpec spectral Lamp Calibrations Association.
 
     Characteristics:
+
         - Association type: ``nrslamp-spec2``
         - Pipeline: ``calwebb_nrslamp-spec2``
         - Spectral-based calibration exposures
@@ -741,6 +754,7 @@ class Asn_Lv2WFSSNIS(
     Level2b WFSS/GRISM Association.
 
     Characteristics:
+
         - Association type: ``spec2``
         - Pipeline: ``calwebb_spec2``
         - Multi-object science exposures
@@ -812,6 +826,7 @@ class Asn_Lv2WFSSNRC(
     Level2b WFSS/GRISM Association.
 
     Characteristics:
+
         - Association type: ``spec2``
         - Pipeline: ``calwebb_spec2``
         - Multi-object science exposures
@@ -872,6 +887,7 @@ class Asn_Lv2NRSMSA(AsnMixin_Lv2Nod, AsnMixin_Lv2Spectral, DMSLevel2bBase):
     Level2b NIRSpec MSA Association.
 
     Characteristics:
+
         - Association type: ``spec2``
         - Pipeline: ``calwebb_spec2``
         - Spectral-based NIRSpec MSA multi-object science exposures
@@ -912,6 +928,7 @@ class Asn_Lv2NRSFSS(AsnMixin_Lv2Nod, AsnMixin_Lv2Spectral, DMSLevel2bBase):
     Notes
     -----
     Characteristics:
+
         - Association type: ``spec2``
         - Pipeline: ``calwebb_spec2``
         - Spectral-based NIRSpec fixed-slit single target science exposures
@@ -979,6 +996,7 @@ class Asn_Lv2NRSIFUNod(AsnMixin_Lv2Imprint, AsnMixin_Lv2Nod, AsnMixin_Lv2Spectra
     Level2b NIRSpec IFU Association.
 
     Characteristics:
+
         - Association type: ``spec2``
         - Pipeline: ``calwebb_spec2``
         - Spectral-based NIRSpec IFU multi-object science exposures
@@ -1022,6 +1040,7 @@ class Asn_Lv2WFSC(DMSLevel2bBase):
     Level2b Wavefront Sensing & Control Association.
 
     Characteristics:
+
         - Association type: ``wfs-image2``
         - Pipeline: ``calwebb_wfs-image2``
         - WFS and WFS&C observations
@@ -1068,6 +1087,7 @@ class Asn_Lv2WFSSParallel(
     Level 2b WFSS/GRISM associations for WFSS taken in pure-parallel mode.
 
     Characteristics:
+
         - Association type: ``spec2``
         - Pipeline: ``calwebb_spec2``
         - Multi-object science exposures
@@ -1157,7 +1177,7 @@ class Asn_Lv2WFSSParallel(
         Returns
         -------
         closest : dict
-            The direct image that is the "closest"
+            The direct image that is the "closest".
         """
         long_directs = [d for d in directs if "long" in d["expname"]]
         if len(long_directs) == 0:

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -73,6 +73,7 @@ class Asn_Lv3ACQ_Reprocess(DMS_Level3_Base):
     Level 3 Gather Target Acquisitions.
 
     Characteristics:
+
         - Association type: Not applicable
         - Pipeline: Not applicable
         - Used to populate other related associations
@@ -107,6 +108,7 @@ class Asn_Lv3AMI(AsnMixin_Science):
     Level 3 Aperture Mask Interferometry Association.
 
     Characteristics:
+
         - Association type: ``ami3``
         - Pipeline: ``calwebb_ami3``
         - Gather science and related PSF exposures
@@ -160,6 +162,7 @@ class Asn_Lv3Image(AsnMixin_Science):
     Level 3 Science Image Association.
 
     Characteristics:
+
         - Association type: ``image3``
         - Pipeline: ``calwebb_image3``
         - Non-TSO
@@ -204,6 +207,7 @@ class Asn_Lv3ImageBackground(AsnMixin_AuxData, AsnMixin_Science):
     Level 3 Background Image Association.
 
     Characteristics:
+
         - Association type: ``image3``
         - Pipeline: ``calwebb_image3``
         - Non-TSO
@@ -243,6 +247,7 @@ class Asn_Lv3MIRCoron(AsnMixin_Coronagraphy, AsnMixin_Science):
     Level 3 Coronagraphy Association.
 
     Characteristics:
+
         - Association type: ``coron3``
         - Pipeline: ``calwebb_coron3``
         - MIRI Coronagraphy
@@ -299,6 +304,7 @@ class Asn_Lv3MIRMRS(AsnMixin_Spectrum):
     Level 3 MIRI MRS Association.
 
     Characteristics:
+
         - Association type: ``spec3``
         - Pipeline: ``calwebb_spec3``
         - Just MIRI MRS
@@ -348,6 +354,7 @@ class Asn_Lv3MIRMRSBackground(AsnMixin_AuxData, AsnMixin_Spectrum):
     Level 3 MIRI MRS Association Auxiliary data.
 
     Characteristics:
+
         - Association type: ``spec3``
         - Pipeline: ``calwebb_spec3``
         - Just MIRI MRS
@@ -402,6 +409,7 @@ class Asn_Lv3NRCCoron(AsnMixin_Coronagraphy, AsnMixin_Science):
     Level 3 Coronagraphy Association.
 
     Characteristics:
+
         - Association type: ``coron3``
         - Pipeline: ``calwebb_coron3``
         - Gather science and related PSF exposures
@@ -463,6 +471,7 @@ class Asn_Lv3NRCCoronImage(AsnMixin_Science):
     Level 3 Coronagraphy Association handled as regular imaging.
 
     Characteristics:
+
         - Association type: ``image3``
         - Pipeline: ``calwebb_image3``
         - Gather science exposures only, no psf exposures
@@ -559,6 +568,7 @@ class Asn_Lv3NRSFSS(AsnMixin_Spectrum):
     Level 3 NIRSpec Fixed-slit Science.
 
     Characteristics:
+
         - Association type: ``spec3``
         - Pipeline: ``calwebb_spec3``
         - NIRSpec Fixed-slit Science
@@ -608,6 +618,7 @@ class Asn_Lv3NRSIFU(AsnMixin_Spectrum):
     Level 3 IFU gratings Association.
 
     Characteristics:
+
         - Association type: ``spec3``
         - Pipeline: ``calwebb_spec3``
         - optical path determined by calibration
@@ -653,6 +664,7 @@ class Asn_Lv3NRSIFUBackground(AsnMixin_AuxData, AsnMixin_Spectrum):
     Level 3 Spectral Association.
 
     Characteristics:
+
         - Association type: ``spec3``
         - Pipeline: ``calwebb_spec3``
     """
@@ -701,6 +713,7 @@ class Asn_Lv3SlitlessSpectral(AsnMixin_Spectrum):
     Level 3 slitless, target-based or single-object spectrographic Association.
 
     Characteristics:
+
         - Association type: ``spec3``
         - Pipeline: ``calwebb_spec3``
         - Single target
@@ -751,6 +764,7 @@ class Asn_Lv3SpecAux(AsnMixin_AuxData, AsnMixin_Spectrum):
     Level 3 Spectral Association.
 
     Characteristics:
+
         - Association type: ``spec3``
         - Pipeline: ``calwebb_spec3``
     """
@@ -790,6 +804,7 @@ class Asn_Lv3SpectralSource(AsnMixin_Spectrum):
     Level 3 slit-like, multi-object spectrographic Association.
 
     Characteristics:
+
         - Association type: ``spec3``
         - Pipeline: ``calwebb_spec3``
         - Multi-object
@@ -829,7 +844,7 @@ class Asn_Lv3SpectralSource(AsnMixin_Spectrum):
         Returns
         -------
         str
-            The product name using source id.
+            The product name using source ID.
         """
         return dms_product_name_sources(self)
 
@@ -840,6 +855,7 @@ class Asn_Lv3SpectralTarget(AsnMixin_Spectrum):
     Level 3 slit-like, target-based or single-object spectrographic Association.
 
     Characteristics:
+
         - Association type: ``spec3``
         - Pipeline: ``calwebb_spec3``
         - Single target
@@ -901,6 +917,7 @@ class Asn_Lv3TSO(AsnMixin_Science):
     Level 3 Time-Series Association.
 
     Characteristics:
+
         - Association type: ``tso3``
         - Pipeline: ``calwebb_tso3``
     """
@@ -1045,6 +1062,7 @@ class Asn_Lv3WFSCMB(AsnMixin_Science):
     is assumed to be equivalent within an activity.
 
     Characteristics:
+
         - Association type: ``wfs-image3``
         - Pipeline: ``calwebb_wfs-image3``
         - Coarse and fine phasing dithers
@@ -1092,7 +1110,7 @@ class Asn_Lv3WFSCMB(AsnMixin_Science):
         """
         Define product name.
 
-        Modification is to append the `expspcin` value
+        Modification is to append the ``expspcin`` value
         after the calibration suffix.
 
         Returns
@@ -1117,7 +1135,7 @@ class Asn_Lv3WFSCMB(AsnMixin_Science):
         """
         Check if current product has two members.
 
-        If `entry` is given, it is counted as one of the
+        If ``entry`` is given, it is counted as one of the
         members. If not, the existing member list is only
         accounted for.
 
@@ -1165,6 +1183,7 @@ class Asn_Lv3WFSSNRC(AsnMixin_Spectrum):
     Level 3 NIRCam WFSS/Grism Association.
 
     Characteristics:
+
         - Association type: ``spec3``
         - Pipeline: ``calwebb_spec3``
         - Gather all grism exposures
@@ -1215,6 +1234,7 @@ class Asn_Lv3WFSSNIS(AsnMixin_Spectrum):
     Level 3 NIRISS WFSS/Grism Association.
 
     Characteristics:
+
         - Association type: ``spec3``
         - Pipeline: ``calwebb_spec3``
         - Gather all grism exposures
@@ -1265,6 +1285,7 @@ class Asn_Lv3ImageMosaic(AsnMixin_Science):
     Level 3 Science Image Mosaic Association.
 
     Characteristics:
+
         - Association type: ``image3``
         - Pipeline: ``calwebb_image3``
         - Non-TSO
@@ -1319,7 +1340,7 @@ class Asn_Lv3ImageMosaic(AsnMixin_Science):
         Returns
         -------
         bool
-            True if candidate type is mosaic, false otherwise.
+            True if candidate type is mosaic, False otherwise.
         """
         # If a group candidate, reject.
         if self.acid.type.lower() != "mosaic":

--- a/jwst/associations/lib/rules_level3_base.py
+++ b/jwst/associations/lib/rules_level3_base.py
@@ -147,7 +147,7 @@ class DMS_Level3_Base(DMSBaseMixin, Association):
 
         Parameters
         ----------
-        association : `Association`
+        association : `~jwst.associations.Association`
             Association to get the name from.
 
         Returns
@@ -203,8 +203,8 @@ class DMS_Level3_Base(DMSBaseMixin, Association):
 
         Notes
         -----
-        If both `item` and `member` are given,
-        information in `member` will take precedence.
+        If both ``item`` and ``member`` are given,
+        information in ``member`` will take precedence.
         """
         super(DMS_Level3_Base, self).update_asn(item=item, member=member)
 
@@ -376,8 +376,8 @@ class DMS_Level3_Base(DMSBaseMixin, Association):
             conventions will be attempted.
         with_exptype : bool
             If True, each item is expected to be a 2-tuple with
-            the first element being the item to add as `expname`
-            and the second items is the `exptype`.
+            the first element being the item to add as ``expname``
+            and the second items is the ``exptype``.
         **kwargs : dict
             Allows other keyword arguments used by other subclasses.
 
@@ -440,8 +440,8 @@ class Utility:
         """
         Rename a Level 1b Exposure to a Level2 name.
 
-        The basic transform is changing the suffix `uncal` to
-        `cal`, `calints`, or `rate`.
+        The basic transform is changing the suffix ``uncal`` to
+        ``cal``, ``calints``, or ``rate``.
 
         Parameters
         ----------
@@ -492,7 +492,7 @@ class Utility:
         ----------
         value : str
             The value from the item to parse. Usually
-            item['ASN_CANDIDATE']
+            ``item['ASN_CANDIDATE']``.
 
         Returns
         -------
@@ -513,12 +513,12 @@ class Utility:
 
         Parameters
         ----------
-        associations : [association[, ...]]
+        associations : [Association[, ...]]
             List of associations.
 
         Returns
         -------
-        finalized_associations : [association[, ...]]
+        finalized_associations : [Association[, ...]]
             The validated list of associations.
         """
         finalized_asns = []
@@ -1006,7 +1006,7 @@ class AsnMixin_Science(DMS_Level3_Base):
 
         Returns
         -------
-        associations : [association[, ...]] or None
+        associations : [Association[, ...]] or None
             List of fully-qualified associations that this association
             represents.
             `None` if a complete association cannot be produced.

--- a/jwst/associations/load_asn.py
+++ b/jwst/associations/load_asn.py
@@ -25,12 +25,12 @@ def load_asn(
     validate : bool
         Validate against the class's defined schema, if any.
     registry : AssociationRegistry or None
-        The `AssociationRegistry` to use.
+        The `~jwst.associations.AssociationRegistry` to use.
         If None, no registry is used.
         Can be passed just a registry class instead of instance.
     **kwargs : dict
-        Other arguments to pass to the `load` methods defined
-        in the `Association.KeyValueRegistry`
+        Other arguments to pass to the ``load`` methods defined
+        in the `~jwst.associations.lib.keyvalue_registry.KeyValueRegistry`
 
     Returns
     -------
@@ -44,13 +44,13 @@ def load_asn(
 
     Notes
     -----
-    The `serialized` object can be in any format
+    The serialized object can be in any format
     supported by the registered I/O routines. For example, for
-    `json` and `yaml` formats, the input can be either a string or
+    JSON and YAML formats, the input can be either a string or
     a file object containing the string.
 
-    If no registry is specified, the default `Association.load`
-    method is used.
+    If no registry is specified, the default
+    :meth:`~jwst.associations.Association.load` method is used.
     """
     if registry is None:
         return Association.load(serialized, fmt=fmt, validate=validate)

--- a/jwst/associations/main.py
+++ b/jwst/associations/main.py
@@ -24,23 +24,24 @@ class Main:
 
     Parameters
     ----------
-    args : [str, ...], or None
-        The command line arguments. Can be one of
-        - `None`: `sys.argv` is then used.
-        - `[str, ...]`: A list of strings which create the command line
-        with the similar structure as `sys.argv`
+    args : list of str or None
+        The command line arguments. Can be one of:
 
-    pool : None or AssociationPool
-        If `None`, a pool file must be specified in the `args`.
-        Otherwise, an `AssociationPool`
+        - `None`: Command line arguments are then used.
+        - List of str: A list of strings which create the command line
+          with the similar structure as ``sys.argv``
+
+    pool : None or `~jwst.associations.AssociationPool`
+        If `None`, a pool file must be specified in the ``args``.
+        Otherwise, an `~jwst.associations.AssociationPool`.
 
     Attributes
     ----------
-    pool : `AssociationPool`
-        The pool read in, or passed in through the parameter `pool`
-    rules : `AssociationRegistry`
+    pool : `~jwst.associations.AssociationPool`
+        The pool read in, or passed in through the parameter ``pool``.
+    rules : `~jwst.associations.AssociationRegistry`
         The rules used for association creation.
-    associations : [`Association`, ...]
+    associations : list of `~jwst.associations.Association`
         The list of generated associations.
 
     Notes
@@ -59,15 +60,16 @@ class Main:
 
         Parameters
         ----------
-        args : [str, ...], or None
-            The command line arguments. Can be one of
-            - `None`: `sys.argv` is then used.
-            - `[str, ...]`: A list of strings which create the command line
-            with the similar structure as `sys.argv`
+        args : list of str or None
+            The command line arguments. Can be one of:
 
-        pool : None or AssociationPool
-            If `None`, a pool file must be specified in the `args`.
-            Otherwise, an `AssociationPool`
+            - `None`: Command line arguments are then used.
+            - List of str: A list of strings which create the command line
+              with the similar structure as ``sys.argv``
+
+        pool : None or `~jwst.associations.AssociationPool`
+            If `None`, a pool file must be specified in the ``args``.
+            Otherwise, an `~jwst.associations.AssociationPool`.
 
         Returns
         -------
@@ -86,7 +88,7 @@ class Main:
 
         Returns
         -------
-        pool : `jwst.associations.pool.AssociationPool`
+        pool : `~jwst.associations.AssociationPool`
             The pool of orphaned exposures.
         """
         not_in_asn = np.ones((len(self.pool),), dtype=bool)
@@ -106,16 +108,16 @@ class Main:
 
         Parameters
         ----------
-        args : [str, ...], or None
-            The command line arguments. Can be one of
+        args : list of str or None
+            The command line arguments. Can be one of:
 
-            - `None`: `sys.argv` is then used.
-            - `[str, ...]`: A list of strings which create the command line
-              with the similar structure as `sys.argv`
+            - `None`: Command line arguments are then used.
+            - List of str: A list of strings which create the command line
+              with the similar structure as ``sys.argv``
 
-        pool : None or AssociationPool
-            If `None`, a pool file must be specified in the `args`.
-            Otherwise, an `AssociationPool`
+        pool : None or `~jwst.associations.AssociationPool`
+            If `None`, a pool file must be specified in the ``args``.
+            Otherwise, an `~jwst.associations.AssociationPool`.
         """
         self.parse_args(args, has_pool=pool)
         parsed = self.parsed
@@ -201,10 +203,10 @@ class Main:
         args : list, str, or None
             List of command-line arguments.
             If a string, spaces separate the arguments.
-            If None, `sys.argv` is used.
+            If None, ``sys.argv`` is used.
 
         has_pool : bool-like
-            Do not require `pool` from the command line if a pool is already in hand.
+            Do not require ``pool`` from the command line if a pool is already in hand.
         """
         if args is None:
             args = sys.argv[1:]
@@ -395,16 +397,16 @@ def main(args=None, pool=None):
 
     Parameters
     ----------
-    args : [str, ...], or None
-        The command line arguments. Can be one of
+    args : list of str or None
+        The command line arguments. Can be one of:
 
-        - `None`: `sys.argv` is then used.
-        - `[str, ...]`: A list of strings which create the command line
-        with the similar structure as `sys.argv`
+        - `None`: ``sys.argv`` is then used.
+        - List of str: A list of strings which create the command line
+          with the similar structure as ``sys.argv``
 
-    pool : None or AssociationPool
-        If `None`, a pool file must be specified in the `args`.
-        Otherwise, an `AssociationPool`
+    pool : None or `~jwst.associations.AssociationPool`
+        If `None`, a pool file must be specified in the ``args``.
+        Otherwise, an `~jwst.associations.AssociationPool`.
     """
     Main.cli(args, pool)
 
@@ -413,7 +415,7 @@ def main(args=None, pool=None):
 # Utilities
 # #########
 class DeprecateNoMerge(argparse.Action):
-    """Deprecate the `--no-merge` option."""
+    """Deprecate the ``--no-merge`` option."""
 
     def __init__(self, option_strings, dest, **kwargs):
         super(DeprecateNoMerge, self).__init__(option_strings, dest, const=True, nargs=0, **kwargs)

--- a/jwst/associations/pool.py
+++ b/jwst/associations/pool.py
@@ -18,7 +18,7 @@ class AssociationPool(Table):
     An ``AssociationPool`` is essentially an astropy Table with the
     following default behaviors:
 
-    - ASCII tables with a default delimiter of `|`
+    - ASCII tables with a default delimiter of ``|``
     - All values are read in as strings
     """
 


### PR DESCRIPTION
This PR addresses a little bit of https://github.com/spacetelescope/jwst/issues/9383 , as seen in https://github.com/spacetelescope/jwst/pull/9666 . This round focuses on `associations` docs. Some broken refs need new API docstrings to be exposed.

The changes are negotiable.

I can run RT when we agree on the changes.

## TODO

- [x] Inspect diff and check rendered doc

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
