### PR TITLE
JP-4122: Fix attribute error in combine_1d log message

### DIFF
--- a/changes/9848.combine_1d.rst
+++ b/changes/9848.combine_1d.rst
@@ -1,0 +1,2 @@
+Fixed a log message that caused a crashing error in the ``master_background_mos`` step,
+when attempting to combine one or more background spectra with no valid values.

--- a/jwst/combine_1d/combine1d.py
+++ b/jwst/combine_1d/combine1d.py
@@ -735,10 +735,17 @@ def _read_input_spectra(input_model, exptime_key, input_spectra):
         spectra = input_model.spec
     for in_spec in spectra:
         if not np.any(np.isfinite(in_spec.spec_table.field("flux"))):
-            log.warning(
-                f"Input spectrum {in_spec.source_id} order {in_spec.spectral_order} "
-                f"from group_id {in_spec.meta.group_id} has no valid flux values; skipping."
-            )
+            if in_spec.meta.hasattr("group_id"):
+                msg = (
+                    f"Input spectrum {in_spec.source_id} order {in_spec.spectral_order} "
+                    f"from group_id {in_spec.meta.group_id} has no valid flux values; skipping."
+                )
+            else:
+                msg = (
+                    f"Input spectrum {in_spec.source_id} order {in_spec.spectral_order} "
+                    "has no valid flux values; skipping."
+                )
+            log.warning(msg)
             continue
         spectral_order = in_spec.spectral_order
         if spectral_order not in input_spectra:

--- a/jwst/combine_1d/tests/test_combine1d.py
+++ b/jwst/combine_1d/tests/test_combine1d.py
@@ -265,6 +265,28 @@ def test_allnan_skip(wfss_multiexposure, monkeypatch):
     watcher2.assert_seen()
 
 
+def test_allnan_skip_non_wfss(caplog, three_spectra):
+    """Test that all-nan spectra are skipped."""
+    # Set all flux values to NaN
+    for spec in three_spectra.spec:
+        spec.spec_table["FLUX"][:] = np.nan
+
+    result = Combine1dStep.call(three_spectra)
+    assert result.meta.cal_step.combine_1d == "SKIPPED"
+
+    # message when a single spectrum has no valid flux values
+    msg1 = "Input spectrum 0 order 1 has no valid flux values; skipping."
+    assert msg1 in caplog.text
+
+    # message when no valid input spectra are found for the source
+    msg2 = "No valid input spectra found for source. Skipping."
+    assert msg2 in caplog.text
+
+    # message when no valid input spectra at all are found
+    msg3 = "No valid input spectra found in WFSSMultiSpecModel"
+    assert msg2 in caplog.text
+
+
 def test_output_is_not_input(two_spectra):
     """Test that input is not modified."""
     result = Combine1dStep.call(two_spectra)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4122](https://jira.stsci.edu/browse/JP-4122)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Fix a crash in the master background step for NIRSpec MOS data. When the input background spectra contain no valid flux values, the step issues a warning message.  The warning was introduced in #9625 to address some failures in WFSS mode, so was tested with WFSS data.  The crash comes from an attempt to log the group_id for the spectrum, which is an attribute that exists for WFSS spectra but not for MOS spectra.

The fix here is to modify the log message to record group_id only if it's present in the datamodel.  I added a unit test for this edge case with non-WFSS data.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
