### PR TITLE
DOC: Complete API for clean_flicker_noise

### DIFF
--- a/docs/jwst/clean_flicker_noise/api_ref.rst
+++ b/docs/jwst/clean_flicker_noise/api_ref.rst
@@ -1,0 +1,21 @@
+===
+API
+===
+
+Public Step API
+===============
+
+.. automodapi:: jwst.clean_flicker_noise.clean_flicker_noise_step
+   :no-inheritance-diagram:
+
+Complete Developer API
+======================
+
+.. automodapi:: jwst.clean_flicker_noise.autoparam
+   :no-inheritance-diagram:
+
+.. automodapi:: jwst.clean_flicker_noise.clean_flicker_noise
+   :no-inheritance-diagram:
+
+.. automodapi:: jwst.clean_flicker_noise.lib
+   :no-inheritance-diagram:

--- a/docs/jwst/clean_flicker_noise/index.rst
+++ b/docs/jwst/clean_flicker_noise/index.rst
@@ -3,11 +3,16 @@
 ===================
 Clean Flicker Noise
 ===================
+
 .. toctree::
    :maxdepth: 2
 
    main.rst
-   reference_files.rst
    arguments.rst
-   
-.. automodapi:: jwst.clean_flicker_noise
+
+* Reference File: The ``clean_flicker_noise`` step does not use any reference files.
+
+.. toctree::
+   :maxdepth: 2
+
+   api_ref.rst

--- a/docs/jwst/clean_flicker_noise/index.rst
+++ b/docs/jwst/clean_flicker_noise/index.rst
@@ -9,10 +9,5 @@ Clean Flicker Noise
 
    main.rst
    arguments.rst
-
-* Reference File: The ``clean_flicker_noise`` step does not use any reference files.
-
-.. toctree::
-   :maxdepth: 2
-
+   reference_files.rst
    api_ref.rst

--- a/docs/jwst/clean_flicker_noise/main.rst
+++ b/docs/jwst/clean_flicker_noise/main.rst
@@ -1,7 +1,7 @@
 Description
 ===========
 
-:Class: `jwst.clean_flicker_noise.CleanFlickerNoiseStep`
+:Class: `jwst.clean_flicker_noise.clean_flicker_noise_step.CleanFlickerNoiseStep`
 :Alias: clean_flicker_noise
 
 Overview
@@ -46,7 +46,7 @@ be used to fit the background noise.  The step builds a scene mask
 on the fly from a draft rate image, generated from the input ramp data,
 which is used to mark usable and unusable pixels. The mask is a 2D
 Boolean array, having the same size as the image, with
-pixels set to True interpreted as being OK to use.
+pixels set to `True` interpreted as being OK to use.
 
 The process of building the mask varies somewhat depending on the
 observing mode of the image being processed. Some features are common
@@ -73,22 +73,22 @@ For IFU images, the majority of the mask is based on knowing which
 pixels are contained within the footprints of the IFU slices. To do
 this, the image's World Coordinate System (WCS) object is queried in
 order to determine which pixels are contained within each of the 30
-slices. Pixels within each slice are set to False (do not use) in the
+slices. Pixels within each slice are set to `False` (do not use) in the
 mask.
 
 NIRSpec MOS/FS Slits
 ^^^^^^^^^^^^^^^^^^^^
-The footprints of each open MOS slitlet or fixed slit are flagged in
+The footprints of each open MOS slitlet or fixed slit (FS) are flagged in
 a similar way as IFU slices. For MOS and FS images, the WCS object is
 queried to determine which pixels are contained within each open
-slit/slitlet and they are set to False in the mask.
+slit/slitlet and they are set to `False` in the mask.
 
 NIRSpec MSA Failed Open Shutters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Pixels affected by stuck open MSA shutters are masked, because they
 may contain signal. This is accomplished by setting all pixels flagged by the
 :ref:`msaflagopen <msaflagopen_step>` step with DQ value "MSA_FAILED_OPEN"
-to False in the mask.
+to `False` in the mask.
 
 NIRSpec Fixed-Slit Region Pixels
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -96,8 +96,8 @@ Full-frame MOS and IFU images may contain signal from the always open
 fixed slits, which appear in a fixed region in the middle of each image.
 The entire region containing the fixed slits is masked out when
 processing MOS and IFU images. The masked region is currently hardwired
-in the step to image indexes [1:2048, 923:1116], where the indexes are
-in x, y order and in 1-indexed values.
+in the step to image indexes ``[1:2048, 923:1116]``, where the indices are
+in ``x, y`` order and in 1-indexed values.
 
 Note, however, that it is possible to plan one or more fixed slit targets
 alongside MSA slitlets in MOS observations. In this situation, the fixed
@@ -109,13 +109,13 @@ The MIRI imager has a metering structure covering a large part of the
 detector area. These regions must be masked in order to fit and
 remove the background data in the science areas of the detector.
 Regions marked with DQ value "DO_NOT_USE" by the
-:ref:`flat_field <flatfield_step>` step are set to False in the
+:ref:`flat_field <flatfield_step>` step are set to `False` in the
 scene mask.
 
 Missing Data
 ^^^^^^^^^^^^
 Any pixel in the draft rate image that has a value of NaN or exactly zero
-is flagged as False in the mask. This typically includes any reference
+is flagged as `False` in the mask. This typically includes any reference
 pixels that are present in the exposure.
 
 Outliers
@@ -129,11 +129,11 @@ pixels in the unilluminated areas of the region can still contain anomalous
 signal, due to uncaught cosmic rays, hot pixels, etc.
 
 For both modes, a sigma-clipping routine is employed to find such outliers
-within the draft rate image and set them to False in the mask. All pixels with
+within the draft rate image and set them to `False` in the mask. All pixels with
 values greater than :math:`median+n\_sigma*sigma` are assumed to contain
