### PR TITLE
TST: Replace minimum_dependencies with tox-uv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 envlist =
     check-{dependencies,docs-links}
     py3{,11,12}{,-oldestdeps,-stdevdeps,-devdeps}{,-cov}{,-xdist}
+requires =
+    tox-uv
 
 [testenv:check-dependencies]
 description = verify that install_requires in setup.cfg has correct dependencies
@@ -43,10 +45,11 @@ extras =
     test
 deps =
     xdist: pytest-xdist
-    oldestdeps: minimum_dependencies
+uv_resolution =
+    # The oldestdeps factor is intended to be used to install
+    # the oldest versions of all dependencies
+    oldestdeps: lowest-direct
 commands_pre =
-    oldestdeps: minimum_dependencies jwst --filename {toxinidir}/requirements-min.txt
-    oldestdeps: pip install -r {toxinidir}/requirements-min.txt
     stdevdeps: pip install -r {toxinidir}/requirements-dev-st.txt -U --upgrade-strategy eager
     devdeps: pip install -r {toxinidir}/requirements-dev-thirdparty.txt -U --upgrade-strategy eager
     pip freeze


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR replaces `minimum_dependencies` with `tox-uv`  using `lowest-direct` for `uv_resolution` (modeled after `astropy`).

RT does not use tox, so no need to run RT.

Related attempts:

* https://github.com/spacetelescope/jwst/pull/9934
* https://github.com/spacetelescope/jwst/pull/9926
* https://github.com/astropy/photutils/pull/2120

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
