### PR TITLE
JP-4219: Avoid changing array shape in-place

### DIFF
--- a/jwst/regtest/test_fgs_pointing.py
+++ b/jwst/regtest/test_fgs_pointing.py
@@ -8,7 +8,7 @@ import pytest
 pytest.importorskip("pysiaf")
 
 from astropy.utils.data import get_pkg_data_filenames  # noqa: E402
-from numpy import array  # noqa: E402
+from numpy import ones  # noqa: E402
 from numpy.testing import assert_allclose  # noqa: E402
 
 from jwst.datamodels import Level1bModel  # type: ignore[attr-defined] # noqa: E402
@@ -294,8 +294,7 @@ def update_wcs(make_level1b):
 @pytest.fixture(scope="module", params=[META_FGS1, META_FGS2])
 def make_level1b(request):
     model_meta = request.param
-    data = array([1.0])
-    data.shape = (1, 1, 1, 1)
+    data = ones((1, 1, 1, 1))
     model = Level1bModel(data)
     model.update(model_meta["wcs"])
     return model, model_meta["expected"]


### PR DESCRIPTION
Resolves [JP-4219](https://jira.stsci.edu/browse/JP-4219)
Closes #10121

This PR addresses the issue of deprecation of changing array shape in-place via setting `np.ndarray.shape` attribute, see https://numpy.org/devdocs/release/notes-towncrier.html#setting-the-shape-attribute-is-deprecated.

Regression test: https://github.com/spacetelescope/RegressionTests/actions/runs/20889153087

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
