### PR TITLE
Update test to use .hasattr

### DIFF
--- a/jwst/extract_1d/tests/test_extract.py
+++ b/jwst/extract_1d/tests/test_extract.py
@@ -496,7 +496,7 @@ def test_copy_keyword_info(mock_nirspec_fs_one_slit, mock_one_spec):
     }
     for key, value in expected.items():
         setattr(mock_nirspec_fs_one_slit, key, value)
-        assert not hasattr(mock_one_spec, key)
+        assert not mock_one_spec.hasattr(key)
 
     ex.copy_keyword_info(mock_nirspec_fs_one_slit, "slit_name", mock_one_spec)
     assert mock_one_spec.name == "slit_name"


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR updates a test to use the `model.hasattr()` workaround to the [bug here](https://github.com/spacetelescope/stdatamodels/issues/470).

The test was causing downstream failures after adding `source_xpos` and `source_ypos` to the core schema in support for [JP-3307](https://jira.stsci.edu/browse/JP-3307); see https://github.com/spacetelescope/stdatamodels/actions/runs/19573903486/job/56054023086?pr=620

No need to run regression tests because only unit test code was touched.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
