### PR TITLE
JP-3967: Update test to go with stcal PR 421 changes

### DIFF
--- a/jwst/ramp_fitting/tests/test_ramp_fit.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit.py
@@ -353,7 +353,7 @@ class TestMethods:
 
         # expect SATURATED
         dq = slopes[1]
-        assert dq[50, 51] == GOOD
+        assert dq[50, 51] == SATURATED
 
         # expect SATURATED and DO_NOT_USE, because 1st group is Saturated
         assert dq[50, 52] == SATURATED | DO_NOT_USE


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3967](https://jira.stsci.edu/browse/JP-3967)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR addresses https://github.com/spacetelescope/jwst/issues/8124 and is a companion for https://github.com/spacetelescope/stcal/pull/421 . 

## TODO

- [x] Make sure CI passes.
- [x] Do we need change log? There is change log in the stcal PR but jwst users might not read stcal change log.
- Verify that RT failures are expected by
  - [x] checking test summary to ensure failures are only from DQ extensions
    - [x] re-check `test_nirspec_picture_frame[rate]`
  - [x] [checking test results](https://gist.github.com/pllim/0c028713feadb7ee8a435da4457ae63a) to ensure only saturation flag is added, and added where it is supposed to by also comparing to input `ramp.fits`, which requires local run
    - [x] resolve `test_niriss_image_detector1_with_likelihood[likely_rate]` 
- [x] Drop the TMP commit pointing to upstream PR branch once point is proven, and upstream PR is merged.

Note: The following uncommitted diff was necessary to decouple CHARGELOSS effect from ramp fitting in [checking test results](https://gist.github.com/pllim/0c028713feadb7ee8a435da4457ae63a) locally.

```diff
--- a/jwst/regtest/test_niriss_image.py
+++ b/jwst/regtest/test_niriss_image.py
@@ -162,6 +162,7 @@ def run_detector1_with_likelihood_fitting(rtdata_mod
ule, resource_tracker):
         rtdata_module.input,
         "--output_file=jw01094001002_02107_00001_nis_likely",
         "--steps.ramp_fit.algorithm=LIKELY",
+        "--steps.charge_migration.skip=True",
     ]
     with resource_tracker.track():
         Step.from_cmdline(args)
```

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md)) using `stcal@git+https://github.com/pllim/stcal.git@life-of-a-sat-grid` -- https://github.com/spacetelescope/RegressionTests/actions/runs/19682955885 and https://github.com/spacetelescope/RegressionTests/actions/runs/19901568465 and https://github.com/spacetelescope/RegressionTests/actions/runs/20086800853 and https://github.com/spacetelescope/RegressionTests/actions/runs/20108700591 and https://github.com/spacetelescope/RegressionTests/actions/runs/20248199486 and https://github.com/spacetelescope/RegressionTests/actions/runs/20289156418
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
