### PR TITLE
add py.warnings to stpipe loggers

### DIFF
--- a/jwst/ami/tests/test_ami_average.py
+++ b/jwst/ami/tests/test_ami_average.py
@@ -4,6 +4,7 @@ import pytest
 from stdatamodels.jwst.datamodels import ImageModel
 
 from jwst.ami.ami_average_step import AmiAverageStep
+from jwst.tests.helpers import _help_pytest_warns
 
 
 def test_ami_average_deprecated(example_model):
@@ -11,7 +12,7 @@ def test_ami_average_deprecated(example_model):
     for i in range(example_model.data.shape[0]):
         image_list.append(ImageModel(example_model.data[i, :, :]))
 
-    with pytest.deprecated_call():
+    with _help_pytest_warns(), pytest.deprecated_call():
         result = AmiAverageStep.call(image_list)
         assert result is not image_list
         assert result.meta.cal_step.ami_average == "COMPLETE"

--- a/jwst/outlier_detection/tests/conftest.py
+++ b/jwst/outlier_detection/tests/conftest.py
@@ -10,6 +10,7 @@ from jwst.assign_wcs.tests.test_miri import create_hdul
 from jwst.assign_wcs.tests.test_nirspec import create_nirspec_ifu_file
 from jwst.datamodels import ModelContainer
 from jwst.outlier_detection.tests import helpers
+from jwst.tests.helpers import _help_pytest_warns
 
 
 @pytest.fixture()
@@ -248,7 +249,7 @@ def miri_container(three_sci):
         Container of 3 models with MIR_LYOT exp_type and an assigned WCS.
     """
     exptype = "MIR_LYOT"
-    with pytest.warns(UserWarning, match="Double sampling check FAILED"):
+    with _help_pytest_warns(), pytest.warns(UserWarning, match="Double sampling check FAILED"):
         three_sci = helpers.assign_wcs_to_models(three_sci, exptype, False)
     container = ModelContainer(three_sci)
     return container

--- a/jwst/pipeline/tests/test_calwebb_image2.py
+++ b/jwst/pipeline/tests/test_calwebb_image2.py
@@ -5,6 +5,7 @@ import pytest
 
 from jwst.datamodels import ImageModel  # type: ignore[attr-defined]
 from jwst.stpipe import Step
+from jwst.tests.helpers import _help_pytest_warns
 
 INPUT_FILE = "test_rate.fits"
 INPUT_FILE_2 = "test2_rate.fits"
@@ -152,5 +153,8 @@ def test_bsub_deprecated(make_rate_file):
         "--steps.photom.skip=true",
         "--steps.resample.skip=true",
     ]
-    with pytest.warns(DeprecationWarning, match="The --save_bsub parameter is deprecated"):
+    with (
+        _help_pytest_warns(),
+        pytest.warns(DeprecationWarning, match="The --save_bsub parameter is deprecated"),
+    ):
         Step.from_cmdline(args)

--- a/jwst/pipeline/tests/test_calwebb_spec2.py
+++ b/jwst/pipeline/tests/test_calwebb_spec2.py
@@ -6,6 +6,7 @@ import pytest
 from jwst.datamodels import IFUImageModel  # type: ignore[attr-defined]
 from jwst.pipeline.calwebb_spec2 import Spec2Pipeline
 from jwst.stpipe import Step
+from jwst.tests.helpers import _help_pytest_warns
 
 INPUT_FILE = "test_rate.fits"
 INPUT_FILE_2 = "test2_rate.fits"
@@ -181,5 +182,8 @@ def test_bsub_deprecated(make_test_rate_file):
         "--steps.extract_1d.skip=true",
     ]
 
-    with pytest.warns(DeprecationWarning, match="The --save_bsub parameter is deprecated"):
+    with (
+        _help_pytest_warns(),
+        pytest.warns(DeprecationWarning, match="The --save_bsub parameter is deprecated"),
+    ):
         Step.from_cmdline(args)

--- a/jwst/regtest/test_miri_mrs_spec3.py
+++ b/jwst/regtest/test_miri_mrs_spec3.py
@@ -6,6 +6,7 @@ import pytest
 
 from jwst.regtest.st_fitsdiff import STFITSDiff as FITSDiff
 from jwst.stpipe import Step
+from jwst.tests.helpers import _help_pytest_warns
 
 # Define artifactory source and truth
 TRUTH_PATH = "truth/test_miri_mrs"
@@ -72,7 +73,7 @@ def run_spec3_ifushort_emsm(rtdata_module):
         '--steps.cube_build.output_file="miri_mrs_emsm"',
         "--steps.extract_1d.save_results=true",
     ]
-    with pytest.warns(Warning, match="Sources were found, but none pass"):
+    with _help_pytest_warns(), pytest.warns(Warning, match="Sources were found, but none pass"):
         Step.from_cmdline(args)
     return rtdata
 

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -20,6 +20,7 @@ from jwst.resample.resample import input_jwst_model_to_dict
 from jwst.resample.resample_spec import ResampleSpec, compute_spectral_pixel_scale
 from jwst.resample.resample_step import GOOD_BITS
 from jwst.resample.resample_utils import load_custom_wcs
+from jwst.tests.helpers import _help_pytest_warns
 
 _FLT32_EPS = np.finfo(np.float32).eps
 
@@ -974,7 +975,10 @@ def test_resample_undefined_variance(nircam_rate, shape):
     im.meta.filename = "foo.fits"
     c = ModelLibrary([im])
 
-    with pytest.warns(RuntimeWarning, match="'var_rnoise' array not available"):
+    with (
+        _help_pytest_warns(),
+        pytest.warns(RuntimeWarning, match="'var_rnoise' array not available"),
+    ):
         result = ResampleStep.call(c, blendheaders=False)
 
     # no valid variance - output error and variance are all NaN

--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -92,8 +92,9 @@ class JwstStep(_Step):
             Tuple of log names to configure.
         """
         # Specify the log names for any dependencies whose
