### PR TITLE
JP-4193: Prepare output for coron3 pipeline

### DIFF
--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -218,7 +218,7 @@ class JwstStep(_Step):
                     # It is assumed the provided class is appropriate for the input.
                     input_models = open_as_type(init, **kwargs)
                 else:
-                    input_models = datamodels.open(init)
+                    input_models = datamodels.open(init, **kwargs)
             else:
                 # Return the filename or path -
                 # the calling code will handle opening it as needed.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-4193](https://jira.stsci.edu/browse/JP-4193)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Handle datamodel opening and copies for the coron3 pipeline.

The coron3 pipeline was previously opening all models from the input ASN as a container, but then re-opening models from the input filenames before processing them.  I've updated the input method here to use `prepare_output` to open the input association, and then just use the open models instead of re-opening.

Also, using prepare_output here to open the ASN with optional filter `asn_exptypes`, I noticed that there is a missing `**kwargs` in the datamodels.open call inside the `prepare_output` function.  I added it here.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
