### PR TITLE
API: Complete API for jump

### DIFF
--- a/docs/jwst/jump/api_ref.rst
+++ b/docs/jwst/jump/api_ref.rst
@@ -1,0 +1,14 @@
+===
+API
+===
+
+Public Step API
+===============
+
+.. automodapi:: jwst.jump.jump_step
+   :no-inheritance-diagram:
+
+Complete Developer API
+======================
+
+See :ref:`stcal.jump <stcal:jump_step>`.

--- a/docs/jwst/jump/api_ref.rst
+++ b/docs/jwst/jump/api_ref.rst
@@ -11,4 +11,4 @@ Public Step API
 Complete Developer API
 ======================
 
-See :ref:`stcal.jump <stcal:jump_step>`.
+N/A

--- a/docs/jwst/jump/arguments.rst
+++ b/docs/jwst/jump/arguments.rst
@@ -56,14 +56,14 @@ The details for each are listed below.
 
 **Parameters that affect after jump Flagging**
 
-After a jump of at least 'after_jump_flag_dn1' DN, groups up to 'after_jump_flag_time1'
+After a jump of at least ``after_jump_flag_dn1`` DN, groups up to ``after_jump_flag_time1``
 seconds will also be flagged as jumps. That pair of arguments is defined as:
 
 * ``--after_jump_flag_dn1``: A floating point value in units of DN
 * ``--after_jump_flag_time1``: A floating point value in units of seconds
 
-A second threshold and time can also be set: after a jump of at least 'after_jump_flag_dn2' DN,
-groups up to 'after_jump_flag_time2' seconds will also be flagged as jumps. That pair of arguments
+A second threshold and time can also be set: after a jump of at least ``after_jump_flag_dn2`` DN,
+groups up to ``after_jump_flag_time2`` seconds will also be flagged as jumps. That pair of arguments
 is defined as:
 
 * ``--after_jump_flag_dn2``: A floating point value in units of DN
@@ -71,17 +71,15 @@ is defined as:
 
 **Parameters that affect Near-IR Snowball Flagging**
 
-* ``--expand_large_events``:  A boolean parameter that controls whether the jump step will expand the number of pixels that are flagged around large cosmic ray events. These are know as "snowballs" in the near-infrared detectors and "showers" for the MIRI detectors. In general, this should be set to True.
+* ``--expand_large_events``:  A boolean parameter that controls whether the jump step will expand the number of pixels that are flagged around large cosmic ray events. These are know as "snowballs" in the near-infrared detectors and "showers" for the MIRI detectors. In general, this should be set to `True`.
 
 * ``--min_jump_area``: The minimum number of contiguous pixels needed to trigger the expanded flagging of large cosmic rays events.
 
-* ``--min_sat_area``:  The minimum number of saturated pixels required to meet "sat_required_snowball".
+* ``--min_sat_area``:  The minimum number of saturated pixels required to meet ``sat_required_snowball``.
 
 * ``--expand_factor``: A multiplicative factor applied to the enclosing ellipse for snowballs. This larger area will have all pixels flagged as having a jump.
 
-* ``--use_ellipses``:  deprecated
-
-* ``--sat_required_snowball``: A boolean value that if True requires that there are saturated pixels within the enclosed jump circle.
+* ``--sat_required_snowball``: A boolean value that if `True` requires that there are saturated pixels within the enclosed jump circle.
 
 * ``--min_sat_radius_extend``: The minimum radius of the saturated core of a snowball required to for the radius of the saturated core to be extended.
 
@@ -101,9 +99,9 @@ is defined as:
 
 * ``--extend_min_area``: The required minimum area of extended emission after convolution for the detection of showers in MIRI
 
-* ``--extend_inner_radius``: The inner radius of the ring_2D_kernel that is used for the detection of extended emission in showers
+* ``--extend_inner_radius``: The inner radius of the `~astropy.convolution.Ring2DKernel` that is used for the detection of extended emission in showers
 
