### PR TITLE
JP-4123: Prepare output for clean_flicker_noise

### DIFF
--- a/jwst/clean_flicker_noise/tests/test_clean_flicker_noise_step.py
+++ b/jwst/clean_flicker_noise/tests/test_clean_flicker_noise_step.py
@@ -16,10 +16,13 @@ from jwst.pipeline import Detector1Pipeline
 @pytest.mark.parametrize("skip", [True, False])
 def test_output_type(skip):
     input_model = make_small_ramp_model()
-    step_instance = CleanFlickerNoiseStep()
+
     # Default is that step is skipped
+    step_instance = CleanFlickerNoiseStep()
     assert step_instance.skip == True
-    cleaned = step_instance.call(input_model, skip=skip)
+
+    # Run call with skip option
+    cleaned = CleanFlickerNoiseStep.call(input_model, skip=skip)
 
     # output is a ramp model either way
     assert isinstance(cleaned, datamodels.RampModel)
@@ -31,12 +34,13 @@ def test_output_type(skip):
 @pytest.mark.parametrize("skip", [True, False])
 def test_run_in_pipeline(skip):
     input_model = make_small_ramp_model()
-    pipeline_instance = Detector1Pipeline()
 
+    # Default is to skip the step
+    pipeline_instance = Detector1Pipeline()
     assert pipeline_instance.steps["clean_flicker_noise"]["skip"] == True
 
     # Run the pipeline, omitting steps that are incompatible with our datamodel
-    cleaned = pipeline_instance.call(
+    cleaned = Detector1Pipeline.call(
         input_model,
         steps={
             "clean_flicker_noise": {"skip": skip},


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-4123](https://jira.stsci.edu/browse/JP-4123)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Update clean_flicker_noise to use prepare_output to open and copy datamodels as necessary.

This change required some minor refactoring to move the input data copy out of the algorithm implementation and into the step instead.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
