### PR TITLE
Remove unstable timing tests

### DIFF
--- a/jwst/jump/tests/test_jump_step.py
+++ b/jwst/jump/tests/test_jump_step.py
@@ -1,7 +1,4 @@
 import multiprocessing
-import os
-import platform
-import time
 from itertools import cycle
 
 import numpy as np
@@ -515,99 +512,6 @@ def test_snowball_flagging_sat(generate_nircam_reffiles, setup_inputs):
 
 
 # --------  Brought over from detect jumps --------
-
-
-def test_exec_time_0_crs(setup_inputs):
-    """ "Set up with dimension similar to simulated MIRI datasets.
-
-    Dataset has no cosmic rays. Test only the execution time of jump detection
-    for comparison with nominal time; hopefully indicative of faults with newly
-    added code.
-    """
-    model1, gdq, rnoise, pixdq, err, gain = setup_inputs(
-        ngroups=10,
-        nrows=1024,
-        ncols=1032,
-        nints=2,
-        readnoise=6.5,
-        gain=5.5,
-        grouptime=2.775,
-        deltatime=2.775,
-    )
-
-    tstart = time.monotonic()
-
-    # using dummy variable in next to prevent "F841-variable is assigned to but never used"
-    _ = JumpStep.call(
-        model1,
-        override_gain=gain,
-        override_readnoise=rnoise,
-        rejection_threshold=4.0,
-        three_group_rejection_threshold=5.0,
-        four_group_rejection_threshold=6.0,
-        maximum_cores="none",
-        max_jump_to_flag_neighbors=200,
-        min_jump_to_flag_neighbors=4,
-        flag_4_neighbors=True,
-    )
-    tstop = time.monotonic()
-
-    t_elapsed = tstop - tstart
-    if platform.system() == "Darwin" and os.environ.get("CI", False):
-        # github mac runners have known performance issues see:
-        # https://github.com/actions/runner-images/issues/1336
-        # use a longer MAX_TIME when running on github on a mac
-        MAX_TIME = 20
-    else:
-        MAX_TIME = 10  # takes 1.6 sec on my Mac
-
-    assert t_elapsed < MAX_TIME
-
-
-def test_exec_time_many_crs(setup_inputs):
-    """ "Set up with dimension similar to simulated MIRI datasets.
-
-    Dataset has many cosmic rays; approximately one CR per 4 groups. Test only
-    the execution time of jump detection for comparison with nominal time;
-    hopefully indicative of faults with newly added code.
-    """
-    nrows = 350
-    ncols = 400
-
-    model1, gdq, rnoise, pixdq, err, gain = setup_inputs(
-        ngroups=10,
-        nrows=nrows,
-        ncols=ncols,
-        nints=2,
-        readnoise=6.5,
-        gain=5.5,
-        grouptime=2.775,
-        deltatime=2.775,
-    )
-
-    crs_frac = 0.25  # fraction of groups having a CR
-    model1 = add_crs(model1, crs_frac)  # add desired fraction of CRs
-
-    tstart = time.time()
-    # using dummy variable in next to prevent "F841-variable is assigned to but never used"
-    _ = JumpStep.call(
-        model1,
-        override_gain=gain,
-        override_readnoise=rnoise,
-        rejection_threshold=4.0,
-        three_group_rejection_threshold=5.0,
-        four_group_rejection_threshold=6.0,
-        maximum_cores="none",
-        max_jump_to_flag_neighbors=200,
-        min_jump_to_flag_neighbors=4,
-        flag_4_neighbors=True,
-    )
-    tstop = time.time()
-
-    t_elapsed = tstop - tstart
-    MAX_TIME = 600  # takes ~100 sec on my Mac
-
-    assert t_elapsed < MAX_TIME
 
 
 def test_nocrs_noflux(setup_inputs):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Remove a couple unit tests that only check execution time against a hard-coded limit.

One of these tests is unstable and failing intermittently in CI (`test_exec_time_0_crs`).   We could fix it by assigning a more generous execution time, but I think these kinds of tests are not helpful in general, so I propose removing them instead.  We should measure performance via regression tests on consistent architectures.

Unit test change only, no need for regtests.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
