### PR TITLE
DOC: Complete API for badpix_selfcal

### DIFF
--- a/docs/jwst/badpix_selfcal/api_ref.rst
+++ b/docs/jwst/badpix_selfcal/api_ref.rst
@@ -1,0 +1,15 @@
+===
+API
+===
+
+Public Step API
+===============
+
+.. automodapi:: jwst.badpix_selfcal.badpix_selfcal_step
+   :no-inheritance-diagram:
+
+Complete Developer API
+======================
+
+.. automodapi:: jwst.badpix_selfcal.badpix_selfcal
+   :no-inheritance-diagram:

--- a/docs/jwst/badpix_selfcal/arguments.rst
+++ b/docs/jwst/badpix_selfcal/arguments.rst
@@ -3,7 +3,7 @@ Step Arguments
 The ``badpix_selfcal`` step has the following optional arguments.
 
 ``--flagfrac_lower`` (float, default=0.001)
-  The fraction of pixels to flag as outliers on the low-flux 
+  The fraction of pixels to flag as outliers on the low-flux
   side of the smoothed-subtracted image.
 
 ``--flagfrac_upper`` (float, default=0.001)
@@ -11,8 +11,8 @@ The ``badpix_selfcal`` step has the following optional arguments.
   side of the smoothed-subtracted image.
 
 ``--kernel_size`` (integer, default=15)
-  The size of the kernel to use for the median filter, which is applied 
+  The size of the kernel to use for the median filter, which is applied
   in the spectral direction to make the smoothed image.
 
 ``--save_flagged_bkg`` (boolean, default=False)
-  Whether to save the flagged background exposures to fits files.
+  Whether to save the flagged background exposures to FITS files.

--- a/docs/jwst/badpix_selfcal/description.rst
+++ b/docs/jwst/badpix_selfcal/description.rst
@@ -58,6 +58,6 @@ the spectral axis. The algorithm proceeds as follows:
 Output product
 --------------
 The output is a new copy of the input `~stdatamodels.jwst.datamodels.IFUImageModel`, with the
-bad pixels flagged.  If the entire ``calwebb_spec2`` pipeline is run, the background
-exposures passed into the ``background`` step will include the flags from the
+bad pixels flagged.  If the entire :ref:`calwebb_spec2 <calwebb_spec2>` pipeline is run, the background
+exposures passed into the :ref:`background step <background_subtraction>` will include the flags from the
 ``badpix_selfcal`` step.

--- a/docs/jwst/badpix_selfcal/description.rst
+++ b/docs/jwst/badpix_selfcal/description.rst
@@ -21,10 +21,10 @@ Input details
 The input data must be in the form of a `~stdatamodels.jwst.datamodels.IFUImageModel` or
 a `~jwst.datamodels.container.ModelContainer` containing exactly one
 science exposure and any number of additional exposures.
-A fits or association file
+A FITS or association file
 that can be read into one of these data models is also acceptable.
 Any exposure with the metadata attribute ``asn.exptype`` set to
-``background`` or ``selfcal`` will be used in conjunction with the science
+``"background"`` or ``"selfcal"`` will be used in conjunction with the science
 exposure to construct the combined background image.
 
 Algorithm
@@ -32,7 +32,7 @@ Algorithm
 The algorithm relies on the assumption that bad pixels are outliers in the data along
 the spectral axis. The algorithm proceeds as follows:
 
-* A combined background image is created. If additional (``selfcal`` or ``background``)
+* A combined background image is created. If additional (``"selfcal"`` or ``"background"``)
   exposures are available,
   the pixelwise minimum of all background, selfcal, and science exposures is taken.
   If no additional exposures are available, the science data itself is passed in

--- a/docs/jwst/badpix_selfcal/description.rst
+++ b/docs/jwst/badpix_selfcal/description.rst
@@ -1,7 +1,7 @@
 Description
 ===========
 
-:Class: `jwst.badpix_selfcal.BadpixSelfcalStep`
+:Class: `jwst.badpix_selfcal.badpix_selfcal_step.BadpixSelfcalStep`
 :Alias: badpix_selfcal
 
 Overview

--- a/docs/jwst/badpix_selfcal/index.rst
+++ b/docs/jwst/badpix_selfcal/index.rst
@@ -9,6 +9,10 @@ Bad Pixel Self-Calibration
 
    description.rst
    arguments.rst
-   reference_files.rst
 
-.. automodapi:: jwst.badpix_selfcal
+* Reference File: The ``badpix_selfcal`` step does not use any reference files.
+
+.. toctree::
+   :maxdepth: 2
+
+   api_ref.rst

