### PR TITLE
Change NIRCam WFSS spec2 regtest data to be a sparser field so bkgsub won't fail

### DIFF
--- a/jwst/regtest/test_nircam_wfss_spec2.py
+++ b/jwst/regtest/test_nircam_wfss_spec2.py
@@ -15,9 +15,9 @@ def run_pipeline(rtdata_module, resource_tracker):
     rtdata = rtdata_module
 
     # Get the input data; load individual data files first, load ASN file last
-    rtdata.get_data("nircam/wfss/jw01076-o101_t002_nircam_clear-f356w_cat.ecsv")
-    rtdata.get_data("nircam/wfss/jw01076101001_02101_00003_nrcalong_rate.fits")
-    rtdata.get_data("nircam/wfss/jw01076-o101_20220403t120233_spec2_002_asn.json")
+    rtdata.get_data("nircam/wfss/jw01076-o103_t001_nircam_clear-f250m_cat.ecsv")
+    rtdata.get_data("nircam/wfss/jw01076103001_02104_00001_nrcblong_rate.fits")
+    rtdata.get_data("nircam/wfss/jw01076-o103_20231023t160322_spec2_00003_asn.json")
 
     # Run the calwebb_spec2 pipeline; save results from intermediate steps
     args = [
@@ -52,7 +52,7 @@ def test_nircam_wfss_spec2(run_pipeline, fitsdiff_default_kwargs, suffix):
 
     # Run the pipeline and retrieve outputs
     rtdata = run_pipeline
-    output = f"jw01076101001_02101_00003_nrcalong_{suffix}.fits"
+    output = f"jw01076103001_02104_00001_nrcblong_{suffix}.fits"
     rtdata.output = output
 
     # Get the truth files


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Relates to [JP-4184](https://jira.stsci.edu/browse/JP-4184)

<!-- describe the changes comprising this PR here -->
During the background step of the pipeline run currently on main, the 5% background pixels threshold barely passes, and the step completes.  But the bugfix for JP-4184 will make the "non-background" regions longer by ~200 pixels for NIRCam data.  This change causes the 5% background pixels threshold to no longer be satisfied for the regtest data, so the background step is skipped and therefore the test is no longer adequate.

This PR makes the regression tests for the NIRCam WFSS spec2 pipeline use a dataset pointed toward a sparser field.  This allows the background step to be meaningfully tested even after the stdatamodels change for JP-4184.

After this PR is merged the following files can be deleted from the regression test suite:

- truth/test_nircam_wfss_spec2/jw01076101001_02101_00003_nrcalong_*.fits

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