-        # loggers we want to configure
-        return ("jwst", "stcal", "stdatamodels", "stpipe", "tweakwcs")
+        # loggers we want to configure and for the special "py.warnings"
+        # logger which is the source of warning log messages for python warnings
+        return ("jwst", "stcal", "stdatamodels", "stpipe", "tweakwcs", "py.warnings")
 
     def load_as_level2_asn(self, obj):
         """

--- a/jwst/tests/helpers.py
+++ b/jwst/tests/helpers.py
@@ -1,5 +1,7 @@
 """Handy helpful pytest helpers helping pytest test."""
 
+import contextlib
+import logging
 from os import path as op
 from pathlib import Path
 
@@ -126,3 +128,26 @@ class LogWatcher:
 
         # reset flag after check
         self.seen = False
+
+
+@contextlib.contextmanager
+def _help_pytest_warns():
+    """
+    Help pytest.warns.
+
+    Helper context to deal with a limitation with using warnings and logging.
+
+    This should be used for any pytest.warns context that contains a Step.call
+    (where logging.captureWarnings will be enabled) due to an incompatibility
+    between what python logging does to capture warnings and what python
+    warnings does to catch_warnings (and by extension what pytest.warns does).
+
+    This context works around the incompatibility by calling logging.captureWarnings
+    prior to the catch_warnings call. This allows the warnings module to
+    do the internal patching that is required to record warnings.
+
+    For minimal examples see the tests in test_helpers.
+    """
+    logging.captureWarnings(True)
+    yield
+    logging.captureWarnings(False)

--- a/jwst/tests/test_helpers.py
+++ b/jwst/tests/test_helpers.py
@@ -1,0 +1,41 @@
+import logging
+import warnings
+
+import pytest
+
+from jwst.tests.helpers import _help_pytest_warns
+
+
+def test_warning_inside_capture_logging():
+    """
+    Using _help_pytest_warns with pytest.warns doesn't prevent catching
+    expected warnings.
+    """
+    with _help_pytest_warns(), pytest.warns(UserWarning, match="expected"):
+        warnings.warn("expected", UserWarning)
+
+
+@pytest.mark.xfail
+def test_unexpected_warning_inside_capture_logging():
+    """
+    This should fail (see xfail) since the warning doesn't match.
+    We're using an xfail here because we're testing that pytest.warns
+    fails to catch a warnings.
+    """
+    with _help_pytest_warns(), pytest.warns(UserWarning, match="expected"):
+        warnings.warn("not the warning you're looking for", UserWarning)
+
+
+@pytest.mark.filterwarnings("ignore:foo")
+def test_python_warning_logging_incompatibility():
+    """
+    An example and smoke test for python showing the incompatibility
+    of logging.captureWarnings used within a warnings.catch_warnings
+    context.
+    """
+    with warnings.catch_warnings(record=True) as rec:
+        logging.captureWarnings(True)
+        warnings.warn("foo", UserWarning)
+        logging.captureWarnings(False)
+
+    assert len(rec) == 0  # note this is 0 and not 1


### PR DESCRIPTION
The "py.warnings" named logger is used by python when warnings are captured and routed to log messages.
https://docs.python.org/3.13/library/logging.html#logging.captureWarnings
as is done [in stpipe](https://github.com/spacetelescope/stpipe/blob/fe38ab0c68594e73449211f0b41a3df9de8886fc/src/stpipe/log.py#L342).

Including "py.warnings" allows log messages like [this one from stcal](https://github.com/spacetelescope/stcal/blob/1b28b89c206ef1a78a43c46f1558a5fd8929d467/src/stcal/resample/utils.py#L449) to be captured. Without listing "py.warnings" the warning message is lost and not displayed to the user.

However, the inclusion of "py.warnings" also means warnings from other packages (gwcs, asdf, astropy, etc...) will show up in strun executions. These were/are shown for all currently released versions of stpipe but not for stpipe main.

warnings.warn messages contain information that we want users to see and ideally also log these to `cal_logs`. Since stpipe currently [captures these](https://github.com/spacetelescope/stpipe/blob/fe38ab0c68594e73449211f0b41a3df9de8886fc/src/stpipe/log.py#L342) they no longer go through the warnings system (which for example displays UserWarnings). To have these messages be displayed and recorded we could:
1) merge this PR and accept that (perhaps temporarily) we also log warnings from packages not listed in `get_stpipe_loggers`
2) disable `captureWarnings` in stpipe, update jwst, stcal, stpipe, tweakwcs (etc) swapping all warnings.warn with logger.warn.
3) something else?

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
