### PR TITLE
DOC: Complete API for combine_1d

### DIFF
--- a/docs/jwst/combine_1d/api_ref.rst
+++ b/docs/jwst/combine_1d/api_ref.rst
@@ -1,0 +1,15 @@
+===
+API
+===
+
+Public Step API
+===============
+
+.. automodapi:: jwst.combine_1d.combine_1d_step
+   :no-inheritance-diagram:
+
+Complete Developer API
+======================
+
+.. automodapi:: jwst.combine_1d.combine1d
+   :no-inheritance-diagram:

--- a/docs/jwst/combine_1d/description.rst
+++ b/docs/jwst/combine_1d/description.rst
@@ -1,7 +1,7 @@
 Description
 ===========
 
-:Class: `jwst.combine_1d.Combine1dStep`
+:Class: `jwst.combine_1d.combine_1d_step.Combine1dStep`
 :Alias: combine_1d
 
 The ``combine_1d`` step computes a weighted average of 1-D spectra and writes
@@ -24,7 +24,7 @@ wavelengths will be increasing, regardless of the order of the input
 wavelengths.  In the ideal case, all input spectra would have wavelength
 arrays that were very nearly the same.  In this case, each output
 wavelength would be computed as the average of the wavelengths at the same
-pixel in all the input files.  The combine_1d step is intended to handle a
+pixel in all the input files.  The ``combine_1d`` step is intended to handle a
 more general case where the input wavelength arrays may be offset with
 respect to each other, or they might not align well due to different
 distortions.  All the input wavelength arrays will be concatenated and then

--- a/docs/jwst/combine_1d/index.rst
+++ b/docs/jwst/combine_1d/index.rst
@@ -9,6 +9,4 @@ Combine 1D Spectra
 
    description.rst
    arguments.rst
-
-
-.. automodapi:: jwst.combine_1d
+   api_ref.rst

--- a/jwst/combine_1d/combine_1d_step.py
+++ b/jwst/combine_1d/combine_1d_step.py
@@ -41,7 +41,7 @@ class Combine1dStep(Step):
 
         Returns
         -------
-        output_spectrum : MultiCombinedSpecModel
+        output_spectrum : `~stdatamodels.jwst.datamodels.MultiCombinedSpecModel`
             A single combined 1D spectrum.
         """
         output_model = self.prepare_output(input_data)


### PR DESCRIPTION
Towards [JP-4107](https://jira.stsci.edu/browse/JP-4107)

This PR addresses `combine_1d` portion of https://github.com/spacetelescope/jwst/issues/9793 . Only touch docs so should not need RT.

On main:

* https://jwst-pipeline.readthedocs.io/en/latest/jwst/combine_1d/index.html

With this patch:

* https://jwst-pipeline--10282.org.readthedocs.build/en/10282/jwst/combine_1d/index.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)