### PR TITLE
JP-4056 follow-up: setting maxiters to zero

### DIFF
--- a/docs/jwst/background_subtraction/arguments.rst
+++ b/docs/jwst/background_subtraction/arguments.rst
@@ -44,6 +44,8 @@ control the sigma clipping, and are passed as arguments to
   a FITS or ASDF file openable as `~stdatamodels.jwst.datamodels.ImageModel`
   containing a 2D array of integers in its ``.mask`` attribute (FITS ``MASK`` extension)
   with pixels to be used as background set to 1 and other pixels set to 0.
+  To use the mask as-is without any additional outlier rejection,
+  the ``wfss_maxiter`` argument should be set to 0.
   The ``.data`` attribute is not used.
   Defaults to ``None``.
 

--- a/docs/jwst/background_subtraction/arguments.rst
+++ b/docs/jwst/background_subtraction/arguments.rst
@@ -50,7 +50,8 @@ control the sigma clipping, and are passed as arguments to
 ``--wfss_maxiter``
   Only applies to Wide Field Slitless Spectroscopy (WFSS) exposures.
   Sets the maximum number of iterations allowed for iterative outlier rejection
-  during determination of the reference background scaling factor. Defaults to 5.
+  during determination of the reference background scaling factor. If set to 0,
+  no outlier rejection will be applied. Defaults to 5.
 
 ``--wfss_rms_stop``
   Only applies to Wide Field Slitless Spectroscopy (WFSS) exposures.

--- a/docs/jwst/background_subtraction/description.rst
+++ b/docs/jwst/background_subtraction/description.rst
@@ -188,6 +188,9 @@ a valid model from scratch, use something like::
     mask_model.mask = mask_data
     mask_model.save('custom_mask.fits')
 
+To apply the user-defined mask as-is, the ``wfss_maxiter`` argument should be set to 0;
+doing so will prevent any additional outlier rejection from being applied by the step.
+
 SOSS Mode
 ---------
 In a similar manner to WFSS modes, the NIRISS SOSS mode uses a set of reference


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR adds explanation of how to stop outlier rejection from being applied by setting the `wfss_maxiter` param to zero.  This is in response to a comment by @gnoir0t 

No need for changelog nor regression tests.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
