### PR TITLE
Avoid passing zero-size arrays to wcs_bbox_from_shape in tests

### DIFF
--- a/jwst/assign_wcs/tests/test_assign_wcs_step.py
+++ b/jwst/assign_wcs/tests/test_assign_wcs_step.py
@@ -11,8 +11,8 @@ from jwst.assign_wcs.tests.test_niriss import create_hdul as create_niriss
 
 def test_assign_wcs_step_miri_ifu():
     hdul = create_miri(detector="MIRIFULONG", channel="34", band="MEDIUM")
+    hdul[1].data = np.zeros((3, 40, 50))
     model = datamodels.CubeModel(hdul)
-    model.data = np.zeros((3, 40, 50))
     result = AssignWcsStep.call(model)
     assert result is not model
     assert result.meta.cal_step.assign_wcs == "COMPLETE"
@@ -31,6 +31,7 @@ def test_assign_wcs_step_nis_wfss():
 def test_assign_wcs_step_nrc_wfss():
     hdul = create_nircam(exptype="NRC_WFSS", filtername="F444W", pupil="GRISMR")
     model = datamodels.ImageModel(hdul)
+    model.data = np.zeros((10, 10))
     result = AssignWcsStep.call(model)
     assert result is not model
     assert result.meta.cal_step.assign_wcs == "COMPLETE"

--- a/jwst/assign_wcs/tests/test_miri.py
+++ b/jwst/assign_wcs/tests/test_miri.py
@@ -64,6 +64,7 @@ def create_hdul(detector, channel, band):
     scihdu = fits.ImageHDU()
     scihdu.header["EXTNAME"] = "SCI"
     scihdu.header.update(wcs_kw)
+    scihdu.data = np.zeros((10, 10))
     hdul.append(phdu)
     hdul.append(scihdu)
     return hdul

--- a/jwst/assign_wcs/tests/test_nircam.py
+++ b/jwst/assign_wcs/tests/test_nircam.py
@@ -111,6 +111,7 @@ def create_wfss_wcs(pupil, filtername="F444W"):
     """Help create WFSS GWCS object."""
     hdul = create_hdul(exptype="NRC_WFSS", filtername=filtername, pupil=pupil)
     im = ImageModel(hdul)
+    im.data = np.zeros((10, 10))
     ref = get_reference_files(im)
     pipeline = nircam.create_pipeline(im, ref)
     wcsobj = wcs.WCS(pipeline)
@@ -120,6 +121,7 @@ def create_wfss_wcs(pupil, filtername="F444W"):
 def create_imaging_wcs():
     hdul = create_hdul()
     image = ImageModel(hdul)
+    image.data = np.zeros((10, 10))
     ref = get_reference_files(image)
     pipeline = nircam.create_pipeline(image, ref)
     wcsobj = wcs.WCS(pipeline)
@@ -138,6 +140,7 @@ def create_tso_wcs(filtername=tsgrism_filters[0], subarray="SUBGRISM256"):
         wcskeys=wcs_tso_kw,
     )
     im = CubeModel(hdul)
+    im.data = np.zeros((10, 10, 10))
     ref = get_reference_files(im)
     pipeline = nircam.create_pipeline(im, ref)
     wcsobj = wcs.WCS(pipeline)
@@ -269,6 +272,7 @@ def test_imaging_frames():
 def test_wfss_sip():
     hdul = create_hdul(filtername="F444W", pupil="GRISMR", exptype="NRC_WFSS")
     wfss_model = ImageModel(hdul)
+    wfss_model.data = np.zeros((10, 10))
     ref = get_reference_files(wfss_model)
     pipeline = nircam.create_pipeline(wfss_model, ref)
     wcsobj = wcs.WCS(pipeline)
@@ -281,6 +285,7 @@ def test_wfss_sip():
 def test_update_s_region_imaging():
     """Ensure the s_region keyword matches output of wcs.footprint()"""
     model = ImageModel(create_hdul())
+    model.data = np.zeros((10, 10))
     model.meta.wcs = create_imaging_wcs()
     util.update_s_region_imaging(model)
 

