### PR TITLE
JP-4123: Prepare output for reset; update flags in place

### DIFF
--- a/jwst/reset/reset_step.py
+++ b/jwst/reset/reset_step.py
@@ -26,46 +26,44 @@ class ResetStep(Step):
 
         Parameters
         ----------
-        step_input : DataModel
+        step_input : `~stdatamodels.jwst.datamodels.RampModel`
            Input datamodel to be corrected
 
         Returns
         -------
-        reset: DataModel
+        reset: `~stdatamodels.jwst.datamodels.RampModel`
            The reset corrected ramp model.
         """
         # Open the input data model
-        with datamodels.open(step_input) as input_model:
-            # Work on a copy
-            result = input_model.copy()
+        result = self.prepare_output(step_input, open_as_type=datamodels.RampModel)
 
-            # check the data is MIRI data
-            detector = result.meta.instrument.detector
-            if not detector.startswith("MIR"):
-                log.warning("Reset Correction is only for MIRI data")
-                log.warning("Reset step will be skipped")
-                result.meta.cal_step.reset = "SKIPPED"
-                return result
+        # check the data is MIRI data
+        detector = result.meta.instrument.detector
+        if not detector.startswith("MIR"):
+            log.warning("Reset Correction is only for MIRI data")
+            log.warning("Reset step will be skipped")
+            result.meta.cal_step.reset = "SKIPPED"
+            return result
 
-            # Get the name of the reset reference file to use
-            self.reset_name = self.get_reference_file(result, "reset")
-            log.info(f"Using RESET reference file {self.reset_name}")
+        # Get the name of the reset reference file to use
+        reset_name = self.get_reference_file(result, "reset")
+        log.info(f"Using RESET reference file {reset_name}")
 
-            # Check for a valid reference file
-            if self.reset_name == "N/A":
-                log.warning("No RESET reference file found")
-                log.warning("Reset step will be skipped")
-                result.meta.cal_step.reset = "SKIPPED"
-                return result
+        # Check for a valid reference file
+        if reset_name == "N/A":
+            log.warning("No RESET reference file found")
+            log.warning("Reset step will be skipped")
+            result.meta.cal_step.reset = "SKIPPED"
+            return result
 
-            # Open the reset ref file data model
-            reset_model = datamodels.ResetModel(self.reset_name)
+        # Open the reset ref file data model
+        reset_model = datamodels.ResetModel(reset_name)
 
-            # Do the reset correction subtraction
-            result = reset_sub.do_correction(result, reset_model)
-            result.meta.cal_step.reset = "COMPLETE"
+        # Do the reset correction subtraction
+        result = reset_sub.do_correction(result, reset_model)
+        result.meta.cal_step.reset = "COMPLETE"
 
-            # Cleanup
-            del reset_model
+        # Cleanup
+        del reset_model
 
         return result

--- a/jwst/reset/reset_sub.py
+++ b/jwst/reset/reset_sub.py
@@ -24,15 +24,15 @@ def do_correction(output_model, reset_model):
 
     Parameters
     ----------
-    output_model : `~jwst.datamodels.RampModel`
+    output_model : `~stdatamodels.jwst.datamodels.RampModel`
         Science data to be corrected
 
-    reset_model : `~jwst.datamodels.ResetModel`
+    reset_model : `~stdatamodels.jwst.datamodels.ResetModel`
         Reset reference file model
 
     Returns
     -------
-    output_model : `~jwst.datamodels.RampModel`
+    output_model : `~stdatamodels.jwst.datamodels.RampModel`
         Reset-subtracted science data
     """
     # Save some data params for easy use later
@@ -69,7 +69,7 @@ def do_correction(output_model, reset_model):
             ir = reset_nints - 1
 
         # combine the science and reset DQ arrays
-        output_model.pixeldq = np.bitwise_or(output_model.pixeldq, reset_model.dq)
+        output_model.pixeldq |= reset_model.dq
 
         # we are only correcting the first reset_ngroups
         for j in range(igroup):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-4123](https://jira.stsci.edu/browse/JP-4123)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Implement prepare_output for reset.  Also:
- rename an unnecessary attribute to a local variable (self.reset_name)
- update pixeldq flags in place instead of making a copy with np.bitwise_or

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