-signal and are set to False in the scene mask. In addition, all pixels
+signal and are set to `False` in the scene mask. In addition, all pixels
 with values less than :math:`median-3.0*sigma` are assumed to be bad pixels,
-and are also set to False in the scene mask.
+and are also set to `False` in the scene mask.
 
 Mode-Specific Masking Steps
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -164,7 +164,7 @@ images from each instrument and observing mode.
 
 :sup:`1`\ These steps are only applied if the
 :ref:`step parameter <clean_flicker_noise_arguments>`
-``mask_science_regions`` is set to True.
+``mask_science_regions`` is set to `True`.
 
 Correction Algorithm
 --------------------
@@ -173,8 +173,8 @@ The detailed process for fitting and removing flicker noise is as follows.
 See the :ref:`step arguments <clean_flicker_noise_arguments>` for more
 information on all referenced parameters.
 
-#. From the calibrated ramp input, make a draft rate (``single_mask`` = True)
-   or rateints (``single_mask`` = False) file. If the input to the step
+#. From the calibrated ramp input, make a draft rate (``single_mask=True``)
+   or rateints (``single_mask= False``) file. If the input to the step
    is already a rate or rateints file, it is used directly for all following
    steps.
 
@@ -205,9 +205,9 @@ information on all referenced parameters.
    #. If ``fit_histogram`` is set, compute a histogram from 4-sigma clipped
       values and fit a Gaussian to it to refine the center and sigma values.
 
-   #. Mask data more than 3 * sigma below the center as bad values.
+   #. Mask data more than :math:`3 * sigma` below the center as bad values.
 
-   #. Mask data more than ``n_sigma`` * sigma above the center as signal
+   #. Mask data more than :math:`n_sigma * sigma` above the center as signal
       (not background).
 
 #. Iterate over each integration and group in the data, to fit and correct
@@ -224,28 +224,28 @@ information on all referenced parameters.
 
       #. Clip the background data in the diff image to remove more outliers.
 
-      #. If ``background_method`` = 'median', the background value is a simple
+      #. If ``background_method='median'``, the background value is a simple
          median of the remaining values.
 
-      #. If ``background_method`` = 'model', the background data is fit with
+      #. If ``background_method='model'``, the background data is fit with
          a low-resolution model via the photutils
-         `Background2D <https://photutils.readthedocs.io/en/latest/api/photutils.background.Background2D.html>`__
+         `~photutils.background.Background2D`
          utility. The resolution box size is set by ``background_box_size``.
 
       #. Subtract the background level from the diff image and clip again
-         to ``n_sigma`` * sigma, with sigma recomputed from the
+         to :math:`n_sigma * sigma`, with sigma recomputed from the
          background-subtracted data in the remaining background pixels.
 
    #. Fit and remove the residual noise in the background-subtracted image.
 
-      #. If ``fit_method`` = 'fft', the ``nsclean`` library is called to fit
+      #. If ``fit_method='fft'``, the `~jwst.clean_flicker_noise.lib.NSClean` library is called to fit
          and remove the noise in frequency space.
 
-      #. If ``fit_method`` = 'median', the noise is fit with a simple median
+      #. If ``fit_method='median'``, the noise is fit with a simple median
          along the appropriate detector axis and subtracted from the
          background-subtracted image.
 
-         If ``fit_by_channel`` = True, and the data is a NIR full-frame exposure,
+         If ``fit_by_channel=True``, and the data is a NIR full-frame exposure,
          the median value is computed and subtracted independently for each
          detector channel.
 
@@ -266,7 +266,7 @@ suits their data, but it is possible in some cases for the algorithm to
 recommend parameter settings from a statistical analysis of the input
 data.
 
-If the input parameter ``autoparam`` is set to True, and if the input
+If the input parameter ``autoparam`` is set to `True`, and if the input
 exposure type is supported, the cleaning algorithm will attempt some pre-processing
 and analysis on the input exposure and override some of the input background
 and fitting parameters according to a heuristic decision tree.
@@ -288,23 +288,25 @@ For NIRISS and NIRCam imaging, the auto-parameter process is:
 
 #. From the computed statistics, use a decision tree to set values for the
    ``background_method`` and ``fit_by_channel`` parameters.  For both of these
-   imaging modes, ``apply_flat_field`` is also set to True, regardless of the
+   imaging modes, ``apply_flat_field`` is also set to `True`, regardless of the
    computed statistics.
 
 Any parameters that are not explicitly overridden by the auto-parameter determination
 are left at input values.
 
+.. _nsclean-algo-references:
+
 References
 ==========
 
-The FFT cleaning algorithm implementation is based on NSClean,
+The FFT cleaning algorithm implementation is based on ``NSClean``
 developed by Bernard Rauscher. Details on the source of the correlated
 noise and the algorithm used by the ``nsclean`` library to fit and
 remove it can be found in
 `Rauscher 2024 <https://ui.adsabs.harvard.edu/abs/2023arXiv230603250R/abstract>`__.
 
 The background fitting and median cleaning algorithm are based on
-the image1overf algorithm, developed by Chris Willott, and available
+the ``image1overf`` algorithm, developed by Chris Willott, and available
 on GitHub at `chriswillott/jwst <https://github.com/chriswillott/jwst>`__.
 The algorithm was adapted to the ``clean_flicker_noise`` step and is released
 under the BSD license for the JWST calibration pipeline by permission

--- a/docs/jwst/clean_flicker_noise/main.rst
+++ b/docs/jwst/clean_flicker_noise/main.rst
@@ -205,9 +205,9 @@ information on all referenced parameters.
    #. If ``fit_histogram`` is set, compute a histogram from 4-sigma clipped
       values and fit a Gaussian to it to refine the center and sigma values.
 
-   #. Mask data more than :math:`3 * sigma` below the center as bad values.
+   #. Mask data more than ``3 * sigma`` below the center as bad values.
 
