### PR TITLE
JP-4192: Prepare output for cube_build

### DIFF
--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -25,8 +25,7 @@ class DataTypes:
         """
         Assemble input data for processing.
 
-        Open the input data using datamodels and determine if data is
-        a single input model, an association, or a set of input models
+        Determine if data is a single input model or a set of input models
         contained in a ModelContainer. The method populates the self.input_models
         which is a list of input models. An initial base name for the output file
         is constructed.
@@ -34,11 +33,10 @@ class DataTypes:
         Parameters
         ----------
         input_models : IFUImageModel or ModelContainer
-           Input data to cube_build either a filename, single model,
-           association table, or a ModelContainer
+           Input data to cube_build. Either a single model or a ModelContainer.
         single : bool
-           If True then creating single mode IFUCubes for outlier detection
-           or mrs_matching. If false then creating standard IFUcubes
+           If True, then create single mode IFU cubes for outlier detection.
+           If False, then create standard IFU cubes.
         output_file : str
            Optional user provided output file name.
         output_dir : str

--- a/jwst/cube_build/data_types.py
+++ b/jwst/cube_build/data_types.py
@@ -21,7 +21,7 @@ class DataTypes:
         "products": [{"name": "", "members": [{"exptype": "", "expname": ""}]}],
     }
 
-    def __init__(self, input_data, single, output_file, output_dir):
+    def __init__(self, input_models, single, output_file, output_dir):
         """
         Assemble input data for processing.
 
@@ -33,7 +33,7 @@ class DataTypes:
 
         Parameters
         ----------
-        input_data : str, IFUImageModel or ModelContainer
+        input_models : IFUImageModel or ModelContainer
            Input data to cube_build either a filename, single model,
            association table, or a ModelContainer
         single : bool
@@ -54,14 +54,6 @@ class DataTypes:
         self.input_models = []
         self.output_name = None
 
-        # open the input_data with datamodels
-        # if input_data is filename or model when it is opened it is a model
-        # if input_data is an association name or ModelContainer then it is opened as a container
-
-        input_models = datamodels.open(input_data)
-        # if input_data is a filename, we will need to close the opened file
-        self._opened = [input_models]
-
         if isinstance(input_models, datamodels.IFUImageModel):
             # It's a single image that's been passed in as a model
             # input_data is a model
@@ -75,9 +67,8 @@ class DataTypes:
             if not single:  # find the name of the output file from the association
                 self.output_name = input_models.asn_table["products"][0]["name"]
         else:
-            # close files opened above
-            self.close()
             raise TypeError(f"Failed to process file type {type(input_models)}")
+
         # If the user has set the output name, strip off *.fits.
         # Suffixes will be added to this name later, to designate the
         # channel+subchannel (MIRI MRS) or grating+filter (NRS IFU) the output cube covers.
@@ -88,11 +79,6 @@ class DataTypes:
         if output_dir is not None:
             self.output_name = output_dir + "/" + self.output_name
 
-    def close(self):
-        """Close any files opened by this instance."""
-        [f.close() for f in self._opened]
-
-    # _______________________________________________________________________________
     def build_product_name(self, filename):
         """
         Determine the base of output name if an input data is a FITS filename.
@@ -119,9 +105,6 @@ class DataTypes:
         else:
             single_product = filename[:indx]
         return single_product
-
-
-# _______________________________________________________________________________
 
 
 class NotIFUImageModelError(Exception):

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -683,7 +683,7 @@ class IFUCubeData:
             for input_model in self.master_table.FileMap[self.instrument][this_par1][this_par2]:
                 # loop over the files that cover the spectral range the cube is for
 
-                self.input_models_this_cube.append(input_model.copy())
+                self.input_models_this_cube.append(input_model)
                 # set up input_model to be first file used to copy in basic header info
                 # to ifucube meta data
                 if ib == 0 and k == 0:

--- a/jwst/cube_build/tests/test_offset.py
+++ b/jwst/cube_build/tests/test_offset.py
@@ -138,10 +138,10 @@ def test_offset_file_config(tmp_cwd, miri_ifushort_short_2files, offset_file):
 
     # first test that it is a valid asdf file and has what is needed
     step = CubeBuildStep()
-    step.input_models = miri_ifushort_short_2files
+    input_models = miri_ifushort_short_2files
 
     step.offset_file = offset_file
-    offsets = step.check_offset_file()
+    offsets = step.check_offset_file(input_models)
     assert isinstance(offsets, dict)
 
 
@@ -151,13 +151,13 @@ def test2_offset_file_config(tmp_cwd, miri_ifushort_short_2files, offset_file):
     # Test changing one of the filenames so it is not in the list given
     # in the offset_file
     step = CubeBuildStep()
-    step.input_models = miri_ifushort_short_2files
+    input_models = miri_ifushort_short_2files
 
     miri_ifushort_short_2files[0].meta.filename = "test3.fits"
     step.offset_file = offset_file
 
     with pytest.raises(ValueError):
-        step.check_offset_file()
+        step.check_offset_file(input_models)
 
 
 def test_offset_file_units(tmp_cwd, miri_ifushort_short_2files, offset_file_arcmin):
@@ -165,20 +165,20 @@ def test_offset_file_units(tmp_cwd, miri_ifushort_short_2files, offset_file_arcm
 
     # test is the if the user set the units to arcmins
     step = CubeBuildStep()
-    step.input_models = miri_ifushort_short_2files
+    input_models = miri_ifushort_short_2files
 
     step.offset_file = offset_file_arcmin
     with pytest.raises(Exception):
-        step.check_offset_file()
+        step.check_offset_file(input_models)
 
 
 def test_read_offset_file(miri_ifushort_short_2files, offset_file):
     """Test offset file has been read in correctly"""
 
     step = CubeBuildStep()
-    step.input_models = miri_ifushort_short_2files
+    input_models = miri_ifushort_short_2files
     step.offset_file = offset_file
-    offsets = step.check_offset_file()
+    offsets = step.check_offset_file(input_models)
     # Test that the offset file is read in and is a dictionary
     assert isinstance(offsets, dict)
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-4192](https://jira.stsci.edu/browse/JP-4192)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Update cube_build to use `prepare_output`.  

Some notes:
- I moved a datamodels.open call out of the DataTypes class, so it now expects open datamodels and does not attempt to close anything.  
- I moved a reference to the input datamodels out of `self.input_models` for the class, to make sure they can be garbage collected, even if the step is still in scope.  
- I removed an unnecessary datamodel copy in IFUCubeData.build_ifucube.
- I raised an error in a couple places where the step was warning and returning None.  The calling code in the pipelines does not check for None in the return value, so these conditions would have resulted in crashes anyway.
- I added a test to check that the input data is not modified by the pre-processing in the step.  Since the input models were not previously copied when called standalone, this test fails on main.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
