### PR TITLE
Add deprecation policy blurb to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,3 +415,13 @@ If developers need to update the truth files in our nightly regression tests,
 there are instructions in the repository wiki.
 
 https://github.com/spacetelescope/jwst/wiki/Maintaining-Regression-Tests
+
+
+## Public API and Deprecation Policy
+
+We consider our public API to be steps (e.g., ``JumpStep``), pipelines (e.g. ``Spec3Pipeline``),
+and command-line tools (e.g. ``calwebb_spec3``, ``set_telescope_pointing``) only.
+When API changes are made to these scripts and classes, a deprecation warning will be issued
+before the change is finalized. The deprecation period is typically two builds or six months.
+Other classes, functions, and methods may be modified or removed in minor releases
+and without warning.


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR adds a deprecation and public API note to the README.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