--- a/jwst/assign_wcs/tests/test_niriss.py
+++ b/jwst/assign_wcs/tests/test_niriss.py
@@ -9,6 +9,7 @@ file.
 
 """
 
+import numpy as np
 from astropy.io import fits
 from gwcs import wcs
 from numpy.testing import assert_allclose
@@ -63,6 +64,7 @@ def create_hdul(detector="NIS", filtername="CLEAR", exptype="NIS_IMAGE", pupil="
     scihdu = fits.ImageHDU()
     scihdu.header["EXTNAME"] = "SCI"
     scihdu.header.update(wcs_kw)
+    scihdu.data = np.zeros((10, 10))
     hdul.append(phdu)
     hdul.append(scihdu)
     return hdul

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -195,6 +195,7 @@ def test_nirspec_imaging_via_step_call(exptype):
     """Test Nirspec Imaging modes in the step call."""
     f = create_nirspec_imaging_file(exptype=exptype)
     im = datamodels.ImageModel(f)
+    im.data = np.zeros((10, 10))
     result = assign_wcs_step.AssignWcsStep.call(im)
     assert result.meta.wcs.available_frames == [
         "detector",

--- a/jwst/assign_wcs/tests/test_wcs.py
+++ b/jwst/assign_wcs/tests/test_wcs.py
@@ -74,6 +74,7 @@ def create_model_2d():
 @pytest.fixture
 def create_model_3d():
     im = CubeModel()
+    im.data = zeros((5, 10, 10))
     im.meta.wcsinfo.crpix1 = 2.5
     im.meta.wcsinfo.crpix2 = 3
     im.meta.wcsinfo.crval1 = 5.6

--- a/jwst/wavecorr/tests/test_wavecorr.py
+++ b/jwst/wavecorr/tests/test_wavecorr.py
@@ -18,6 +18,7 @@ from jwst.wavecorr import WavecorrStep, wavecorr
 def nrs_fs_model():
     hdul = create_nirspec_fs_file(grating="G140H", filter="F100LP")
     im = datamodels.ImageModel(hdul)
+    im.data = np.zeros((2048, 2048))
     im_wcs = AssignWcsStep.call(im)
     im_ex2d = Extract2dStep.call(im_wcs)
     yield im_ex2d
@@ -47,6 +48,7 @@ def test_wavecorr():
     hdul[0].header["MSAMETFL"] = msa_meta
     hdul[0].header["MSAMETID"] = 12
     im = datamodels.ImageModel(hdul)
+    im.data = np.zeros((2048, 2048))
     im_wcs = AssignWcsStep.call(im)
     im_ex2d = Extract2dStep.call(im_wcs)
     bbox = ((-0.5, 1432.5), (-0.5, 37.5))
@@ -152,6 +154,7 @@ def test_skip_missing_prerequisites():
 def test_reference_file_requirements():
     hdul = create_nirspec_fs_file(grating="G140H", filter="F100LP")
     im = datamodels.ImageModel(hdul)
+    im.data = np.zeros((2048, 2048))
 
     outa = AssignWcsStep.call(im)
 
@@ -222,6 +225,7 @@ def test_mos_slit_status():
     hdul[0].header["MSAMETFL"] = msa_meta
     hdul[0].header["MSAMETID"] = 12
     im = datamodels.ImageModel(hdul)
+    im.data = np.zeros((2048, 2048))
     im_wcs = AssignWcsStep.call(im)
     im_ex2d = Extract2dStep.call(im_wcs)
     bbox = ((-0.5, 1432.5), (-0.5, 37.5))
@@ -289,7 +293,7 @@ def test_wavecorr_fs():
         "waverange_end": 5.3e-06,
         "waverange_start": 6e-07,
     }
-
+    im.data = np.zeros((2048, 2048))
     result = AssignWcsStep.call(im)
     result = Extract2dStep.call(result)
     bbox = ((-0.5, 428.5), (-0.5, 38.5))

--- a/jwst/wavecorr/tests/test_wavecorr.py
+++ b/jwst/wavecorr/tests/test_wavecorr.py
@@ -34,6 +34,7 @@ def nrs_slit_model(nrs_fs_model):
 
     # make a slit model to run through correction
     slit = datamodels.SlitModel(im_ex2d.slits[0].data)
+    slit.wavelength = im_ex2d.slits[0].wavelength
     slit.update(im_ex2d)
     slit.meta.wcs = im_ex2d.slits[0].meta.wcs
     slit.source_type = "POINT"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Relates to [JP-4228](https://jira.stsci.edu/browse/JP-4228)

<!-- describe the changes comprising this PR here -->
This PR makes creation of a `data` array attribute explicit for test data in `assign_wcs` and `wavecorr`.

Without this PR, some tests rely on automatic default setting of `data` to a size-zero array.  Arrays with shapes like `(0,0)` are passed into `wcs_bbox_from_shape`, which does not cause any errors but seems to generally be a not-great idea.

With this PR, all models run through `assign_wcs` during tests will have a non-empty data array, bypassing the problem.

This PR is required for https://github.com/spacetelescope/stdatamodels/pull/658 because that PR would make it so `model = ImageModel()` or similar no longer sets `model.data` to an array of shape `(0,0)`.

This PR only touches unit tests, so no changelog or regression tests are needed.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
