### PR TITLE
Check for previously disabled log

### DIFF
--- a/jwst/lib/basic_utils.py
+++ b/jwst/lib/basic_utils.py
@@ -72,8 +72,12 @@ def disable_logging(level=logging.CRITICAL):
             # code containing logging to ignore, other than CRITICAL messages
             ...
     """
-    logging.disable(level)
-    try:
+    current_level = logging.root.manager.disable
+    if current_level < level:
+        logging.disable(level)
+        try:
+            yield
+        finally:
+            logging.disable(current_level)
+    else:
         yield
-    finally:
-        logging.disable(logging.NOTSET)

--- a/jwst/lib/tests/test_basic_utils.py
+++ b/jwst/lib/tests/test_basic_utils.py
@@ -1,0 +1,60 @@
+import logging
+
+from jwst.lib.basic_utils import LoggingContext, disable_logging
+
+log = logging.getLogger(__name__)
+
+
+def test_logging_context(caplog):
+    with LoggingContext(logger=log, level=logging.CRITICAL):
+        log.info("test 1")
+    assert caplog.text == ""
+
+    with LoggingContext(logger=log, level=logging.INFO):
+        log.info("test 2")
+    assert "test 2" in caplog.text
+
+
+def test_disable_logging(caplog):
+    with LoggingContext(logger=log, level=logging.INFO):
+        # log is enabled
+        log.info("test 1")
+        assert "test 1" in caplog.text
+        assert logging.root.manager.disable == logging.NOTSET
+
+        with disable_logging():
+            log.info("test 2")
+            assert logging.root.manager.disable == logging.CRITICAL
+        assert "test 2" not in caplog.text
+
+        # log is re-enabled after exit
+        log.info("test 3")
+        assert "test 3" in caplog.text
+        assert logging.root.manager.disable == logging.NOTSET
+
+        # if the level is higher than the message, it will appear
+        with disable_logging(level=logging.DEBUG):
+            log.info("test 4")
+            assert logging.root.manager.disable == logging.DEBUG
+        assert "test 4" in caplog.text
+        assert logging.root.manager.disable == logging.NOTSET
+
+
+def test_disable_logging_already_disabled(caplog):
+    with LoggingContext(logger=log, level=logging.INFO):
+        with disable_logging():
+            # log is disabled
+            log.info("test 1")
+            assert caplog.text == ""
+            assert logging.root.manager.disable == logging.CRITICAL
+
+            # log is still disabled inside the context manager
+            with disable_logging(level=logging.DEBUG):
+                log.info("test 2")
+                assert caplog.text == ""
+                assert logging.root.manager.disable == logging.CRITICAL
+
+            # log is still disabled after exiting the context manager
+            log.info("test 3")
+            assert caplog.text == ""
+            assert logging.root.manager.disable == logging.CRITICAL


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Working on some clean_flicker_noise updates, I noticed a small problem with a context manager it uses to disable some unneeded log messages.  If logging is already disabled before the step is called, the step will re-enable it in the middle of processing.  This PR modifies the context manager to check for an already-disabled log and adds some tests.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