-   #. Mask data more than :math:`n_sigma * sigma` above the center as signal
+   #. Mask data more than ``n_sigma * sigma`` above the center as signal
       (not background).
 
 #. Iterate over each integration and group in the data, to fit and correct
@@ -233,13 +233,13 @@ information on all referenced parameters.
          utility. The resolution box size is set by ``background_box_size``.
 
       #. Subtract the background level from the diff image and clip again
-         to :math:`n_sigma * sigma`, with sigma recomputed from the
+         to ``n_sigma * sigma``, with sigma recomputed from the
          background-subtracted data in the remaining background pixels.
 
    #. Fit and remove the residual noise in the background-subtracted image.
 
       #. If ``fit_method='fft'``, the `~jwst.clean_flicker_noise.lib.NSClean` library is called to fit
-         and remove the noise in frequency space.
+         and remove the noise in frequency space (also see :ref:`nsclean-algo-references`).
 
       #. If ``fit_method='median'``, the noise is fit with a simple median
          along the appropriate detector axis and subtracted from the

--- a/docs/jwst/clean_flicker_noise/reference_files.rst
+++ b/docs/jwst/clean_flicker_noise/reference_files.rst
@@ -1,0 +1,5 @@
+Reference Files
+===============
+For some optional processing steps, the ``clean_flicker_noise`` step may use the FLAT reference file.
+
+.. include:: ../references_general/flat_reffile.inc

--- a/docs/jwst/clean_flicker_noise/reference_files.rst
+++ b/docs/jwst/clean_flicker_noise/reference_files.rst
@@ -1,3 +1,0 @@
-Reference Files
-===============
-The ``clean_flicker_noise`` step does not use any reference files.

--- a/docs/jwst/clean_flicker_noise/reference_files.rst
+++ b/docs/jwst/clean_flicker_noise/reference_files.rst
@@ -1,5 +1,3 @@
 Reference Files
 ===============
-For some optional processing steps, the ``clean_flicker_noise`` step may use the FLAT reference file.
-
-.. include:: ../references_general/flat_reffile.inc
+For some optional processing steps, the ``clean_flicker_noise`` step may use the :ref:`flat_reffile`.

--- a/docs/jwst/flatfield/reference_files.rst
+++ b/docs/jwst/flatfield/reference_files.rst
@@ -1,14 +1,16 @@
 Reference Files
 ===============
 The ``flat_field`` step uses four different types of reference files, depending on the
-type of data being processed. Most cases just use the FLAT reference file, while NIRSpec
-spectroscopic exposures use the three reference files FFLAT (fore optics),
-SFLAT (spectrograph optics), and DFLAT (detector).
+type of data being processed. Most cases just use the :ref:`flat_reffile`, while NIRSpec
+spectroscopic exposures use the three reference files :ref:`fflat_reffile` (fore optics),
+:ref:`sflat_reffile` (spectrograph optics), and :ref:`dflat_reffile` (detector).
+
+.. _flat_reffile:
 
 .. include:: ../references_general/flat_reffile.inc
 
 Reference Files for NIRSpec Spectroscopy
-===================================================
+========================================
 For NIRSpec spectroscopic data, the flat-field reference files allow for variations in
 the flat field with wavelength, as well as from pixel to pixel.  There is a
 separate flat-field reference file for each of three sections of the
@@ -78,4 +80,3 @@ which are now described.
 .. include:: ../references_general/sflat_reffile.inc
 
 .. include:: ../references_general/dflat_reffile.inc
-

--- a/docs/jwst/flatfield/reference_files.rst
+++ b/docs/jwst/flatfield/reference_files.rst
@@ -5,8 +5,6 @@ type of data being processed. Most cases just use the :ref:`flat_reffile`, while
 spectroscopic exposures use the three reference files :ref:`fflat_reffile` (fore optics),
 :ref:`sflat_reffile` (spectrograph optics), and :ref:`dflat_reffile` (detector).
 
-.. _flat_reffile:
-
 .. include:: ../references_general/flat_reffile.inc
 
 Reference Files for NIRSpec Spectroscopy

--- a/docs/jwst/references_general/flat_reffile.inc
+++ b/docs/jwst/references_general/flat_reffile.inc
@@ -1,5 +1,3 @@
-.. _flat_reffile:
-
 FLAT Reference File
 -------------------
 

--- a/docs/jwst/references_general/flat_reffile.inc
+++ b/docs/jwst/references_general/flat_reffile.inc
@@ -16,7 +16,7 @@ Type Specific Keywords for FLAT
 In addition to the standard reference file keywords listed above,
 the following keywords are *required* in FLAT reference files,
 because they are used as CRDS selectors
-(see :ref:`flat_selectors`):
+(see "Reference Selection Keywords for FLAT" above):
 
 =========  ==============================  =============================
 Keyword    Data Model Name                 Instruments

--- a/docs/jwst/references_general/flat_reffile.inc
+++ b/docs/jwst/references_general/flat_reffile.inc
@@ -1,3 +1,5 @@
+.. _flat_reffile:
+
 FLAT Reference File
 -------------------
 
@@ -16,7 +18,7 @@ Type Specific Keywords for FLAT
 In addition to the standard reference file keywords listed above,
 the following keywords are *required* in FLAT reference files,
 because they are used as CRDS selectors
-(see "Reference Selection Keywords for FLAT" above):
+(see :ref:`flat_selectors`):
 
 =========  ==============================  =============================
 Keyword    Data Model Name                 Instruments

--- a/docs/jwst/references_general/flat_selection.inc
+++ b/docs/jwst/references_general/flat_selection.inc
@@ -1,3 +1,5 @@
+.. _flat_selectors:
+
 Reference Selection Keywords for FLAT
 +++++++++++++++++++++++++++++++++++++
 CRDS selects appropriate FLAT references based on the following keywords.

