### PR TITLE
Temporarily don't treat drizzle deprecation warnings as errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,7 +228,11 @@ addopts = [
 ]
 xfail_strict = true
 filterwarnings = [
-    "error"
+    "error",
+    "ignore:Argument 'scale' has been deprecated since version 3.0.*Use 'iscale' and 'pixel_scale_ratio' instead.*:DeprecationWarning",
+    "ignore:Argument 'output_pixel_shape' has been deprecated since version 3.0.*can be inferred from 'pixmap'.*:DeprecationWarning",
+    "ignore:Argument 'exptime' has been deprecated since version 3.0.*Use 'iscale' instead and set iscale=exptime.*:DeprecationWarning",
+    "ignore:Argument 'pix_ratio' has been deprecated since version 3.0.*Use 'iscale' instead and set iscale.*:DeprecationWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
In preparation for release 3.0 of `drizzle` package, this PR disables treatment of deprecation warnings to be introduced in the upcoming release of the `drizzle` as errors during testing.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
