### PR TITLE
JP-4193: Prepare output for source_catalog

### DIFF
--- a/jwst/source_catalog/tests/test_source_catalog.py
+++ b/jwst/source_catalog/tests/test_source_catalog.py
@@ -157,7 +157,7 @@ def test_source_catalog_point_sources(finder, nircam_model, tmp_cwd):
 
 
 def test_output_is_not_input(nircam_model):
-    """Make sure output is not the same as input."""
+    """Make sure input is not modified."""
     step = SourceCatalogStep(
         snr_threshold=0.5, npixels=5, bkg_boxsize=50, kernel_fwhm=2.0, save_results=False
     )
@@ -167,3 +167,7 @@ def test_output_is_not_input(nircam_model):
     assert result is not nircam_model
     assert isinstance(result, QTable)
     assert isinstance(nircam_model, dm.ImageModel)
+
+    # Input is not modified when called standalone
+    assert nircam_model.meta.source_catalog is None
+    assert nircam_model.meta.cal_step.source_catalog is None


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-4193](https://jira.stsci.edu/browse/JP-4193)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Update the source_catalog step to use prepare_output.

Note:  this step currently modifies the `output_model` to record the catalog and segmentation map if they are saved, but the output model is not returned.  This will have the effect of recording the catalog and map if this step is run in a pipeline context, but will now throw away these changes if it is run standalone since input models are copied before processing.  I think this is consistent with our policy of not modifying input models to steps, just wanted to note it here.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