--- a/docs/jwst/references_general/flat_selection.inc
+++ b/docs/jwst/references_general/flat_selection.inc
@@ -1,5 +1,3 @@
-.. _flat_selectors:
-
 Reference Selection Keywords for FLAT
 +++++++++++++++++++++++++++++++++++++
 CRDS selects appropriate FLAT references based on the following keywords.
@@ -7,12 +5,11 @@ FLAT is not applicable for instruments not in the table.
 Non-standard keywords used for file selection are *required*.
 
 ========== ========================================================================
-Instrument Keywords                                                                 
+Instrument Keywords
 ========== ========================================================================
-FGS        INSTRUME, DETECTOR, EXP_TYPE, DATE-OBS, TIME-OBS                         
-MIRI       INSTRUME, DETECTOR, FILTER, BAND, READPATT, SUBARRAY, DATE-OBS, TIME-OBS 
-NIRCam     INSTRUME, DETECTOR, FILTER, PUPIL, DATE-OBS, TIME-OBS                    
-NIRISS     INSTRUME, DETECTOR, FILTER, PUPIL, DATE-OBS, TIME-OBS                    
-NIRSpec    INSTRUME, DETECTOR, FILTER, GRATING, EXP_TYPE, DATE-OBS, TIME-OBS        
+FGS        INSTRUME, DETECTOR, EXP_TYPE, DATE-OBS, TIME-OBS
+MIRI       INSTRUME, DETECTOR, FILTER, BAND, READPATT, SUBARRAY, DATE-OBS, TIME-OBS
+NIRCam     INSTRUME, DETECTOR, FILTER, PUPIL, DATE-OBS, TIME-OBS
+NIRISS     INSTRUME, DETECTOR, FILTER, PUPIL, DATE-OBS, TIME-OBS
+NIRSpec    INSTRUME, DETECTOR, FILTER, GRATING, EXP_TYPE, DATE-OBS, TIME-OBS
 ========== ========================================================================
-

--- a/jwst/clean_flicker_noise/autoparam.py
+++ b/jwst/clean_flicker_noise/autoparam.py
@@ -26,7 +26,9 @@ def quick_clean(input_model, flat_filename=None):
 
     Parameters
     ----------
-    input_model : RampModel, ImageModel, or CubeModel
+    input_model : `~stdatamodels.jwst.datamodels.RampModel`, \
+                  `~stdatamodels.jwst.datamodels.ImageModel`, or \
+                  `~stdatamodels.jwst.datamodels.CubeModel`
         Input data to clean.
     flat_filename : str or None
         If provided, will be read in and divided into the image before cleaning.
@@ -36,7 +38,7 @@ def quick_clean(input_model, flat_filename=None):
     image : ndarray of float
         2D cleaned rate image.
     mask : ndarray of bool
-        2D mask marking background pixels as True.
+        2D mask marking background pixels as `True`.
     """
     # Make a draft rate file first
     if isinstance(input_model, datamodels.RampModel):
@@ -301,7 +303,9 @@ def niriss_image_parameters(input_model, flat_filename):
 
     Parameters
     ----------
-    input_model : RampModel, ImageModel, or CubeModel
+    input_model : `~stdatamodels.jwst.datamodels.RampModel`, \
+                  `~stdatamodels.jwst.datamodels.ImageModel`, or \
+                  `~stdatamodels.jwst.datamodels.CubeModel`
         Input model.
     flat_filename : str
         Path to a FLAT reference file.
@@ -399,7 +403,9 @@ def nircam_image_parameters(input_model, flat_filename):
 
     Parameters
     ----------
-    input_model : RampModel, ImageModel, or CubeModel
+    input_model : `~stdatamodels.jwst.datamodels.RampModel`, \
+                  `~stdatamodels.jwst.datamodels.ImageModel`, or \
+                  `~stdatamodels.jwst.datamodels.CubeModel`
         Input model.
     flat_filename : str
         Path to a FLAT reference file.

--- a/jwst/clean_flicker_noise/clean_flicker_noise.py
+++ b/jwst/clean_flicker_noise/clean_flicker_noise.py
@@ -52,20 +52,20 @@ def read_flat_file(input_model, flat_filename):
 
     Only the flat image is returned: error and DQ arrays are ignored.
     Any zeros or NaNs in the flat image are set to a smoothed local average
-    value (via `background_level`, with background_method = 'model') before
+    value (via ``background_level``, with ``background_method = 'model'``) before
     returning, to avoid impacting the background and noise fits near
     missing flat data.
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.JwstDataModel`
+    input_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The input data.
     flat_filename : str
         File path for a full-frame flat image.
 
     Returns
     -------
-    flat_data : array-like of float
+    flat_data : ndarray of float
         A 2D flat image array matching the input data.
     """
     if flat_filename is None:
@@ -104,21 +104,23 @@ def make_rate(input_model, input_dir="", return_cube=False):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.RampModel`
+    input_model : `~stdatamodels.jwst.datamodels.RampModel`
         Input ramp model.
 
     input_dir : str
-        Path to the input directory.  Used by sub-steps (e.g. assign_wcs
+        Path to the input directory.  Used by sub-steps (e.g., ``assign_wcs``
         for NIRSpec MOS data) to find auxiliary data.
 
     return_cube : bool, optional
-        If set, a CubeModel will be returned, with a separate
-        rate for each integration.  Otherwise, an ImageModel is returned
+        If set, a `~stdatamodels.jwst.datamodels.CubeModel` will be returned, with a separate
+        rate for each integration.  Otherwise, an
+        `~stdatamodels.jwst.datamodels.ImageModel` is returned
         with the combined rate for the full observation.
 
     Returns
     -------
-    rate_model : `~jwst.datamodels.ImageModel` or `~jwst.datamodels.CubeModel`
+    rate_model : `~stdatamodels.jwst.datamodels.ImageModel` or \
+                 `~stdatamodels.jwst.datamodels.CubeModel`
         The rate or rateints model.
     """
     # Call the ramp fit step on a copy of the input
@@ -154,29 +156,31 @@ def post_process_rate(
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.ImageModel` or `~jwst.datamodels.CubeModel`
+    input_model : `~stdatamodels.jwst.datamodels.ImageModel` or \
+                  `~stdatamodels.jwst.datamodels.CubeModel`
         Input rate model.
 
     input_dir : str