--- a/docs/jwst/badpix_selfcal/reference_files.rst
+++ b/docs/jwst/badpix_selfcal/reference_files.rst
@@ -1,4 +1,0 @@
-Reference Files
-===============
-The ``badpix_selfcal`` step does not use any reference files.
-

--- a/jwst/badpix_selfcal/badpix_selfcal.py
+++ b/jwst/badpix_selfcal/badpix_selfcal.py
@@ -41,7 +41,7 @@ def badpix_selfcal(
     -------
     flagged_indices : ndarray
         Indices of the flagged pixels,
-        shaped like output from np.where
+        shaped like output from :func:`numpy.where`.
     """
     if dispaxis not in [1, 2, None]:
         raise ValueError("dispaxis must be either 1 or 2, or None.")
@@ -65,8 +65,7 @@ def badpix_selfcal(
         minimg_hpf, [flagfrac_lower * 100, (1 - flagfrac_upper) * 100]
     )
     bad = (minimg_hpf > flag_high) | (minimg_hpf < flag_low)
-    flagged_indices = np.where(bad)
-    return flagged_indices
+    return np.where(bad)
 
 
 def apply_flags(input_model: IFUImageModel, flagged_indices: np.ndarray) -> IFUImageModel:
@@ -74,19 +73,19 @@ def apply_flags(input_model: IFUImageModel, flagged_indices: np.ndarray) -> IFUI
     Apply the flagged indices to the input model.
 
     Sets the flagged pixels to NaN
-    and the DQ flag to DO_NOT_USE + OTHER_BAD_PIXEL
+    and the DQ flag to ``DO_NOT_USE + OTHER_BAD_PIXEL``.
 
     Parameters
     ----------
-    input_model : IFUImageModel
-        Input science data to be corrected. Updated in place.
+    input_model : `~stdatamodels.jwst.datamodels.IFUImageModel`
+        Input science data to be corrected; updated in place.
     flagged_indices : ndarray
         Indices of the flagged pixels,
-        shaped like output from np.where
+        shaped like output from :func:`numpy.where`.
 
     Returns
     -------
-    output_model : IFUImageModel
+    output_model : `~stdatamodels.jwst.datamodels.IFUImageModel`
         Flagged data model
     """
     input_model.dq[flagged_indices] |= pixel["DO_NOT_USE"] + pixel["OTHER_BAD_PIXEL"]

--- a/jwst/badpix_selfcal/badpix_selfcal.py
+++ b/jwst/badpix_selfcal/badpix_selfcal.py
@@ -34,7 +34,7 @@ def badpix_selfcal(
     kernel_size : int
         Size of kernel for median filter
     dispaxis : int
-        Dispersion axis, either 1 or 2. If None, a two-dimensional
+        Dispersion axis, either 1 or 2. If ``None``, a two-dimensional
         median filter is applied.
 
     Returns

--- a/jwst/badpix_selfcal/badpix_selfcal_step.py
+++ b/jwst/badpix_selfcal/badpix_selfcal_step.py
@@ -1,3 +1,5 @@
+"""Self-calibration of bad pixels in JWST data."""
+
 import logging
 import warnings
 
@@ -21,11 +23,11 @@ class BadpixSelfcalStep(Step):
     """
     Flag residual artifacts as bad pixels using a median filter and percentile cutoffs.
 
-    All input exposures in the association file (or manually-provided bkg_list) are combined
+    All input exposures in the association file (or manually-provided ``bkg_list``) are combined
     into a single background model using a MIN operation. The bad pixels are then identified
     using a median filter and percentile cutoffs, and applied to the science data by setting
     the flagged pixels, errors, and variances to NaN,
-    and the DQ flag to DO_NOT_USE + OTHER_BAD_PIXEL.
+    and the DQ flag to ``DO_NOT_USE + OTHER_BAD_PIXEL``.
     """
 
     class_alias = "badpix_selfcal"
@@ -45,12 +47,12 @@ class BadpixSelfcalStep(Step):
 
         Parameters
         ----------
-        model : JWST data model
+        model : `~stdatamodels.jwst.datamodels.JwstDataModel`
             Data model to save
         *args : tuple
-            Additional arguments to pass to Step.save_model
+            Additional arguments to pass to :meth:`stpipe.Step.save_model`
         **kwargs : dict
-            Additional keyword arguments to pass to Step.save_model
+            Additional keyword arguments to pass to :meth:`stpipe.Step.save_model`
 
         Returns
         -------
@@ -66,7 +68,7 @@ class BadpixSelfcalStep(Step):
 
         Parameters
         ----------
-        bkg_list : list of ImageModels
+        bkg_list : list of `~stdatamodels.jwst.datamodels.ImageModel`
             Background exposures to save
         suffix : str
             Suffix to append to the filename
@@ -104,11 +106,11 @@ class BadpixSelfcalStep(Step):
         If an association file is read in, all exposures in the
         association file, including science, background, and selfcal exposures,
         are included in the MIN frame from which outliers are detected.
-        If selfcal_list and/or bkg_list are specified manually, they are appended to any
+        If ``selfcal_list`` and/or ``bkg_list`` are specified manually, they are appended to any
         selfcal or background exposures found in the input association file.
-        If selfcal_list and bkg_list are both set to None and input is
+        If ``selfcal_list`` and ``bkg_list`` are both set to `None` and input is
         a single science exposure, the step will be skipped with a warning unless
-        the force_single parameter is set True.
+        the force_single parameter is set `True`.
         In that case, the input exposure will be used as the sole background exposure,
         i.e., true self-calibration.
         """
@@ -279,7 +281,7 @@ def split_container_by_asn_exptype(container: dm.ModelContainer, exptypes: list)
 
     Parameters
     ----------
-    container : ModelContainer
+    container : `~jwst.datamodels.container.ModelContainer`
         The input association.
     exptypes : list[str]
         List of exposure types to split on.
@@ -287,8 +289,10 @@ def split_container_by_asn_exptype(container: dm.ModelContainer, exptypes: list)
     Returns
     -------
     split_list : list of lists
-        Lists of ImageModels, where the outer list is indexed by the input exptypes and the
-        inner list contains the ImageModels of that type.
+        Lists of `~stdatamodels.jwst.datamodels.ImageModel`,
+        where the outer list is indexed by the input exptypes and the
+        inner list contains the `~stdatamodels.jwst.datamodels.ImageModel`
+        of that type.
     """
     split_list = []
     for exptype in exptypes:

--- a/jwst/badpix_selfcal/badpix_selfcal_step.py
+++ b/jwst/badpix_selfcal/badpix_selfcal_step.py
@@ -58,7 +58,7 @@ class BadpixSelfcalStep(Step):
         -------
         list[str]
             List of output paths for the saved models
-        """
+        """  # noqa: E501
         kwargs["idx"] = None
         return Step.save_model(self, model, *args, **kwargs)
 
@@ -108,7 +108,7 @@ class BadpixSelfcalStep(Step):
         are included in the MIN frame from which outliers are detected.
         If ``selfcal_list`` and/or ``bkg_list`` are specified manually, they are appended to any
         selfcal or background exposures found in the input association file.
-        If ``selfcal_list`` and ``bkg_list`` are both set to `None` and input is
+        If ``selfcal_list`` and ``bkg_list`` are both set to ``None`` and input is
         a single science exposure, the step will be skipped with a warning unless
         the force_single parameter is set `True`.
         In that case, the input exposure will be used as the sole background exposure,

--- a/jwst/badpix_selfcal/badpix_selfcal_step.py
+++ b/jwst/badpix_selfcal/badpix_selfcal_step.py
@@ -43,7 +43,7 @@ class BadpixSelfcalStep(Step):
 
     def save_model(self, model, *args, **kwargs):
         """
-        Override save_model to suppress index 0 when save_model is True.
+        Override base step class :meth:`stpipe.Step.save_model` to suppress index 0 when save_model is True.
 
         Parameters
         ----------
@@ -291,8 +291,7 @@ def split_container_by_asn_exptype(container: dm.ModelContainer, exptypes: list)
     split_list : list of lists
         Lists of `~stdatamodels.jwst.datamodels.ImageModel`,
         where the outer list is indexed by the input exptypes and the
-        inner list contains the `~stdatamodels.jwst.datamodels.ImageModel`
-        of that type.
+        inner list contains the models of that exposure type.
     """
     split_list = []
     for exptype in exptypes:


### PR DESCRIPTION
Towards [JP-4107](https://jira.stsci.edu/browse/JP-4107)

This PR addresses `badpix_selfcal` portion of https://github.com/spacetelescope/jwst/issues/9793 . Only touch docs so should not need RT.

On main:

* https://jwst-pipeline.readthedocs.io/en/latest/jwst/badpix_selfcal/index.html

With this patch:

* https://jwst-pipeline--10252.org.readthedocs.build/en/10252/jwst/badpix_selfcal/index.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
