### PR TITLE
remove ignores for ResourceWarnings

### DIFF
--- a/jwst/pipeline/tests/test_calwebb_image2.py
+++ b/jwst/pipeline/tests/test_calwebb_image2.py
@@ -109,7 +109,6 @@ def test_output_file_rename_file(run_image2_pipeline_file):
         assert os.path.exists(f"{custom_stem}_{extension}.fits")
 
 
-@pytest.mark.filterwarnings("ignore::ResourceWarning")
 def test_output_file_norename_asn(run_image2_pipeline_asn):
     """
     Ensure output_file parameter is ignored, with warning,

--- a/jwst/pipeline/tests/test_calwebb_image3.py
+++ b/jwst/pipeline/tests/test_calwebb_image3.py
@@ -63,7 +63,6 @@ def make_dummy_association(make_dummy_cal_file):
     )
 
 
-@pytest.mark.filterwarnings("ignore::ResourceWarning")  # in_memory=False
 @pytest.mark.parametrize("in_memory", [True, False])
 def test_run_image3_pipeline(make_dummy_association, in_memory):
     """
@@ -88,7 +87,6 @@ def test_run_image3_pipeline(make_dummy_association, in_memory):
     _is_run_complete(LOGFILE)
 
 
-@pytest.mark.filterwarnings("ignore::ResourceWarning")
 def test_run_image3_single_file(make_dummy_cal_file):
     args = [
         "calwebb_image3",

--- a/jwst/pipeline/tests/test_calwebb_spec2.py
+++ b/jwst/pipeline/tests/test_calwebb_spec2.py
@@ -127,7 +127,6 @@ def test_output_file_rename(run_spec2_pipeline):
         assert os.path.exists(f"{custom_stem}_{extension}.fits")
 
 
-@pytest.mark.filterwarnings("ignore::ResourceWarning")
 def test_output_file_norename_asn(run_spec2_pipeline_asn):
     """
     Ensure output_file parameter is ignored, with warning,


### PR DESCRIPTION
Remove pytest marks that ignore `ResourceWarnings` for a few unit tests. The removal does not produce any test failures (which would be expected if these tests emitted warnings which would be turned into warnings).

Regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/20756706360/job/59601070575

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