-        Path to the input directory.  Used by sub-steps (e.g. assign_wcs
+        Path to the input directory.  Used by sub-steps (e.g., ``assign_wcs``
         for NIRSpec MOS data) to find auxiliary data.
 
     assign_wcs : bool, optional
         If set and the input does not already have a WCS assigned,
-        the assign_wcs step will be called on the rate model.
+        the ``assign_wcs`` step will be called on the rate model.
 
     msaflagopen : bool, optional
-        If set, the msaflagopen step will be called on the rate model.
-        If a WCS is not already present, assign_wcs will be called first.
+        If set, the ``msaflagopen`` step will be called on the rate model.
+        If a WCS is not already present, ``assign_wcs`` will be called first.
 
     flat_dq : bool, optional
-        If set, the flat_field step will be run on the input model. DQ
+        If set, the ```flat_field`` step will be run on the input model. DQ
         flags are retrieved from the output and added to the input
         model's DQ array. The rate data is not modified.
 
     Returns
     -------
-    output_model : `~jwst.datamodels.ImageModel` or `~jwst.datamodels.CubeModel`
+    output_model : `~stdatamodels.jwst.datamodels.ImageModel` or \
+                   `~stdatamodels.jwst.datamodels.CubeModel`
         The updated model.
     """
     output_model = input_model
@@ -222,16 +226,16 @@ def mask_ifu_slices(input_model, mask):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.JwstDataModel`
+    input_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Science data model
 
-    mask : array-like of bool
-        2D input mask that will be updated. True indicates background
-        pixels to be used. IFU slice regions will be set to False.
+    mask : ndarray of bool
+        2D input mask that will be updated. `True` indicates background
+        pixels to be used. IFU slice regions will be set to `False`.
 
     Returns
     -------
-    mask : array-like of bool
+    mask : ndarray of bool
         2D output mask with additional flags for science pixels
     """
     log.info("Finding slice pixels for an IFU image")
@@ -278,16 +282,16 @@ def mask_slits(input_model, mask):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.JwstDataModel`
+    input_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Science data model.
 
-    mask : array-like of bool
-        2D input mask that will be updated. True indicates background
-        pixels to be used. Slit regions will be set to False.
+    mask : ndarray of bool
+        2D input mask that will be updated. `True` indicates background
+        pixels to be used. Slit regions will be set to `False`.
 
     Returns
     -------
-    mask : array-like of bool
+    mask : ndarray of bool
         2D output mask with additional flags for slit pixels
     """
     log.info("Finding slit/slitlet pixels")
@@ -327,36 +331,36 @@ def clip_to_background(
     to a histogram of the values.  In that case, the center is the
     Gaussian mean and the sigma is the Gaussian width.
 
-    Pixels above the center + sigma_upper * sigma are assumed to
+    Pixels above the ``center + sigma_upper * sigma`` are assumed to
     have signal; those below this level are assumed to be background pixels.
 
-    Pixels less than center - sigma_lower * sigma are also excluded as bad values.
+    Pixels less than ``center - sigma_lower * sigma`` are also excluded as bad values.
 
     The input mask is updated in place.
 
     Parameters
     ----------
-    image : array-like of float
+    image : ndarray of float
         2D image containing signal and background values.
 
-    mask : array-like of bool
+    mask : ndarray of bool
         2D input mask to be updated. True indicates background
         pixels to be used. Regions containing signal or outliers
-        will be set to False.
+        will be set to `False`.
 
     sigma_lower : float, optional
         The number of standard deviations to use as the lower bound
         for the clipping limit. Values below this limit are marked
-        False in the mask.
+        `False` in the mask.
 
     sigma_upper : float, optional
         The number of standard deviations to use as the upper bound
         for the clipping limit. Values above this limit are marked
-        False in the mask.
+        `False` in the mask.
 
     fit_histogram :  bool, optional
         If set, the center value and standard deviation used with
-        `sigma_lower` and `sigma_upper` for clipping outliers is derived
+        ``sigma_lower`` and ``sigma_upper`` for clipping outliers is derived
         from a Gaussian fit to a histogram of values. Otherwise, the
         center and standard deviation are derived from a simple iterative
         sigma clipping.
@@ -489,7 +493,7 @@ def create_mask(
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.JwstDataModel`
+    input_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Science data model, containing rate data with all necessary
         pre-processing already performed.
 
@@ -497,7 +501,7 @@ def create_mask(
         For NIRSpec, mask regions of the image defined by WCS bounding
         boxes for slits/slices, as well as any regions known to be
         affected by failed-open MSA shutters. This requires the
-        `assign_wcs` and `msaflagopen` steps to have been run on the
+        ``assign_wcs`` and ``msaflagopen`` steps to have been run on the
         input_model.
         For MIRI imaging, mask regions of the detector not used for science.
         This requires that DO_NOT_USE flags are set in the DQ array
@@ -507,7 +511,7 @@ def create_mask(
         Sigma threshold for masking outliers.
 
     fit_histogram : bool, optional
-        If set, the 'sigma' used with `n_sigma` for clipping outliers
+        If set, the 'sigma' used with ``n_sigma`` for clipping outliers
         is derived from a Gaussian fit to a histogram of values.
         Otherwise, a simple iterative sigma clipping is performed.
 
@@ -518,7 +522,7 @@ def create_mask(
 
     Returns
     -------
-    mask : array-like of bool
+    mask : ndarray of bool
         2D or 3D image mask
     """
     exptype = input_model.meta.exposure.type.lower()
@@ -605,10 +609,10 @@ def background_level(image, mask, background_method="median", background_box_siz
 
     Parameters
     ----------
-    image : array-like of float
+    image : ndarray of float
         The 2D image containing the background to fit.
 
-    mask : array-like of bool
+    mask : ndarray of bool
         The mask that indicates which pixels are to be used in fitting.
         True indicates a background pixel.
 
@@ -620,17 +624,17 @@ def background_level(image, mask, background_method="median", background_box_siz
         value is 0.0.
 
     background_box_size : tuple of int, optional
-        Box size for the data grid used by `Background2D` when
-        `background_method` = 'model'. For best results, use a box size
+        Box size for the data grid used by `~photutils.background.Background2D` when
+        ``background_method = 'model'``. For best results, use a box size
         that evenly divides the input image shape. Defaults to 32x32 if
         not provided.
 
     Returns
     -------
-    background : float or array-like of float
-        The background level: a single value, if `background_method`
+    background : float or ndarray of float
+        The background level: a single value, if ``background_method``
         is 'median' or None, or an array matching the input image size
-        if `background_method` is 'model'.
+        if ``background_method`` is 'model'.
     """
     if background_method is None:
         background = 0.0
@@ -696,10 +700,10 @@ def fft_clean_full_frame(image, mask, detector):
 
     Parameters
     ----------
-    image : array-like of float
+    image : ndarray of float
         The image to be cleaned.
 
-    mask : array-like of bool
+    mask : ndarray of bool
         The mask that indicates which pixels are to be used in fitting.
 
     detector : str
@@ -707,7 +711,7 @@ def fft_clean_full_frame(image, mask, detector):
 
     Returns
     -------
-    cleaned_image : array-like of float
+    cleaned_image : ndarray of float
         The cleaned image.
     """
     # Instantiate the cleaner
@@ -738,10 +742,10 @@ def fft_clean_subarray(
 
     Parameters
     ----------
-    image : array-like of float
+    image : ndarray of float
         The image to be cleaned.
 
-    mask : array-like of bool
+    mask : ndarray of bool
         The mask that indicates which pixels are to be used in fitting.
 
     detector : str
@@ -751,30 +755,32 @@ def fft_clean_subarray(
         Number of pixels to process simultaneously.  Default 512.  Should
         be at least a few hundred to access sub-kHz frequencies in areas
         where most pixels are available for fitting.  Previous default
-        behavior corresponds to npix_iter of infinity.
+        behavior corresponds to ``npix_iter`` of infinity.
 
     fc : tuple
         Apodizing filter definition. These parameters are tunable. The
-        defaults happen to work well for NIRSpec BOTS exposures.
-          1) Unity gain for f < fc[0]
-          2) Cosine roll-off from fc[0] to fc[1]
-          3) Zero gain from fc[1] to fc[2]
-          4) Cosine roll-on from fc[2] to fc[3]
-        Default (1061, 1211, 49943, 49957)
+        defaults happen to work well for NIRSpec BOTS exposures:
+
+        1. Unity gain for ``f < fc[0]``
+        2. Cosine roll-off from ``fc[0]`` to ``fc[1]``
+        3. Zero gain from ``fc[1]`` to ``fc[2]``
+        4. Cosine roll-on from ``fc[2]`` to ``fc[3]``
+
+        Default ``(1061, 1211, 49943, 49957)``
 
     exclude_outliers : bool
-        Find and mask outliers in the fit?  Default True
+        Find and mask outliers in the fit? Default: `True`
 
     sigrej : float
-        Number of sigma to clip when identifying outliers.  Default 4.
+        Number of sigma to clip when identifying outliers. Default: 4.
 
     minfrac : float
         Minimum fraction of pixels locally available in the mask in
-        order to attempt a correction.  Default 0.05 (i.e., 5%).
+        order to attempt a correction. Default: 0.05 (i.e., 5%)
 
     Returns
     -------
-    cleaned_image : array-like of float
+    cleaned_image : ndarray of float
         The cleaned image.
     """
     # Flip the image to detector coords. NRS1 requires a transpose
@@ -909,18 +915,18 @@ def median_clean(image, mask, axis_to_correct, fit_by_channel=False):
 
     Parameters
     ----------
-    image : array-like of float
+    image : ndarray of float
         The image to be cleaned.
 
-    mask : array-like of bool
+    mask : ndarray of bool
         The mask that indicates which pixels are to be used in fitting.
         True indicates a background pixel.
 
     axis_to_correct : int
         For NIR detectors, the axis to correct should be the detector slow
         readout direction.  Values expected are 1 or 2, following the JWST
-        datamodel definition (meta.subarray.slowaxis).  For MIRI, flicker
-        noise appears along the vertical direction, so `axis_to_correct`
+        datamodel definition (``meta.subarray.slowaxis``).  For MIRI, flicker
+        noise appears along the vertical direction, so ``axis_to_correct``
         should be set to 1 (median along the y-axis).
 
     fit_by_channel : bool, optional
@@ -929,7 +935,7 @@ def median_clean(image, mask, axis_to_correct, fit_by_channel=False):
 
     Returns
     -------
-    cleaned_image : array-like of float
+    cleaned_image : ndarray of float
         The cleaned image.
     """
     # Masked median along slow axis
@@ -986,14 +992,14 @@ def make_intermediate_model(input_model, intermediate_data):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.JwstDataModel`
+    input_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The input data.
-    intermediate_data : array-like
+    intermediate_data : ndarray
         The intermediate data to save.
 
     Returns
     -------
-    intermediate_model : `~jwst.datamodels.JwstDataModel`
+    intermediate_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         A model containing only the intermediate data and top-level
         metadata matching the input.
     """
@@ -1116,7 +1122,7 @@ def _make_processed_rate_image(
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.JwstDataModel`
+    input_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The input data.
     single_mask : bool
         If set, a single scene mask is desired, so create
@@ -1130,16 +1136,16 @@ def _make_processed_rate_image(
         Exposure type for the input data, used to determine
         which kinds of postprocessing is necessary.
     mask_science_regions : bool
-        If set, science regions should be masked, so run `assign_wcs`
-        and `msaflagopen` for NIRSpec and `flatfield` for MIRI
+        If set, science regions should be masked, so run ``assign_wcs``
+        and ``msaflagopen`` for NIRSpec and ``flatfield`` for MIRI
         after creating the draft rate image.
-    flat : array-like of float or None
+    flat : ndarray of float or None
         If not None, the draft rate will be divided by the flat array
         before returning. The provided flat must match the rate shape.
 
     Returns
     -------
-    image_model : `~jwst.datamodels.JwstDataModel`
+    image_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The processed rate image or cube.
     """
     if isinstance(input_model, datamodels.RampModel):
@@ -1180,13 +1186,13 @@ def _make_scene_mask(
 
     If provided, the user mask is opened as a datamodel and directly
     returned. Otherwise, the mask is generated from the rate data in
-    `image_model`.
+    ``image_model``.
 
     Parameters
     ----------
     user_mask : str or None
         Path to user-supplied mask image.
-    image_model : `~jwst.datamodels.JwstDataModel`
+    image_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         A rate image or cube, processed as needed.
     mask_science_regions : bool
         For NIRSpec, mask regions of the image defined by WCS bounding
@@ -1196,7 +1202,7 @@ def _make_scene_mask(
     n_sigma : float
         N-sigma rejection level for finding outliers.
     fit_histogram : bool
-        If set, the 'sigma' used with `n_sigma` for clipping outliers
+        If set, the 'sigma' used with ``n_sigma`` for clipping outliers
         is derived from a Gaussian fit to a histogram of values.
         Otherwise, a simple iterative sigma clipping is performed.
     single_mask : bool
@@ -1205,16 +1211,16 @@ def _make_scene_mask(
         be a 3D cube, with one plane for each integration.
     save_mask : bool
         If set, a mask model is created and returned along with the mask
-        array. If not, the `mask_model` returned is None.
+        array. If not, the ``mask_model`` returned is None.
 
     Returns
     -------
-    background_mask : array-like of bool
+    background_mask : ndarray of bool
         Mask array, with True indicating background pixels, False
         indicating source pixels.
-    mask_model : `~jwst.datamodels.JwstDataModel` or None
-        A datamodel containing the background mask, if `save_mask`
-        is True.
+    mask_model : `~stdatamodels.jwst.datamodels.JwstDataModel` or None
+        A datamodel containing the background mask, if ``save_mask``
+        is `True`.
     """
     # Check for a user-supplied mask image. If provided, use it.
     if user_mask is not None:
@@ -1251,15 +1257,15 @@ def _check_data_shapes(input_model, background_mask):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.JwstDataModel`
+    input_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The input data model.
-    background_mask : array-like of bool
+    background_mask : ndarray of bool
         The background mask.
 
     Returns
     -------
     mismatch : bool
-        If True, the background mask does not match the data
+        If `True`, the background mask does not match the data
         and the step should be skipped.
     ndim : int
         Number of dimensions in the input data.
@@ -1318,15 +1324,15 @@ def _clean_one_image(
 
     Parameters
     ----------
-    image : array-like of float
+    image : ndarray of float
         The input image.
-    mask : array-like of bool
+    mask : ndarray of bool
         The scene mask.  All non-background signal should be
-        marked as True.
+        marked as `True`.
     background_method : str
         The method for fitting the background.
     background_box_size : tuple of int
-        Background box size, used with `background_method`
+        Background box size, used with ``background_method``
         is 'model'.
     n_sigma : float
         N-sigma rejection level for outliers.
@@ -1336,26 +1342,26 @@ def _clean_one_image(
     detector : str
         The detector name.
     fc : tuple of int
-        Frequency cutoff values, used for `fit_method` = 'fft'.
+        Frequency cutoff values, used for ``fit_method = 'fft'``.
     axis_to_correct : int
         Axis along which noise appears, used for
-        `fit_method` = 'median'.
+        ``fit_method = 'median'``.
     fit_by_channel : bool
         Option to fit noise in detector channels separately,
-        used for `fit_method` = 'median'
-    flat : array-like of float or None
+        used for ``fit_method = 'median'``
+    flat : ndarray of float or None
         If not None, the image is divided by the flat before fitting background
         and noise.  Flat data must match the shape of the image.
 
     Returns
     -------
-    cleaned_image : array-like of float
+    cleaned_image : ndarray of float
         The cleaned image.
-    background : array-like of float
+    background : ndarray of float
         The background fit and removed prior to cleaning.
         Used for diagnostic purposes.
     success : bool
-        True if cleaning proceeded as expected; False if
+        `True` if cleaning proceeded as expected; `False` if
         cleaning failed and the step should be skipped.
     """
     success = True
@@ -1432,9 +1438,9 @@ def _mask_unusable(mask, dq):
 
     Parameters
     ----------
-    mask : array-like of bool
+    mask : ndarray of bool
         Input mask, updated in place.
-    dq : array-like of int
+    dq : ndarray of int
         DQ flag array matching the mask shape.
     """
     dnu = (dq & dqflags.group["DO_NOT_USE"]) > 0
@@ -1465,11 +1471,11 @@ def do_correction(
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.JwstDataModel`
+    input_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Science data to be corrected. Updated in place.
 
     input_dir : str
-        Path to the input directory.  Used by sub-steps (e.g. assign_wcs
+        Path to the input directory.  Used by sub-steps (e.g., ``assign_wcs``
         for NIRSpec MOS data) to find auxiliary data.
 
     fit_method : {'fft', 'median'}, optional
@@ -1477,7 +1483,7 @@ def do_correction(
 
     fit_by_channel : bool, optional
         If set, flicker noise is fit independently for each detector channel.
-        Ignored for MIRI, for subarray data, and for `fit_method` = 'fft'.
+        Ignored for MIRI, for subarray data, and for ``fit_method = 'fft'``.
 
     background_method : {'median', 'model', None}, optional
         If 'median', the preliminary background to remove and restore
@@ -1487,8 +1493,8 @@ def do_correction(
         value is 0.0.
 
     background_box_size : tuple of int, optional
-        Box size for the data grid used by `Background2D` when
-        `background_method` = 'model'. For best results, use a box size
+        Box size for the data grid used by `~photutils.background.Background2D` when
+        ``background_method = 'model'``. For best results, use a box size
         that evenly divides the input image shape.
 
     mask_science_regions : bool, optional
@@ -1505,7 +1511,7 @@ def do_correction(
         N-sigma rejection level for finding outliers.
 
     fit_histogram : bool, optional
-        If set, the 'sigma' used with `n_sigma` for clipping outliers
+        If set, the 'sigma' used with ``n_sigma`` for clipping outliers
         is derived from a Gaussian fit to a histogram of values.
         Otherwise, a simple iterative sigma clipping is performed.
 
@@ -1528,22 +1534,22 @@ def do_correction(
 
     Returns
     -------
-    output_model : `~jwst.datamodels.JwstDataModel`
+    output_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Corrected data.
 
-    mask_model : `~jwst.datamodels.JwstDataModel`
+    mask_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Pixel mask to be saved or None.
 
-    background_model : `~jwst.datamodels.JwstDataModel`
+    background_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Background model to be saved or None.
 
-    noise_model : `~jwst.datamodels.JwstDataModel`
+    noise_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Background model to be saved or None.
 
     status : {'COMPLETE', 'SKIPPED'}
-        Completion status.  If errors were encountered, status = 'SKIPPED'
+        Completion status.  If errors were encountered, status is set to 'SKIPPED'
         and the output data matches the input data.  Otherwise,
-        status = 'COMPLETE'.
+        status is set to 'COMPLETE'.
     """
     # Track the completion status, for various failure conditions
     status = "SKIPPED"

--- a/jwst/clean_flicker_noise/clean_flicker_noise.py
+++ b/jwst/clean_flicker_noise/clean_flicker_noise.py
@@ -173,7 +173,7 @@ def post_process_rate(
         If a WCS is not already present, ``assign_wcs`` will be called first.
 
     flat_dq : bool, optional
-        If set, the ```flat_field`` step will be run on the input model. DQ
+        If set, the ``flat_field`` step will be run on the input model. DQ
         flags are retrieved from the output and added to the input
         model's DQ array. The rate data is not modified.
 

--- a/jwst/clean_flicker_noise/clean_flicker_noise_step.py
+++ b/jwst/clean_flicker_noise/clean_flicker_noise_step.py
@@ -1,3 +1,5 @@
+"""Correct ramp or rate data for flicker noise."""
+
 import logging
 
 from jwst.clean_flicker_noise import autoparam, clean_flicker_noise
@@ -39,12 +41,12 @@ class CleanFlickerNoiseStep(Step):
 
         For any supported exposure type, the data is inspected and fit
         parameters are determined accordingly.  Any parameters specified
-        by the `autoparam` algorithm are directly overridden, ignoring
+        by the ``autoparam`` algorithm are directly overridden, ignoring
         user input.
 
         Parameters
         ----------
-        input_model : DataModel
+        input_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
             Input datamodel to be corrected.
         """
         exp_type = input_model.meta.exposure.type
@@ -75,17 +77,19 @@ class CleanFlickerNoiseStep(Step):
         """
         Fit and subtract 1/f background noise from a ramp data set.
 
-        Input data is expected to be a ramp file (RampModel), in between
-        jump and ramp fitting steps, or a rate file (ImageModel or CubeModel).
+        Input data is expected to be a ramp file
+        (`~stdatamodels.jwst.datamodels.RampModel`), in between
+        jump and ramp fitting steps, or a rate file
+        (`~stdatamodels.jwst.datamodels.ImageModel` or `~stdatamodels.jwst.datamodels.CubeModel`).
 
         Correction algorithms implemented are:
 
-            - "fft": Background noise is fit in frequency space.
-               Implementation is based on the NSClean algorithm, developed
-               by Bernard Rauscher.
-            - "median": Background noise is characterized by a median
-              along the detector slow axis. Implementation is based on the
-              "image1overf" algorithm, developed by Chris Willott.
+        - "fft": Background noise is fit in frequency space.
+          Implementation is based on the NSClean algorithm, developed
+          by Bernard Rauscher.
+        - "median": Background noise is characterized by a median
+          along the detector slow axis. Implementation is based on the
+          "image1overf" algorithm, developed by Chris Willott.
 
         Parameters
         ----------

--- a/jwst/clean_flicker_noise/clean_flicker_noise_step.py
+++ b/jwst/clean_flicker_noise/clean_flicker_noise_step.py
@@ -82,7 +82,7 @@ class CleanFlickerNoiseStep(Step):
         jump and ramp fitting steps, or a rate file
         (`~stdatamodels.jwst.datamodels.ImageModel` or `~stdatamodels.jwst.datamodels.CubeModel`).
 
-        Correction algorithms implemented are:
+        Correction algorithms implemented are (also see :ref`nsclean-algo-references`):
 
         - "fft": Background noise is fit in frequency space.
           Implementation is based on the NSClean algorithm, developed


### PR DESCRIPTION
Towards [JP-4107](https://jira.stsci.edu/browse/JP-4107)

This PR addresses `clean_flicker_noise` portion of https://github.com/spacetelescope/jwst/issues/9793 . Only touch docs so should not need RT.

On main:

* https://jwst-pipeline.readthedocs.io/en/latest/jwst/clean_flicker_noise/index.html

With this patch:

* https://jwst-pipeline--10276.org.readthedocs.build/en/10276/jwst/clean_flicker_noise/index.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
