### PR TITLE
JP-4193: Prepare output for image3, spec3, tso3

### DIFF
--- a/jwst/pipeline/calwebb_image3.py
+++ b/jwst/pipeline/calwebb_image3.py
@@ -127,7 +127,7 @@ class Image3Pipeline(Pipeline):
                 )
             except OSError:
                 # Try opening input as a single cal file
-                input_data = datamodels.open(input_data)
+                input_data = self.prepare_output(input_data)
                 input_data = [
                     input_data,
                 ]

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -108,7 +108,7 @@ class Spec3Pipeline(Pipeline):
         # could either be done via LoadAsAssociation and then manually
         # load input members into models and ModelContainer, or just
         # do a direct open of all members in ASN file, e.g.
-        input_models = dm.open(input_data, asn_exptypes=asn_exptypes)
+        input_models = self.prepare_output(input_data, asn_exptypes=asn_exptypes)
 
         # Immediately update the ASNTABLE keyword value in all inputs,
         # so that all outputs get the new value
@@ -331,7 +331,8 @@ class Spec3Pipeline(Pipeline):
                 log.info(f"Saving the final c1d product as {c1d_filename}.")
                 c1d_output.save(c1d_filename)
 
-        input_models.close()
+        if input_models is not input_data:
+            input_models.close()
 
         log.info("Ending calwebb_spec3")
         return


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-4193](https://jira.stsci.edu/browse/JP-4193)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Minor changes to make sure the remaining stage 3 pipelines make copies of their input where needed.

The image3 and spec3 pipelines just needed very small changes to use `prepare_output` instead of `datamodels.open`.  

The tso3 pipeline needed the same, but I also made a couple other small changes to allow it to run on a list or container of models rather than an association file name.  

Tests added for the affected use case for all three pipelines.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
