### PR TITLE
don't allow tox later than 4.41

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,8 @@ jobs:
   check:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@99401c364fa51c9c507d3cd6d272049278ac0b2c # v2.4.0
     with:
+      # remove when we can use a tox later than 4.41
+      toxdeps: '--uploaded-prior-to=2026-02-18T00:00:00Z'
       default_python: "3.12"
       envs: |
         - linux: check-dependencies
@@ -52,6 +54,8 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@99401c364fa51c9c507d3cd6d272049278ac0b2c  # v2.4.0
     needs: [ crds_context ]
     with:
+      # remove when we can use a tox later than 4.41
+      toxdeps: '--uploaded-prior-to=2026-02-18T00:00:00Z'
       setenv: |
         CRDS_PATH: /tmp/data/crds_cache
         CRDS_SERVER_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.crds_server || 'https://jwst-crds.stsci.edu' }}

--- a/.github/workflows/tests_extra.yml
+++ b/.github/workflows/tests_extra.yml
@@ -48,6 +48,8 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@99401c364fa51c9c507d3cd6d272049278ac0b2c # v2.4.0
     needs: [ crds_context ]
     with:
+      # remove when we can use a tox later than 4.41
+      toxdeps: '--uploaded-prior-to=2026-02-18T00:00:00Z'
       setenv: |
         CRDS_PATH: /tmp/crds_cache
         CRDS_SERVER_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.crds_server || 'https://jwst-crds.stsci.edu' }}


### PR DESCRIPTION
tox 4.42+ is incompatible with out CI due to what appears to be bugs in command parsing.

Since we use the open astronomy workflow, and that provides no means by which we can pin tox this PR adds an `uploaded-prior-to` **date** limit to tox releases.

This is a stop gap until we can either:
- get an upstream fix in tox
- update the open astronomy workflow to allow us to pin tox (as a slightly better stop-gap)
- migrate our tox.ini to whatever format 4.42+ expects
- migrate away from tox

Here's an example of the failure we're seeing with tox 4.43: https://github.com/spacetelescope/jwst/actions/runs/22234682432/job/64323268182?pr=10267 where the command is parsed incorrectly as
```
py311-xdist: commands[0] /home/runner/work/jwst/jwst/tmp/py311-xdist> pytest /home/runner/work/jwst/jwst/docs --pyargs jwst cov: --cov jwst --cov-config=/home/runner/work/jwst/jwst/pyproject.toml --cov-report xml:/home/runner/work/jwst/jwst/coverage.xml --cov-report term-missing xdist: -n auto --junitxml /home/runner/work/jwst/jwst/results.xml -vv
```

with this PR that job started successfully:
https://github.com/spacetelescope/jwst/actions/runs/22237916596/job/64334120430?pr=10269
because we installed an older tox:
https://github.com/spacetelescope/jwst/actions/runs/22237916596/job/64334120430?pr=10269#step:9:18


<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
