### PR TITLE
Declare out when where is used in np.subtract

### DIFF
--- a/changes/9908.residual_fringe.rst
+++ b/changes/9908.residual_fringe.rst
@@ -1,1 +1,1 @@
-Fixed residual fringe subtraction that could have caused non-deterministic values under certain conditions.
+Fixed a bug that introduced arbitrary values to the residual fringe subtraction under certain conditions.

--- a/changes/9908.residual_fringe.rst
+++ b/changes/9908.residual_fringe.rst
@@ -1,0 +1,1 @@
+Fixed residual fringe subtraction that could have caused non-deterministic values under certain conditions.

--- a/jwst/residual_fringe/residual_fringe.py
+++ b/jwst/residual_fringe/residual_fringe.py
@@ -401,7 +401,7 @@ class ResidualFringeCorrection:
                                 out=np.zeros_like(proc_data),
                                 where=bg_fit != 0,
                             )
-                            res_fringes = np.subtract(res_fringes, 1, where=res_fringes != 0)
+                            np.subtract(res_fringes, 1, out=res_fringes, where=res_fringes != 0)
                             res_fringes *= np.where(col_weight > 1e-07, 1, 1e-08)
 
                             # fit the residual fringes
@@ -474,7 +474,7 @@ class ResidualFringeCorrection:
                             out=np.zeros_like(fringe_sub),
                             where=pbg_fit != 0,
                         )
-                        fit_res = np.subtract(fit_res, 1, where=fit_res != 0)
+                        np.subtract(fit_res, 1, out=fit_res, where=fit_res != 0)
                         fit_res *= np.where(col_weight > 1e-07, 1, 1e-08)
 
                         out_table.add_row(

--- a/jwst/residual_fringe/utils.py
+++ b/jwst/residual_fringe/utils.py
@@ -1107,7 +1107,7 @@ def fit_residual_fringes_1d(flux, wavelength, channel=1, dichroic_only=False, ma
             res_fringes = np.divide(
                 proc_data, bg_fit, out=np.zeros_like(proc_data), where=bg_fit != 0
             )
-            res_fringes = np.subtract(res_fringes, 1, where=res_fringes != 0)
+            res_fringes = np.subtract(res_fringes, 1, out=None, where=res_fringes != 0)
             res_fringes *= np.where(weights > 1e-07, 1, 1e-08)
 
             # fit the residual fringes

--- a/jwst/residual_fringe/utils.py
+++ b/jwst/residual_fringe/utils.py
@@ -1107,7 +1107,7 @@ def fit_residual_fringes_1d(flux, wavelength, channel=1, dichroic_only=False, ma
             res_fringes = np.divide(
                 proc_data, bg_fit, out=np.zeros_like(proc_data), where=bg_fit != 0
             )
-            res_fringes = np.subtract(res_fringes, 1, out=None, where=res_fringes != 0)
+            np.subtract(res_fringes, 1, out=res_fringes, where=res_fringes != 0)
             res_fringes *= np.where(weights > 1e-07, 1, 1e-08)
 
             # fit the residual fringes


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Declare out when where is used in np.subtract to avoid warning from numpy-dev

Motivation: Failure spam from https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst_devdeps.yml is starting to trigger me. Not sure what's up with the FITS diff but one fire at a time.

Should not need a change log since the changes are invisible to user.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md)) https://github.com/spacetelescope/RegressionTests/actions/runs/18209981773 (devdeps) and https://github.com/spacetelescope/RegressionTests/actions/runs/18204144569 (stable)
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
