### PR TITLE
DOC: Complete API for barshadow

### DIFF
--- a/docs/jwst/barshadow/api_ref.rst
+++ b/docs/jwst/barshadow/api_ref.rst
@@ -1,0 +1,15 @@
+===
+API
+===
+
+Public Step API
+===============
+
+.. automodapi:: jwst.barshadow.barshadow_step
+   :no-inheritance-diagram:
+
+Complete Developer API
+======================
+
+.. automodapi:: jwst.barshadow.bar_shadow
+   :no-inheritance-diagram:

--- a/docs/jwst/barshadow/arguments.rst
+++ b/docs/jwst/barshadow/arguments.rst
@@ -4,7 +4,7 @@ The ``barshadow`` step has the following optional arguments.
 
 ``--inverse`` (boolean, default=False)
   A flag to indicate whether the math operations used to apply the
-  correction should be inverted (i.e. multiply the correction into
+  correction should be inverted (i.e., multiply the correction into
   the science data, instead of the usual division).
 
 ``--source_type`` (string, default=None)

--- a/docs/jwst/barshadow/description.rst
+++ b/docs/jwst/barshadow/description.rst
@@ -1,7 +1,7 @@
 Description
 ===========
 
-:Class: `jwst.barshadow.BarShadowStep`
+:Class: `jwst.barshadow.barshadow_step.BarShadowStep`
 :Alias: barshadow
 
 Overview
@@ -24,7 +24,7 @@ It is also assumed that the input data have been processed through the
 SRCTYPE keyword value for each slit to "POINT", "EXTENDED", or "UNKNOWN." If the
 source type is "EXTENDED" or "UNKNOWN", or the SRCTYPE keyword is not present,
 the default action is to treat the source as extended and apply the ``barshadow``
-correction. If SRCTYPE="POINT" for a given slit, the correction is not applied.
+correction. If ``SRCTYPE="POINT"`` for a given slit, the correction is not applied.
 
 Algorithm
 ---------
@@ -36,7 +36,7 @@ The :ref:`barshadow_reffile` contains the correction as a function of Y
 and wavelength for a single open shutter (the DATA1X1 extension), and for 2 adjacent open
 shutters (DATA1X3).  This allows on-the-fly construction of a model for any combination
 of open and closed shutters.  The shutter configuration of a slitlet is contained
-in the attribute shutter_state, which shows whether the shutters of the slitlet are open,
+in the attribute ``shutter_state``, which shows whether the shutters of the slitlet are open,
 closed, or contain the source.  Once the correction as a function of Y and wavelength is
 calculated, the WCS transformation from the detector to the slit frame is used
 to calculate Y and wavelength for each pixel in the cutout.  The Y values are scaled from shutter
@@ -57,5 +57,5 @@ is also added to the datamodel in the "BARSHADOW" extension.
 
 Upon successful completion of the step, the status keyword "S_BARSHA"
 in the primary header is set to "COMPLETE".  For each SCI extension, the "BARSHDW"
-keyword is set to True if the slit was barshadow corrected (it is an extended
-source) or False if it was not corrected (it is a point source).
+keyword is set to `True` if the slit was barshadow corrected (it is an extended
+source) or `False` if it was not corrected (it is a point source).

--- a/docs/jwst/barshadow/index.rst
+++ b/docs/jwst/barshadow/index.rst
@@ -10,5 +10,4 @@ Barshadow Correction
    description.rst
    arguments.rst
    reference_files.rst
-
-.. automodapi:: jwst.barshadow
+   api_ref.rst

--- a/docs/jwst/barshadow/reference_files.rst
+++ b/docs/jwst/barshadow/reference_files.rst
@@ -3,4 +3,3 @@ Reference Files
 The ``barshadow`` step uses a BARSHADOW reference file.
 
 .. include:: ../references_general/barshadow_reffile.inc
-

--- a/docs/jwst/references_general/barshadow_selection.inc
+++ b/docs/jwst/references_general/barshadow_selection.inc
@@ -6,8 +6,7 @@ CRDS selects appropriate BARSHADOW references based on the following keywords.
 BARSHADOW is not applicable for instruments not in the table.
 
 ========== ======================================
-Instrument Keywords                               
+Instrument Keywords
 ========== ======================================
-NIRSpec    INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS 
+NIRSpec    INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS
 ========== ======================================
-

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -123,10 +123,10 @@ def _calc_correction(slitlet, barshadow_model, source_type):
 
     Parameters
     ----------
-    slitlet : `~jwst.datamodels.SlitModel`
+    slitlet : `~stdatamodels.jwst.datamodels.SlitModel`
         The slitlet to calculate the correction for.
 
-    barshadow_model : `~jwst.datamodels.BarshadowModel`
+    barshadow_model : `~stdatamodels.jwst.datamodels.BarshadowModel`
         Bar shadow data model from reference file.
 
     source_type : str or None
@@ -134,7 +134,7 @@ def _calc_correction(slitlet, barshadow_model, source_type):
 
     Returns
     -------
-    correction : `~jwst.datamodels.SlitModel`
+    correction : `~stdatamodels.jwst.datamodels.SlitModel`
         The correction to be applied.
     """
     slitlet_number = slitlet.slitlet_id
@@ -207,28 +207,28 @@ def create_shutter_elements(barshadow_model):
 
     The pieces are:
 
-        1. shutter_elements['first']
-           Goes from the bottom edge of the array (at 1 shutter width from
-           the center of the first shutter) to the center of the first shutter
-        2. shutter_elements['open_open']
-            Goes from the center of an open shutter to the center of the next shutter,
-            if that shutter is open
-        3. shutter_elements['open_closed']
-            Goes from the center of an open shutter to the center of the next shutter,
-            if that shutter is closed
-        4. shutter_elements['closed_open']
-            Goes from the center of a closed shutter to the center of the next shutter,
-            if that shutter is open
-        5. shutter_elements['closed_closed']
-            Goes from the center of a closed shutter to the center of the next shutter,
-            if that shutter is also closed
-        6. shutter_elements['last']
-            Goes from the center of the last open shutter to the top edge of the shutter
-            array (1 shutter width from the center of the last open shutter)
+    1. ``shutter_elements['first']``:
+       Goes from the bottom edge of the array (at 1 shutter width from
+       the center of the first shutter) to the center of the first shutter
+    2. ``shutter_elements['open_open']``:
+       Goes from the center of an open shutter to the center of the next shutter,
+       if that shutter is open
+    3. ``shutter_elements['open_closed']``:
+       Goes from the center of an open shutter to the center of the next shutter,
+       if that shutter is closed
+    4. ``shutter_elements['closed_open']``:
+       Goes from the center of a closed shutter to the center of the next shutter,
+       if that shutter is open
+    5. ``shutter_elements['closed_closed']``:
+       Goes from the center of a closed shutter to the center of the next shutter,
+       if that shutter is also closed
+    6. ``shutter_elements['last']``:
+       Goes from the center of the last open shutter to the top edge of the shutter
+       array (1 shutter width from the center of the last open shutter)
 
     Parameters
     ----------
-    barshadow_model : BarshadowModel
+    barshadow_model : `~stdatamodels.jwst.datamodels.BarshadowModel`
         The barshadow model used to construct these pieces.
 
     Returns
@@ -267,13 +267,14 @@ def create_shadow(shutter_elements, shutter_status):
         The shutter elements dictionary.
     shutter_status : str
         String describing the shutter status:
-           0:  Closed
-           1:  Open
-           x:  Contains source
+
+        * 0: Closed
+        * 1: Open
+        * x: Contains source
 
     Returns
     -------
-    shadow_array : ndarray of float
+    shadow_array : ndarray
         The constructed bar shadow array.
     """
     nshutters = len(shutter_status)
@@ -326,7 +327,7 @@ def add_first_half_shutter(shadow, shadow_element):
     shadow : ndarray
         The bar shadow array.
     shadow_element : ndarray
-        The shutter_elements['first'] array.  Should be 501 rows (Y)
+        The ``shutter_elements['first']`` array.  Should be 501 rows (Y)
         by 101 columns (wavelength).
 
     Returns
@@ -353,7 +354,7 @@ def add_next_shutter(shadow, shadow_element, first_row):
 
     Returns
     -------
-    shadow: ndarray
+    shadow : ndarray
         The bar shadow array with the double internal shutter inserted.
     """
     # Average the last row in the current bar shadow array with the first row of
@@ -373,16 +374,16 @@ def add_last_half_shutter(shadow, shadow_element, first_row):
 
     Parameters
     ----------
-    shadow : nddata array
+    shadow : ndarray
         The bar shadow array.
-    shadow_element : nddata array
+    shadow_element : ndarray
         The shadow_element array.
     first_row : int
         The first row to place the shadow element.
 
     Returns
     -------
-    shadow: ndarray
+    shadow : ndarray
         The bar shadow array with the last half shutter inserted.
     """
     #
@@ -401,15 +402,15 @@ def has_uniform_source(slitlet, force_type=None):
 
     Parameters
     ----------
-    slitlet : `~jwst.datamodels.SlitModel`
+    slitlet : `~stdatamodels.jwst.datamodels.SlitModel`
         The slitlet being interrogated.
     force_type : str or None
         Source type to force to and decide upon.
 
     Returns
     -------
-    answer: bool
-        True if the slitlet contains a uniform source.
+    answer : bool
+        `True` if the slitlet contains a uniform source.
     """
     source_type = force_type if force_type else slitlet.source_type
 


### PR DESCRIPTION
Towards [JP-4107](https://jira.stsci.edu/browse/JP-4107)

This PR addresses `barshadow` portion of https://github.com/spacetelescope/jwst/issues/9793 . Only touch docs so should not need RT.

On main:

* https://jwst-pipeline.readthedocs.io/en/stable/jwst/barshadow/index.html

With this patch:

* https://jwst-pipeline--10258.org.readthedocs.build/en/10258/jwst/barshadow/index.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
