### PR TITLE
JP-4192: Prepare output for guider_cds

### DIFF
--- a/jwst/guider_cds/guider_cds_step.py
+++ b/jwst/guider_cds/guider_cds_step.py
@@ -23,43 +23,45 @@ class GuiderCdsStep(Step):
 
         Parameters
         ----------
-        input_data : datamodel, str
-            The input GuiderRawModel or filename containing
-            a GuiderRawModel.
+        input_data : str or `~stdatamodels.jwst.datamodels.GuiderRawModel`
+            The input file name or datamodel.
 
         Returns
         -------
-        JWST GuiderCalModel or GuiderRawModel
+        output_model : `~stdatamodels.jwst.datamodels.GuiderRawModel` or \
+                       `~stdatamodels.jwst.datamodels.GuiderCalModel`
             This will be a GuiderRawModel if the step was skipped; otherwise,
             it will be a GuiderCalModel containing calibrated count rates.
         """
-        with datamodels.GuiderRawModel(input_data) as input_model:
-            # Get the gain reference file
-            gain_filename = self.get_reference_file(input_model, "gain")
-            if gain_filename == "N/A":
-                log.warning("No GAIN reference file found!")
-                log.warning("guider_cds step will be skipped.")
-                out_model = input_model.copy()
-                out_model.meta.cal_step.guider_cds = "SKIPPED"
-                return out_model
+        output_model = self.prepare_output(input_data, open_as_type=datamodels.GuiderRawModel)
 
-            log.info("Using GAIN reference file: %s", gain_filename)
-            gain_model = datamodels.GainModel(gain_filename)
+        # Get the gain reference file
+        gain_filename = self.get_reference_file(output_model, "gain")
+        if gain_filename == "N/A":
+            log.warning("No GAIN reference file found!")
+            log.warning("guider_cds step will be skipped.")
+            output_model.meta.cal_step.guider_cds = "SKIPPED"
+            return output_model
 
-            # Get the readnoise reference file
-            readnoise_filename = self.get_reference_file(input_model, "readnoise")
-            if readnoise_filename == "N/A":
-                log.warning("No READNOISE reference file found!")
-                log.warning("guider_cds step will be skipped.")
-                out_model = input_model.copy()
-                out_model.meta.cal_step.guider_cds = "SKIPPED"
-                return out_model
+        log.info("Using GAIN reference file: %s", gain_filename)
+        gain_model = datamodels.GainModel(gain_filename)
 
-            log.info("Using READNOISE reference file: %s", readnoise_filename)
-            readnoise_model = datamodels.ReadnoiseModel(readnoise_filename)
+        # Get the readnoise reference file
+        readnoise_filename = self.get_reference_file(output_model, "readnoise")
+        if readnoise_filename == "N/A":
+            log.warning("No READNOISE reference file found!")
+            log.warning("guider_cds step will be skipped.")
+            output_model.meta.cal_step.guider_cds = "SKIPPED"
+            return output_model
 
-            out_model = guider_cds.guider_cds(input_model, gain_model, readnoise_model)
+        log.info("Using READNOISE reference file: %s", readnoise_filename)
+        readnoise_model = datamodels.ReadnoiseModel(readnoise_filename)
 
-        out_model.meta.cal_step.guider_cds = "COMPLETE"
+        result = guider_cds.guider_cds(output_model, gain_model, readnoise_model)
+        result.meta.cal_step.guider_cds = "COMPLETE"
 
-        return out_model
+        # Output is a new model, so close the input if it was opened here
+        if output_model is not input_data:
+            output_model.close()
+
+        return result


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-4192](https://jira.stsci.edu/browse/JP-4192)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Update guider_cds to use `prepare_output`.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
