### PR TITLE
TST: Un-xfail jw01288_c1005_mostilno12_pool

### DIFF
--- a/jwst/regtest/test_associations_sdp_pools.py
+++ b/jwst/regtest/test_associations_sdp_pools.py
@@ -175,5 +175,4 @@ def test_fail(tmp_cwd, rtdata, resource_tracker, request, pool_args):
 )
 @pytest.mark.slow
 def test_fslow(tmp_cwd, rtdata, resource_tracker, request, pool_args):
-    with pytest.raises(MultiDiffError):
-        _assoc_sdp_against_standard(rtdata, resource_tracker, request, pool_args)
+    _assoc_sdp_against_standard(rtdata, resource_tracker, request, pool_args)


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses a mess I made by okifying results from https://github.com/spacetelescope/jwst/pull/9520 for `test_fslow[jw01288_c1005_mostilno12_pool]` in `jwst/regtest/test_associations_sdp_pools.py` too soon. Un-okify won't work because we lost the previous "wrong results" and there is no way to re-generate them automatically. Not immediately clear to me how to recover the truth between https://github.com/spacetelescope/RegressionTests/actions/runs/17804187494 and okify action. So, here we are.

There will be conflict I have to resolve back in #9520 but that is the price I will have to pay for my folly.

## After merge

- [ ] Ditch `jw01288_2005_c1005_mostilno12_pool` and keep `jw01288_c1005_mostilno12_pool` back in https://github.com/spacetelescope/jwst/pull/9520

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md)) https://github.com/spacetelescope/RegressionTests/actions/runs/17814621881
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
