### PR TITLE
JP-4155: Add a bounds check for centroid failure in tso_photometry

### DIFF
--- a/changes/9920.tso_photometry.rst
+++ b/changes/9920.tso_photometry.rst
@@ -1,0 +1,1 @@
+Add a check for centroid values outside of array dimensions.

--- a/jwst/tso_photometry/tests/test_tso_photometry.py
+++ b/jwst/tso_photometry/tests/test_tso_photometry.py
@@ -447,6 +447,48 @@ def test_fit_source_fail(monkeypatch, fit_psf):
         assert np.all(np.isnan(result))
 
 
+@pytest.mark.parametrize("fit_psf", [True, False])
+def test_fit_source_centroid_out_of_bounds(monkeypatch, fit_psf):
+    datamodel = mock_nircam_image()
+    mask = np.full(datamodel.data.shape, False)
+    box_size = int(RADIUS * 2 + 1)
+    xcenter, ycenter = XCENTER, YCENTER
+
+    def mock_centroid(*args, **kwargs):
+        return [-1], [-1]
+
+    monkeypatch.setattr(tp, "centroid_sources", mock_centroid)
+
+    # Failure in centroid just returns NaNs for all values
+    result = tp._fit_source(
+        datamodel.data, mask, mask[0], xcenter, ycenter, box_size, fit_psf=fit_psf
+    )
+    if fit_psf:
+        assert len(result) == 5
+        assert np.all(np.isnan(result))
+    else:
+        assert len(result) == 2
+        assert np.all(np.isnan(result))
+
+
+def test_fit_source_psf_fail(monkeypatch):
+    datamodel = mock_nircam_image()
+    mask = np.full(datamodel.data.shape, False)
+    box_size = int(RADIUS * 2 + 1)
+    xcenter, ycenter = XCENTER, YCENTER
+
+    def mock_psf(*args, **kwargs):
+        raise ValueError("test fail")
+
+    monkeypatch.setattr(tp, "_psf_fit_gaussian_prf", mock_psf)
+
+    # Failure in fit returns valid centroids, but NaNs for all psf values
+    result = tp._fit_source(datamodel.data, mask, mask[0], xcenter, ycenter, box_size, fit_psf=True)
+    assert len(result) == 5
+    assert not np.all(np.isnan(result[:3]))
+    assert np.all(np.isnan(result[3:]))
+
+
 def test_psf_fit():
     datamodel = mock_nircam_image()
     data = datamodel.data[0]

--- a/jwst/tso_photometry/tests/test_tso_photometry.py
+++ b/jwst/tso_photometry/tests/test_tso_photometry.py
@@ -447,15 +447,16 @@ def test_fit_source_fail(monkeypatch, fit_psf):
         assert np.all(np.isnan(result))
 
 
+@pytest.mark.parametrize("centroid_values", [([-1], [-1]), ([0], [-1]), ([-1], [0])])
 @pytest.mark.parametrize("fit_psf", [True, False])
-def test_fit_source_centroid_out_of_bounds(monkeypatch, fit_psf):
+def test_fit_source_centroid_out_of_bounds(monkeypatch, fit_psf, centroid_values):
     datamodel = mock_nircam_image()
     mask = np.full(datamodel.data.shape, False)
     box_size = int(RADIUS * 2 + 1)
     xcenter, ycenter = XCENTER, YCENTER
 
     def mock_centroid(*args, **kwargs):
-        return [-1], [-1]
+        return centroid_values
 
     monkeypatch.setattr(tp, "centroid_sources", mock_centroid)
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4155](https://jira.stsci.edu/browse/JP-4155)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Fix an issue found in testing, where a failed centroid sometimes returns a value out of bounds instead of NaN

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