-* ``--extend_outer_radius``: The outer radius of the Ring2DKernal that is used for the detection of extended emission in showers
+* ``--extend_outer_radius``: The outer radius of the `~astropy.convolution.Ring2DKernel` that is used for the detection of extended emission in showers
 
 * ``--extend_ellipse_expand_ratio``: Multiplicative factor to expand the radius of the ellipse fit to the detected extended emission in MIRI showers
 
@@ -123,4 +121,4 @@ is defined as:
 
 * ``--minimum_sigclip_groups``: The minimum number of groups to switch the jump detection to use sigma clipping
 
-* ``--only_use_ints``: If true the sigma clipping is applied only for a given group across all ints. If not, all groups from all ints are used for the sigma clipping.
+* ``--only_use_ints``: If `True` the sigma clipping is applied only for a given group across all integrations. If not, all groups from all integrations are used for the sigma clipping.

--- a/docs/jwst/jump/description.rst
+++ b/docs/jwst/jump/description.rst
@@ -1,7 +1,7 @@
 Description
 ===========
 
-:Class: `jwst.jump.JumpStep`
+:Class: `jwst.jump.jump_step.JumpStep`
 :Alias: jump
 
 This step finds and flags outliers (usually caused by cosmic-ray hits) in

--- a/docs/jwst/jump/index.rst
+++ b/docs/jwst/jump/index.rst
@@ -10,5 +10,4 @@ Jump Detection
    description.rst
    arguments.rst
    reference_files.rst
-
-.. automodapi:: jwst.jump
+   api_ref.rst

--- a/docs/jwst/jump/reference_files.rst
+++ b/docs/jwst/jump/reference_files.rst
@@ -1,15 +1,13 @@
-Reference File Types
-=====================
+Reference Files
+===============
 
-The ``jump`` step uses two reference files: :ref:`GAIN <gain_reffile>`
-and :ref:`READNOISE <readnoise_reffile>`.
-The GAIN reference file is used to temporarily convert pixel values in
-the ``jump`` step from units of DN to electrons.
-The READNOISE reference file is used in estimating the expected noise
-in each pixel.
+The ``jump`` step uses two reference files:
+
+* :ref:`GAIN <gain_reffile>`: The GAIN reference file is used to
+  temporarily convert pixel values in
+  the ``jump`` step from units of DN to electrons.
+* :ref:`READNOISE <readnoise_reffile>`: The READNOISE reference file
+  is used in estimating the expected noise in each pixel.
+
 Both are necessary for proper computation of noise estimates within the
 ``jump`` step.
-
-:ref:`GAIN <gain_reffile>`
-
-:ref:`READNOISE <readnoise_reffile>`

--- a/jwst/jump/__init__.py
+++ b/jwst/jump/__init__.py
@@ -1,4 +1,4 @@
-"""Detect jumps based on sciene data and reference files."""
+"""Detect jumps based on science data and reference files."""
 
 from .jump_step import JumpStep
 

--- a/jwst/jump/jump_step.py
+++ b/jwst/jump/jump_step.py
@@ -1,3 +1,5 @@
+"""Detect jumps based on science data and reference files."""
+
 import logging
 import time
 
@@ -133,12 +135,12 @@ class JumpStep(Step):
 
         Parameters
         ----------
-        result : RampModel
+        result : `~stdatamodels.jwst.datamodels.RampModel`
             The ramp model input from the previous step.
 
         Returns
         -------
-        jump_data : JumpData
+        jump_data : `~stcal.jump.jump_class.JumpData`
             The data container to be used to run the STCAL detect_jumps_data.
         """
         # Get the gain and readnoise reference files


### PR DESCRIPTION
Towards [JP-4107](https://jira.stsci.edu/browse/JP-4107)

This PR addresses `jump` portion of https://github.com/spacetelescope/jwst/issues/9793 . Only touch docs so should not need RT.

On main:

* https://jwst-pipeline.readthedocs.io/en/latest/jwst/jump/index.html

With this patch:

* https://jwst-pipeline--10238.org.readthedocs.build/en/10238/jwst/jump/index.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
