### PR TITLE
DOC: Complete API for charge_migration

### DIFF
--- a/docs/jwst/charge_migration/api_ref.rst
+++ b/docs/jwst/charge_migration/api_ref.rst
@@ -1,0 +1,15 @@
+===
+API
+===
+
+Public Step API
+===============
+
+.. automodapi:: jwst.charge_migration.charge_migration_step
+   :no-inheritance-diagram:
+
+Complete Developer API
+======================
+
+.. automodapi:: jwst.charge_migration.charge_migration
+   :no-inheritance-diagram:

--- a/docs/jwst/charge_migration/description.rst
+++ b/docs/jwst/charge_migration/description.rst
@@ -1,7 +1,7 @@
 Description
 ===========
 
-:Class: `jwst.charge_migration.ChargeMigrationStep`
+:Class: `jwst.charge_migration.charge_migration_step.ChargeMigrationStep`
 :Alias: charge_migration
 
 

--- a/docs/jwst/charge_migration/index.rst
+++ b/docs/jwst/charge_migration/index.rst
@@ -9,6 +9,10 @@ Charge Migration
 
    description.rst
    arguments.rst
-   reference_files.rst
 
-.. automodapi:: jwst.charge_migration
+* Reference File: The ``charge_migration`` step does not use any reference files.
+
+.. toctree::
+   :maxdepth: 2
+
+   api_ref.rst

--- a/docs/jwst/charge_migration/reference_files.rst
+++ b/docs/jwst/charge_migration/reference_files.rst
@@ -1,3 +1,0 @@
-Reference Files
-===============
-This step does not use any reference files.

--- a/jwst/charge_migration/charge_migration.py
+++ b/jwst/charge_migration/charge_migration.py
@@ -32,7 +32,7 @@ def charge_migration(output_model, signal_threshold):
     -------
     output_model : `~stdatamodels.jwst.datamodels.RampModel`
         Data model with charge_migration applied; add CHARGELOSS and
-        DO_NOT_USE flags to groups exceeding signal_threshold.
+        DO_NOT_USE flags to groups exceeding ``signal_threshold``.
     """
     data = output_model.data
     gdq = output_model.groupdq

--- a/jwst/charge_migration/charge_migration_step.py
+++ b/jwst/charge_migration/charge_migration_step.py
@@ -1,3 +1,5 @@
+"""Detect and flag charge migration."""
+
 import logging
 
 from stdatamodels.jwst import datamodels


### PR DESCRIPTION
Towards [JP-4107](https://jira.stsci.edu/browse/JP-4107)

This PR addresses `charge_migration` portion of https://github.com/spacetelescope/jwst/issues/9793 . Only touch docs so should not need RT.

On main:

* https://jwst-pipeline.readthedocs.io/en/stable/jwst/charge_migration/description.html

With this patch:

* https://jwst-pipeline--10263.org.readthedocs.build/en/10263/jwst/charge_migration/index.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
