### PR TITLE
JP-4168: Use global wavelength spacing so results don't depend on chunk size for wfss_contam

### DIFF
--- a/jwst/wfss_contam/disperse.py
+++ b/jwst/wfss_contam/disperse.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 __all__ = ["disperse"]
 
 
-def _determine_native_wl_spacing(
+def determine_native_wl_spacing(
     x0_sky,
     y0_sky,
     sky_to_imgxy,
@@ -200,6 +200,7 @@ def disperse(
     naxis,
     oversample_factor=2,
     phot_per_lam=True,
+    lambdas=None,
 ):
     """
     Compute the dispersed image pixel values from the direct image.
@@ -238,6 +239,9 @@ def disperse(
         in this step.
         If False, it is assumed that the response is calibrated per pixel, and there is no need
         to multiply by dlam. This is what's done for NIRISS.
+    lambdas : ndarray, optional
+        If provided, use these wavelengths instead of computing them internally based on the native
+        wavelength spacing.
 
     Returns
     -------
@@ -268,17 +272,18 @@ def disperse(
     # Find RA/Dec of the input pixel position in segmentation map
     x0_sky, y0_sky = seg_wcs(x0, y0, with_bounding_box=False)
 
-    # native spacing does not change much over the detector, so just put in one x0, y0
-    lambdas = _determine_native_wl_spacing(
-        x0_sky[0],
-        y0_sky[0],
-        sky_to_imgxy,
-        imgxy_to_grismxy,
-        order,
-        wmin,
-        wmax,
-        oversample_factor=oversample_factor,
-    )
+    # Use provided wavelength grid if available, otherwise calculate it using first pixel position
+    if lambdas is None:
+        lambdas = determine_native_wl_spacing(
+            x0_sky[0],
+            y0_sky[0],
+            sky_to_imgxy,
+            imgxy_to_grismxy,
+            order,
+            wmin,
+            wmax,
+            oversample_factor=oversample_factor,
+        )
     nlam = len(lambdas)
     dlam = lambdas[1] - lambdas[0]
 

--- a/jwst/wfss_contam/observations.py
+++ b/jwst/wfss_contam/observations.py
@@ -3,11 +3,12 @@ import multiprocessing as mp
 import time
 
 import numpy as np
+from astropy.modeling.mappings import Mapping
 from astropy.stats import SigmaClip
 from photutils.background import Background2D, MedianBackground
 from stdatamodels.jwst import datamodels
 
-from jwst.wfss_contam.disperse import disperse
+from jwst.wfss_contam.disperse import determine_native_wl_spacing, disperse
 
 log = logging.getLogger(__name__)
 
@@ -200,6 +201,65 @@ class Observation:
         self.fluxes = np.array(self.fluxes)
         self.source_ids_per_pixel = np.array(self.source_ids_per_pixel)
 
+    def _compute_wavelength_grid(self, order, wmin, wmax):
+        """
+        Pre-compute wavelength grid for consistent dispersion across all chunks.
+
+        Samples a 10x10 grid across the detector, and chooses the finest native wavelength spacing
+        among those sampled points to avoid loss of resolution.
+
+        Parameters
+        ----------
+        order : int
+            Spectral order number
+        wmin : float
+            Minimum wavelength for dispersed spectra
+        wmax : float
+            Maximum wavelength for dispersed spectra
+
+        Returns
+        -------
+        lambdas : ndarray
+            Wavelengths at which to compute dispersed pixel values
+        """
+        # Set up transforms for wavelength grid calculation
+        sky_to_imgxy = self.grism_wcs.get_transform("world", "detector")
+        imgxy_to_grismxy = self.grism_wcs.get_transform("detector", "grism_detector")
+        n_outputs = len(imgxy_to_grismxy.outputs)
+
+        # Making the number of outputs dynamic handles legacy WCS objects that did not pass
+        # the x0, y0, and order through the transform unmodified like the current version does.
+        imgxy_to_grismxy = imgxy_to_grismxy | Mapping((0, 1), n_inputs=n_outputs)
+
+        # Sample a 10x10 grid across the detector to find minimum wavelength spacing
+        ny, nx = self.seg.shape
+        x = np.linspace(0, nx - 1, 10)
+        y = np.linspace(0, ny - 1, 10)
+        xx, yy = np.meshgrid(x, y)
+        x_sky, y_sky = self.seg_wcs(xx.flatten(), yy.flatten(), with_bounding_box=False)
+
+        min_dlam = np.inf
+        best_lambdas = None
+        for xi, yi in zip(x_sky, y_sky, strict=True):
+            # Calculate wavelength grid for this position
+            lambdas = determine_native_wl_spacing(
+                xi,
+                yi,
+                sky_to_imgxy,
+                imgxy_to_grismxy,
+                order,
+                wmin,
+                wmax,
+                oversample_factor=self.oversample_factor,
+            )
+            dlam = lambdas[1] - lambdas[0]
+            if dlam < min_dlam:
+                min_dlam = dlam
+                best_lambdas = lambdas
+
+        log.info(f"Selected wavelength grid with dlam={min_dlam:.6f} microns for order {order}")
+        return best_lambdas
+
     def chunk_sources(
         self, order, wmin, wmax, sens_waves, sens_response, selected_ids=None, max_pixels=1e5
     ):
@@ -244,6 +304,9 @@ class Observation:
         if current_chunk:
             chunks.append(current_chunk)
 
+        # Get pre-computed wavelength grid
+        lambdas = self._compute_wavelength_grid(order, wmin, wmax)
+
         disperse_args = []
         for source_ids in chunks:
             isin = np.isin(self.source_ids_per_pixel, source_ids)
@@ -267,6 +330,7 @@ class Observation:
                     self.naxis,
                     self.oversample_factor,
                     self.phot_per_lam,
+                    lambdas,
                 ]
             )
 

--- a/jwst/wfss_contam/tests/test_observations.py
+++ b/jwst/wfss_contam/tests/test_observations.py
@@ -114,4 +114,56 @@ def test_disperse_order(observation, segmentation_map):
     assert slit.data.shape == (slit.ysize, slit.xsize)
 
     # check for regression by hard-coding one value of slit.data
-    assert np.isclose(slit.data[5, 60], 20.996877670288086)
+    assert np.isclose(slit.data[5, 60], 21.067791)
+
+
+def test_same_result_different_chunks(observation, segmentation_map):
+    """
+    Test that when sources are split into chunks, they have the same result as when not split.
+
+    This covers a bug where sources could have different numerical results when part of a different
+    chunk, because of how the wavelength grid was computed.
+    """
+    obs = copy.deepcopy(observation)
+    order = 1
+    sens_waves = np.linspace(1.708, 2.28, 100)
+    wmin, wmax = np.min(sens_waves), np.max(sens_waves)
+    sens_resp = np.ones_like(sens_waves)
+
+    seg = segmentation_map.data
+    all_ids = np.array(list(set(np.ravel(seg))))
+    source_ids = all_ids[50:55]
+
+    # figure out total number of pixels for these sources and set chunk size accordingly
+    # to make sure a few chunks get made
+    is_selected = np.isin(seg.flatten(), source_ids)
+    max_per_chunk = np.sum(is_selected) // 3
+
+    # Run disperse_order twice: once for reference, once with very small chunks to force splitting
+    obs_reference = copy.deepcopy(obs)
+    obs_reference.disperse_order(order, wmin, wmax, sens_waves, sens_resp, selected_ids=source_ids)
+
+    obs.max_pixels_per_chunk = max_per_chunk
+    obs.disperse_order(order, wmin, wmax, sens_waves, sens_resp, selected_ids=source_ids)
+
+    # Ensure each source ID appears exactly once in final slits
+    slit_source_ids = [slit.source_id for slit in obs.simulated_slits.slits]
+    unique_slit_ids = list(set(slit_source_ids))
+    assert len(slit_source_ids) == len(unique_slit_ids), "Duplicate source IDs found in slits"
+
+    # Verify all slits are identical between reference and test
+    ref_slits = {slit.source_id: slit for slit in obs_reference.simulated_slits.slits}
+    test_slits = {slit.source_id: slit for slit in obs.simulated_slits.slits}
+    for source_id in ref_slits.keys():
+        ref_slit = ref_slits[source_id]
+        test_slit = test_slits[source_id]
+
+        # Bounds and shapes should be identical
+        assert ref_slit.xstart == test_slit.xstart
+        assert ref_slit.ystart == test_slit.ystart
+        assert ref_slit.xsize == test_slit.xsize
+        assert ref_slit.ysize == test_slit.ysize
+
+        # Data should be identical
+        assert ref_slit.data.shape == test_slit.data.shape
+        assert_allclose(ref_slit.data, test_slit.data)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4168](https://jira.stsci.edu/browse/JP-4168)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
Closes #9950 

<!-- describe the changes comprising this PR here -->
This PR addresses ...

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
