### PR TITLE
Capture warnings using stpipe logging config

### DIFF
--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -93,7 +93,7 @@ class JwstStep(_Step):
         """
         # Specify the log names for any dependencies whose
         # loggers we want to configure
-        return ("jwst", "stcal", "stdatamodels", "stpipe", "tweakwcs")
+        return ("jwst", "stcal", "stdatamodels", "stpipe", "tweakwcs", "py.warnings")
 
     def load_as_level2_asn(self, obj):
         """


### PR DESCRIPTION
Relates to [JP-4138](https://jira.stsci.edu/browse/JP-4138)

This PR is linked to https://github.com/spacetelescope/stpipe/pull/271 - the capturing of warnings must be paired with the `py.warnings` logger being added to the stpipe loggers list.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
