### PR TITLE
JP-4238: Fix test_outlier_step_square_source_no_outliers test

### DIFF
--- a/jwst/outlier_detection/tests/helpers.py
+++ b/jwst/outlier_detection/tests/helpers.py
@@ -1,4 +1,5 @@
 import numpy as np
+from stcal.resample.utils import compute_mean_pixel_area
 from stdatamodels.jwst import datamodels
 
 from jwst.assign_wcs import AssignWcsStep
@@ -75,6 +76,10 @@ def assign_wcs_to_models(models, exptype, tsovisit, detector="ANY"):
     for m in models:
         m.meta.wcs = wcs
         m.meta.wcsinfo = wcsinfo
+        m.meta.photometry.pixelarea_steradians = compute_mean_pixel_area(
+            wcs,
+            m.data.shape
+        )
     return models
 
 

--- a/jwst/outlier_detection/tests/helpers.py
+++ b/jwst/outlier_detection/tests/helpers.py
@@ -76,10 +76,7 @@ def assign_wcs_to_models(models, exptype, tsovisit, detector="ANY"):
     for m in models:
         m.meta.wcs = wcs
         m.meta.wcsinfo = wcsinfo
-        m.meta.photometry.pixelarea_steradians = compute_mean_pixel_area(
-            wcs,
-            m.data.shape
-        )
+        m.meta.photometry.pixelarea_steradians = compute_mean_pixel_area(wcs, m.data.shape)
     return models
 
 

--- a/jwst/outlier_detection/tests/test_imaging.py
+++ b/jwst/outlier_detection/tests/test_imaging.py
@@ -151,7 +151,7 @@ def test_outlier_step_with_source_no_outliers(mirimage_three_sci, tmp_cwd, src_t
     with container:
         for ccont in container:
             ccont.data[5:16, 5:16] += src
-            ccont.err[5:16, 5:16] = np.sqrt(ccont.err[5:16, 5:16]**2 + src)
+            ccont.err[5:16, 5:16] = np.sqrt(ccont.err[5:16, 5:16] ** 2 + src)
             container.shelve(ccont)
 
     # Save all the data into a separate array before passing into step
@@ -244,10 +244,14 @@ def test_outlier_step_with_outliers(mirimage_three_sci, tmp_cwd, src_type, weigh
                 m2 = np.isfinite(corrected.data)
 
                 if src_type == "square":
-                    pytest.xfail("Square CR fails with pixels in the interior of the square not flagged as outliers.")
+                    pytest.xfail(
+                        "Square CR fails with pixels in the interior of the square not flagged as outliers."
+                    )
 
                 assert np.all(m == m2)
-                assert np.all((corrected.dq[~m] & helpers.OUTLIER_DO_NOT_USE) == helpers.OUTLIER_DO_NOT_USE)
+                assert np.all(
+                    (corrected.dq[~m] & helpers.OUTLIER_DO_NOT_USE) == helpers.OUTLIER_DO_NOT_USE
+                )
 
             np.testing.assert_allclose(data_as_cube[i][m], corrected.data[m], rtol=0.0, atol=atol)
             np.testing.assert_array_equal(dq_as_cube[i][m], corrected.dq[m])

--- a/jwst/outlier_detection/tests/test_imaging.py
+++ b/jwst/outlier_detection/tests/test_imaging.py
@@ -134,7 +134,7 @@ def test_outlier_step_on_disk(three_sci_as_asn, tmp_cwd):
 @pytest.mark.parametrize("src_type", ["square", "gaussian"])
 def test_outlier_step_with_source_no_outliers(mirimage_three_sci, tmp_cwd, src_type, weight):
     """Test whole step with no outliers and an artificial source:
-    a uniform "square" with sharp edges or a "gaussian" source centerd
+    a uniform "square" with sharp edges or a "gaussian" source centered
     on the image, no outliers."""
     container = ModelLibrary(list(mirimage_three_sci))
 

--- a/jwst/outlier_detection/tests/test_imaging.py
+++ b/jwst/outlier_detection/tests/test_imaging.py
@@ -187,7 +187,7 @@ def test_outlier_step_with_source_no_outliers(mirimage_three_sci, tmp_cwd, src_t
 
 
 @pytest.mark.parametrize("weight", ["exptime", "ivm"])
-@pytest.mark.parametrize("src_type", ["gaussian", "square", "strip"])
+@pytest.mark.parametrize("src_type", ["gaussian", "square", "strip", "point"])
 @pytest.mark.parametrize("idx", [0, 1, 2])
 def test_outlier_step_with_outliers(mirimage_three_sci, tmp_cwd, src_type, weight, idx):
     """Test whole step with no outlier and an artificial source: "gaussian" source
@@ -203,6 +203,9 @@ def test_outlier_step_with_outliers(mirimage_three_sci, tmp_cwd, src_type, weigh
     elif src_type == "square":
         sl = np.s_[5:16, 5:16]
         src = np.full((11, 11), 100 * helpers.SIGMA, dtype=np.float32)
+    elif src_type == "point":
+        sl = (10, 10)
+        src = 100 * helpers.SIGMA
     else:  # gaussian
         sl = np.s_[5:16, 5:16]
         y, x = np.indices((11, 11)) - 5
@@ -237,7 +240,7 @@ def test_outlier_step_with_outliers(mirimage_three_sci, tmp_cwd, src_type, weigh
             m = non_nan_mask_as_cube[i]
             if i == idx:
                 # Make sure CR pixels are now NaN in SCI and flagged in DQ
-                m[sl] = ~cr_mask
+                m[sl] = np.logical_not(cr_mask)
                 m2 = np.isfinite(corrected.data)
 
                 if src_type == "square":


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4238](https://jira.stsci.edu/browse/JP-4238)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR attempts to fix (x)failing `test_outlier_step_square_source_no_outliers` test. For more details, see https://github.com/spacetelescope/jwst/pull/10214#issuecomment-3836925039.

There are multiple things that could contribute to detection of cosmic rays although none were simulated. First, simulated source has very sharp edges that normally would be detected by the outlier detection algorithm as a cosmic ray (depending on derivative setting). Second, RMS of the uniform noise in the image could be large enough to produce large enough deviations from the mean value for a pixel to be flagged as a cosmic ray. This is a real issue when there are only 3 input images.

I start with the first issue and will see if fixing the second is needed.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
