### PR TITLE
TST: Unignore chararray DeprecationWarning

### DIFF
--- a/jwst/extract_1d/apply_apcorr.py
+++ b/jwst/extract_1d/apply_apcorr.py
@@ -1,11 +1,14 @@
 import abc
 
 import numpy as np
+from astropy.utils import minversion
 from scipy.interpolate import RectBivariateSpline, interp1d
 from stcal.alignment.util import compute_scale
 from stdatamodels.jwst.datamodels import MultiSlitModel
 
 __all__ = ["ApCorrBase", "ApCorrPhase", "ApCorrRadial", "ApCorr", "select_apcorr"]
+
+NUMPY_LT_2 = not minversion(np, "2.0")
 
 
 class ApCorrBase(abc.ABC):
@@ -168,7 +171,10 @@ class ApCorrBase(abc.ABC):
         for key, value in self.match_pars.items():
             if isinstance(value, str):
                 # Not all files will have the same format as input model metadata values.
-                table = table[np.strings.upper(table[key]) == value.upper()]
+                if NUMPY_LT_2:
+                    table = table[table[key].upper() == value.upper()]
+                else:
+                    table = table[np.strings.upper(table[key]) == value.upper()]
             else:
                 table = table[table[key] == value]
 

--- a/jwst/extract_1d/apply_apcorr.py
+++ b/jwst/extract_1d/apply_apcorr.py
@@ -168,7 +168,7 @@ class ApCorrBase(abc.ABC):
         for key, value in self.match_pars.items():
             if isinstance(value, str):
                 # Not all files will have the same format as input model metadata values.
-                table = table[table[key].upper() == value.upper()]
+                table = table[np.strings.upper(table[key]) == value.upper()]
             else:
                 table = table[table[key] == value]
 

--- a/jwst/tweakreg/tweakreg_catalog.py
+++ b/jwst/tweakreg/tweakreg_catalog.py
@@ -6,11 +6,10 @@ import warnings
 
 import astropy.units as u
 import numpy as np
-import photutils
 from astropy.convolution import Gaussian2DKernel, convolve
 from astropy.stats import SigmaClip, gaussian_fwhm_to_sigma
 from astropy.table import Table
-from astropy.utils import lazyproperty, minversion
+from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
 from photutils.background import Background2D, MedianBackground
 from photutils.detection import DAOStarFinder, IRAFStarFinder
@@ -32,8 +31,6 @@ SOURCECAT_COLUMNS = DEFAULT_COLUMNS + [
     "sky_bbox_lr",
     "sky_bbox_ur",
 ]
-
-PHOTUTILS_LT_3 = not minversion(photutils, "2.3.1.dev")
 
 
 class JWSTBackground:
@@ -107,10 +104,6 @@ class JWSTBackground:
                     "Using the entire unmasked array for background "
                     f"estimation: bkg_boxsize={self.data.shape}."
                 )
-
-        # Force caching of background now to avoid crashing later.
-        if not PHOTUTILS_LT_3:
-            bkg.background  # noqa: B018
 
         return bkg
 

--- a/jwst/tweakreg/tweakreg_catalog.py
+++ b/jwst/tweakreg/tweakreg_catalog.py
@@ -6,10 +6,11 @@ import warnings
 
 import astropy.units as u
 import numpy as np
+import photutils
 from astropy.convolution import Gaussian2DKernel, convolve
 from astropy.stats import SigmaClip, gaussian_fwhm_to_sigma
 from astropy.table import Table
-from astropy.utils import lazyproperty
+from astropy.utils import lazyproperty, minversion
 from astropy.utils.exceptions import AstropyUserWarning
 from photutils.background import Background2D, MedianBackground
 from photutils.detection import DAOStarFinder, IRAFStarFinder
@@ -31,6 +32,8 @@ SOURCECAT_COLUMNS = DEFAULT_COLUMNS + [
     "sky_bbox_lr",
     "sky_bbox_ur",
 ]
+
+PHOTUTILS_LT_3 = not minversion(photutils, "2.3.1.dev")
 
 
 class JWSTBackground:
@@ -104,6 +107,10 @@ class JWSTBackground:
                     "Using the entire unmasked array for background "
                     f"estimation: bkg_boxsize={self.data.shape}."
                 )
+
+        # Force caching of background now to avoid crashing later.
+        if not PHOTUTILS_LT_3:
+            bkg.background  # noqa: B018
 
         return bkg
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,9 +227,7 @@ addopts = [
 ]
 xfail_strict = true
 filterwarnings = [
-    "error",
-    # https://github.com/astropy/astropy/issues/19216
-    "ignore:The chararray class is deprecated:DeprecationWarning",
+    "error"
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

https://jira.stsci.edu/browse/JP-4255
https://jira.stsci.edu/browse/JP-4256

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
* Closes https://github.com/spacetelescope/jwst/issues/10249
* https://github.com/spacetelescope/jwst/issues/10273
* https://github.com/spacetelescope/jwst/issues/10274

<!-- describe the changes comprising this PR here -->
This PR reverts https://github.com/spacetelescope/jwst/pull/10243 because it has been resolved upstream.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md)) https://github.com/spacetelescope/RegressionTests/actions/runs/22368688646 (stable) and https://github.com/spacetelescope/RegressionTests/actions/runs/22368699345 (devdeps with photutils bug workaround) and https://github.com/spacetelescope/RegressionTests/actions/runs/22401566534 (devdeps)
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
