### PR TITLE
TST: Remove unused folder_copy in regtest

### DIFF
--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -216,7 +216,7 @@ def generate_artifactory_json(request, artifactory_repos):
                 upload_schema = generate_upload_schema(
                     rtdata.output, rtdata.remote_results_path, schema=upload_schema
                 )
-            elif rtdata.okify_op in ("folder_copy", "sdp_pool_copy"):
+            elif rtdata.okify_op == "sdp_pool_copy":
                 output = rtdata.output + "/"
                 target = rtdata.remote_results_path + os.path.basename(rtdata.output) + "/"
                 upload_schema = generate_upload_schema(output, target, schema=upload_schema)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
No longer needed after #9855, I think.

## TODO

- [x] Open companion PR for `ci_watson/scripts/okify_regtests.py`. https://github.com/spacetelescope/ci_watson/pull/92

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md)) https://github.com/spacetelescope/RegressionTests/actions/runs/17871477502
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
