### PR TITLE
JP-4035: Fix a couple bugs in ATM routine

### DIFF
--- a/changes/10299.adaptive_trace_model.rst
+++ b/changes/10299.adaptive_trace_model.rst
@@ -1,0 +1,1 @@
+Fix a couple minor bugs in intermediate products, edge clipping, and spline knots for the adaptive_trace_model step.

--- a/jwst/adaptive_trace_model/tests/test_trace_model.py
+++ b/jwst/adaptive_trace_model/tests/test_trace_model.py
@@ -63,6 +63,7 @@ def test_fit_2d_spline_trace_fail(monkeypatch, caplog, fit_2d_spline_input):
 
 
 def test_fit_2d_spline_trace_none(monkeypatch, fit_2d_spline_input):
+    """Test that fit failure triggers a single retry with fewer knots"""
     # mock a quiet failure in the fit: always return None
     class MockFit(object):
         def __init__(self):

--- a/jwst/adaptive_trace_model/tests/test_trace_model.py
+++ b/jwst/adaptive_trace_model/tests/test_trace_model.py
@@ -25,19 +25,17 @@ def fit_2d_spline_input(nrs_slit_model):
 
 def test_fit_2d_spline_trace(fit_2d_spline_input):
     slit, flux, alpha = fit_2d_spline_input
-    splines, scales = tm.fit_2d_spline_trace(flux, alpha)
+    splines = tm.fit_2d_spline_trace(flux, alpha)
 
     assert len(splines) == flux.shape[1]
-    assert len(scales) == flux.shape[1]
+    scales = [s["scale"] for s in splines.values()]
 
     # for unscaled fits, output scales should be close to 1
-    np.testing.assert_allclose(list(scales.values()), 1.0, atol=0.06)
+    np.testing.assert_allclose(list(scales), 1.0, atol=0.06)
 
     # evaluated fits should be close to input data
     region_map = (~np.isnan(slit.wavelength)).astype(int)
-    trace_used, full_trace = tm._trace_image(
-        flux.shape, {1: splines}, {1: scales}, region_map, alpha
-    )
+    trace_used, full_trace = tm._trace_image(flux.shape, {1: splines}, region_map, alpha)
 
     # Fit values should be close to flux
     atol = 0.25 * np.nanmax(flux)
@@ -59,10 +57,31 @@ def test_fit_2d_spline_trace_fail(monkeypatch, caplog, fit_2d_spline_input):
     monkeypatch.setattr(tm, "bspline_fit", mock_fit)
 
     slit, flux, alpha = fit_2d_spline_input
-    splines, scales = tm.fit_2d_spline_trace(flux, alpha)
+    splines = tm.fit_2d_spline_trace(flux, alpha)
     assert len(splines) == 0
-    assert len(scales) == 0
     assert "Spline fit failed" in caplog.text
+
+
+def test_fit_2d_spline_trace_none(monkeypatch, fit_2d_spline_input):
+    # mock a quiet failure in the fit: always return None
+    class MockFit(object):
+        def __init__(self):
+            self.call_count = 0
+
+        def __call__(self, *args, **kwargs):
+            # Track how many times this mock was called
+            self.call_count += 1
+            return None
+
+    mock_fit = MockFit()
+    monkeypatch.setattr(tm, "bspline_fit", mock_fit)
+
+    slit, flux, alpha = fit_2d_spline_input
+    splines = tm.fit_2d_spline_trace(flux, alpha)
+    assert len(splines) == 0
+
+    # The fit is re-attempted once at every column
+    assert mock_fit.call_count == 2 * flux.shape[1]
 
 
 @pytest.mark.parametrize(
@@ -74,7 +93,7 @@ def test_fit_2d_spline_trace_fail(monkeypatch, caplog, fit_2d_spline_input):
                 "lrange": 50,
                 "col_index": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
                 "require_ngood": 15,
-                "spline_bkpt": 62,
+                "spline_bkpt": 68,
                 "space_ratio": 1.6,
             },
         ),
@@ -84,7 +103,7 @@ def test_fit_2d_spline_trace_fail(monkeypatch, caplog, fit_2d_spline_input):
                 "lrange": 50,
                 "col_index": [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
                 "require_ngood": 15,
-                "spline_bkpt": 62,
+                "spline_bkpt": 68,
                 "space_ratio": 1.6,
             },
         ),

--- a/jwst/adaptive_trace_model/tests/test_trace_model.py
+++ b/jwst/adaptive_trace_model/tests/test_trace_model.py
@@ -64,6 +64,7 @@ def test_fit_2d_spline_trace_fail(monkeypatch, caplog, fit_2d_spline_input):
 
 def test_fit_2d_spline_trace_none(monkeypatch, fit_2d_spline_input):
     """Test that fit failure triggers a single retry with fewer knots"""
+
     # mock a quiet failure in the fit: always return None
     class MockFit(object):
         def __init__(self):

--- a/jwst/adaptive_trace_model/trace_model.py
+++ b/jwst/adaptive_trace_model/trace_model.py
@@ -120,9 +120,21 @@ def fit_2d_spline_trace(
         Keys are column index numbers, values are floating point scales, to pair with
         the returned models. If a spline model could not be fit, the column index
         number is not present.
+    bounds_lo : dict
+        Keys are column index numbers, values are floating point giving the lower bound
+        for which the spline model is valid, to pair with the returned models. If a
+        spline model could not be fit, the column index number is not present.
+    bounds_hi : dict
+        Keys are column index numbers, values are floating point giving the upper bound
+        for which the spline model is valid, to pair with the returned models. If a
+        spline model could not be fit, the column index number is not present.
+
     """
     # Define a fallback spline model, initialize to None
     spline_model_save = None
+    # Similarly define the bounds of the fallback model
+    spline_lobound_save = None
+    spline_hibound_save = None
 
     # Set up the column fitting order if not provided
     xsize = flux.shape[-1]
@@ -138,6 +150,8 @@ def fit_2d_spline_trace(
     # Loop over columns in the slit/slice
     splines = {}
     scales = {}
+    bounds_lo = {}
+    bounds_hi = {}
     for i in col_index:
         col_flux = flux[:, i]
         col_alpha = alpha[:, i]
@@ -179,6 +193,8 @@ def fit_2d_spline_trace(
             # to resolve occasional numerical issues.
             if ((bspline is None) & (spline_model_save is not None)):
                 spline_model = spline_model_save
+                spline_lobound = spline_lobound_save
+                spline_hibound = spline_hibound_save
             elif ((bspline is None) & (spline_model_save is None)):
                 spline_model = bspline_fit(
                     local_alpha,
@@ -190,12 +206,18 @@ def fit_2d_spline_trace(
                     space_ratio=space_ratio,
                     verbose=False,
                 )
+                spline_lobound = np.nanmin(local_alpha)
+                spline_hibound = np.nanmax(local_alpha)
             else:
                 spline_model = bspline
+                spline_lobound = np.nanmin(local_alpha)
+                spline_hibound = np.nanmax(local_alpha)
 
         except (ValueError, RuntimeError) as err:
             log.warning(f"Spline fit failed at column {i}: {str(err)}")
             spline_model = spline_model_save
+            spline_lobound = spline_lobound_save
+            spline_hibound = spline_hibound_save
 
         # Check for a good model
         if spline_model is None:
@@ -204,6 +226,12 @@ def fit_2d_spline_trace(
         # Store the spline model for the column
         splines[i] = spline_model
         spline_model_save = spline_model
+        spline_lobound_save = spline_lobound
+        spline_hibound_save = spline_hibound
+
+        # Store the spline bounds
+        bounds_lo[i] = spline_lobound
+        bounds_hi[i] = spline_hibound
 
         # Evaluate the bspline at the valid input locations to determine
         # a scale factor for the fit
@@ -226,7 +254,7 @@ def fit_2d_spline_trace(
         # Store the scale factor for the column
         scales[i] = wmeanratio
 
-    return splines, scales
+    return splines, scales, bounds_lo, bounds_hi
 
 
 def _reindex(xmin, xmax, scale=2.0):
@@ -325,7 +353,8 @@ def _is_compact_source(
     return is_compact
 
 
-def _trace_image(shape, spline_models, spline_scales, region_map, alpha, slope_limit=0.1, pad=3):
+def _trace_image(shape, spline_models, spline_scales, spline_lobounds,
+                 spline_hibounds, region_map, alpha, slope_limit=0.1, pad=3):
     """
     Evaluate spline models at all pixels to generate a trace image.
 
@@ -342,6 +371,10 @@ def _trace_image(shape, spline_models, spline_scales, region_map, alpha, slope_l
         Spline models to evaluate.
     spline_scales : dict
         Scaling factors for spline models.
+    spline_lobounds : dict
+        Lower bounds for spline models
+    spline_hibounds : dict
+        Upper bounds for spline models
     region_map : ndarray
         2D image matching shape, mapping valid region numbers.
     alpha : ndarray
@@ -374,6 +407,9 @@ def _trace_image(shape, spline_models, spline_scales, region_map, alpha, slope_l
     for slnum in spline_models:
         splines = spline_models[slnum]
         scales = spline_scales[slnum]
+        lobound = spline_lobounds[slnum]
+        hibound = spline_hibounds[slnum]
+
         alpha_slice[:] = np.nan
         trace_slice[:] = np.nan
 
@@ -391,7 +427,7 @@ def _trace_image(shape, spline_models, spline_scales, region_map, alpha, slope_l
 
             # Evaluate the spline model for relevant data
             col_alpha = alpha_slice[:, i]
-            valid_alpha = np.isfinite(col_alpha)
+            valid_alpha = (np.isfinite(col_alpha) & (col_alpha >= lobound[i]) & (col_alpha <= hibound[i]))
             col_fit = splines[i](col_alpha[valid_alpha])
 
             # Set the edges to NaN to avoid edge effects
@@ -574,10 +610,18 @@ def fit_all_regions(flux, alpha, region_map, signal_threshold, **fit_kwargs):
         Keys are region numbers, values are dicts containing a spline model for
         each column index in the region. If a spline model could not be fit, the
         column index number is not present.
-    scales : dict
+    spline_scales : dict
         Keys are region numbers, values are dicts containing a floating point scale
         for each spline model, by column index number. If a spline model could not
         be fit, the column index number is not present.
+    spline_lobounds : dict
+        Keys are region numbers, values are floating point for each spline model by
+        column index number giving the lower bound for which the spline model is valid.
+        If a spline model could not be fit, the column index number is not present.
+    spline_hibounds : dict
+        Keys are region numbers, values are floating point for each spline model by
+        column index number giving the upper bound for which the spline model is valid.
+        If a spline model could not be fit, the column index number is not present.
     """
     # Arrays to reset with NaNs for each slice
     data_slice = np.full_like(flux, np.nan)
@@ -585,7 +629,10 @@ def fit_all_regions(flux, alpha, region_map, signal_threshold, **fit_kwargs):
 
     spline_models = {}
     spline_scales = {}
+    spline_lobounds = {}
+    spline_hibounds = {}
     slice_numbers = np.unique(region_map[region_map > 0])
+
     for slnum in slice_numbers:
         log.info("Fitting slice %s", slnum)
 
@@ -615,16 +662,20 @@ def fit_all_regions(flux, alpha, region_map, signal_threshold, **fit_kwargs):
             dospline = True
 
         if dospline:
-            splines, scales = fit_2d_spline_trace(
+            splines, scales, bounds_lo, bounds_hi = fit_2d_spline_trace(
                 data_slice, alpha_slice, fit_scale=runsum, **fit_kwargs
             )
         else:
             splines = {}
             scales = {}
+            bounds_lo = {}
+            bounds_hi = {}
         spline_models[slnum] = splines
         spline_scales[slnum] = scales
+        spline_lobounds[slnum] = bounds_lo
+        spline_hibounds[slnum] = bounds_hi
 
-    return spline_models, spline_scales
+    return spline_models, spline_scales, spline_lobounds, spline_hibounds
 
 
 def oversample_flux(
@@ -633,6 +684,8 @@ def oversample_flux(
     region_map,
     spline_models,
     spline_scales,
+    spline_lobounds,
+    spline_hibounds,
     oversample_factor,
     alpha_os,
     require_ngood=10,
@@ -678,6 +731,14 @@ def oversample_flux(
         column index number is not present.
     spline_scales : dict
         Keys are region numbers, values are dicts containing a floating point scale
+        for each spline model, by column index number. If a spline model could not
+        be fit, the column index number is not present.
+    spline_lobounds : dict
+        Keys are region numbers, values are dicts containing a floating point lower bound
+        for each spline model, by column index number. If a spline model could not
+        be fit, the column index number is not present.
+    spline_hibounds : dict
+        Keys are region numbers, values are dicts containing a floating point upper bound
         for each spline model, by column index number. If a spline model could not
         be fit, the column index number is not present.
     oversample_factor : float
@@ -782,13 +843,15 @@ def oversample_flux(
                 continue
             spline_model = spline_models[slnum][ii]
             spline_scale = spline_scales[slnum][ii]
+            spline_lobound = spline_lobounds[slnum][ii]
+            spline_hibound = spline_hibounds[slnum][ii]
 
             # Get the number of spline breakpoints used from the first real model
             if spline_bkpt is None:
                 spline_bkpt = len(np.unique(spline_model.t)) - 1
 
             # Get valid input locations and evaluate the spline
-            valid_alpha = np.isfinite(col_alpha)
+            valid_alpha = (np.isfinite(col_alpha) & (col_alpha >= spline_lobound) & (col_alpha <= spline_hibound))
             col_fit = spline_model(col_alpha[valid_alpha])
             scaled_fit = col_fit * spline_scale
 
@@ -815,15 +878,16 @@ def oversample_flux(
             alpha_ptsource.append(col_alpha[valid_alpha][highslope])
 
             # Store the oversampled alpha values to check against later
-            alpha_os_slice[newy, ii] = alpha_os[newy, ii]
+            inbounds = np.where((alpha_os[newy, ii] >= spline_lobound) & (alpha_os[newy, ii] <= spline_hibound))
+            alpha_os_slice[newy[inbounds], ii] = alpha_os[newy[inbounds], ii]
 
             # Evaluate the bspline at the oversampled alpha for this column
-            oversampled_fit = spline_model(alpha_os[newy, ii]) * spline_scale
+            oversampled_fit = spline_model(alpha_os[newy[inbounds], ii]) * spline_scale
             if trim_ends and edge_limit >= 1:
                 oversampled_fit[0:edge_limit] = np.nan
                 oversampled_fit[-edge_limit:] = np.nan
 
-            flux_os_bspline_full[newy, ii] = oversampled_fit
+            flux_os_bspline_full[newy[inbounds], ii] = oversampled_fit
 
         # Now that our initial loop along the slice is done, we have a spline model everywhere
 
@@ -1350,7 +1414,7 @@ def fit_and_oversample(
 
     # Fit spline models to all regions
     fit_kwargs = _set_fit_kwargs(detector, xsize)
-    spline_models, spline_scales = fit_all_regions(
+    spline_models, spline_scales, spline_lobounds, spline_hibounds = fit_all_regions(
         flux_orig, alpha_orig, region_map, signal_threshold, **fit_kwargs
     )
 
@@ -1365,6 +1429,8 @@ def fit_and_oversample(
             flux_orig.shape,
             spline_models,
             spline_scales,
+            spline_lobounds,
+            spline_hibounds,
             region_map,
             alpha_orig,
             slope_limit=slope_limit,
@@ -1406,6 +1472,8 @@ def fit_and_oversample(
         region_map,
         spline_models,
         spline_scales,
+        spline_lobounds,
+        spline_hibounds,
         oversample_factor,
         alpha_os,
         slope_limit=slope_limit,

--- a/jwst/adaptive_trace_model/trace_model.py
+++ b/jwst/adaptive_trace_model/trace_model.py
@@ -114,23 +114,16 @@ def fit_2d_spline_trace(
     Returns
     -------
     splines : dict
-        Keys are column index numbers, values are `~scipy.interpolate.BSpline`.
-        If a spline model could not be fit, the column index number is not present.
-    scales : dict
-        Keys are column index numbers, values are floating point scales, to pair with
-        the returned models. If a spline model could not be fit, the column index
-        number is not present.
-    bounds_lo : dict
-        Keys are column index numbers, values are floating point giving the lower bound
-        for which the spline model is valid, to pair with the returned models. If a
-        spline model could not be fit, the column index number is not present.
-    bounds_hi : dict
-        Keys are column index numbers, values are floating point giving the upper bound
-        for which the spline model is valid, to pair with the returned models. If a
-        spline model could not be fit, the column index number is not present.
+        Keys are column index numbers, values are dicts.  Each dict contains a
+        normalized ``model`` with `~scipy.interpolate.BSpline` value, a ``scale``
+        with a float value to scale to the data, and ``bounds`` with a 2-tuple of
+        floating point values, corresponding to the lower and upper bounds of the
+        alpha coordinates used in the fit. If a spline model could not be fit,
+        the column index number is not present.
     """
     # Define a fallback spline model, initialize to None
     spline_model_save = None
+
     # Similarly define the bounds of the fallback model
     spline_lobound_save = None
     spline_hibound_save = None
@@ -148,9 +141,6 @@ def fit_2d_spline_trace(
 
     # Loop over columns in the slit/slice
     splines = {}
-    scales = {}
-    bounds_lo = {}
-    bounds_hi = {}
     for i in col_index:
         col_flux = flux[:, i]
         col_alpha = alpha[:, i]
@@ -187,15 +177,11 @@ def fit_2d_spline_trace(
                 verbose=False,
             )
 
-            # If this routine could not get a fit (returned None) use the saved fit if available
-            # If no saved fit is available try the fitting routine again with slightly fewer
+            # If the fit failed (returned None) and no saved fit is available,
+            # try the fitting routine again with slightly fewer
             # breakpoints to resolve occasional numerical issues.
-            if ((bspline is None) & (spline_model_save is not None)):
-                spline_model = spline_model_save
-                spline_lobound = spline_lobound_save
-                spline_hibound = spline_hibound_save
-            elif ((bspline is None) & (spline_model_save is None)):
-                spline_model = bspline_fit(
+            if bspline is None and spline_model_save is None and spline_bkpt > 3:
+                bspline = bspline_fit(
                     local_alpha,
                     local_data,
                     nbkpts=spline_bkpt - 3,
@@ -205,16 +191,20 @@ def fit_2d_spline_trace(
                     space_ratio=space_ratio,
                     verbose=False,
                 )
-                spline_lobound = np.nanmin(local_alpha)
-                spline_hibound = np.nanmax(local_alpha)
+
+            # If bspline is still None, use the saved fit if available
+            if bspline is None and spline_model_save is not None:
+                spline_model = spline_model_save
+                spline_lobound = spline_lobound_save
+                spline_hibound = spline_hibound_save
             else:
-                spline_model = bspline
+                spline_model = bspline  # may be valid fit or None
                 spline_lobound = np.nanmin(local_alpha)
                 spline_hibound = np.nanmax(local_alpha)
 
         except (ValueError, RuntimeError) as err:
             log.warning(f"Spline fit failed at column {i}: {str(err)}")
-            spline_model = spline_model_save
+            spline_model = spline_model_save  # may be valid fit or None
             spline_lobound = spline_lobound_save
             spline_hibound = spline_hibound_save
 
@@ -222,15 +212,10 @@ def fit_2d_spline_trace(
         if spline_model is None:
             continue
 
-        # Store the spline model for the column
-        splines[i] = spline_model
+        # Store the spline model and bounds for the column
         spline_model_save = spline_model
         spline_lobound_save = spline_lobound
         spline_hibound_save = spline_hibound
-
-        # Store the spline bounds
-        bounds_lo[i] = spline_lobound
-        bounds_hi[i] = spline_hibound
 
         # Evaluate the bspline at the valid input locations to determine
         # a scale factor for the fit
@@ -250,10 +235,14 @@ def fit_2d_spline_trace(
             weights = _get_weights_for_fit_scale(ratio, col_fit)
             wmeanratio = np.nansum(ratio * weights)
 
-        # Store the scale factor for the column
-        scales[i] = wmeanratio
+        # Store the model, scale, and bounds to return
+        splines[i] = {
+            "model": spline_model,
+            "scale": wmeanratio,
+            "bounds": (spline_lobound, spline_hibound),
+        }
 
-    return splines, scales, bounds_lo, bounds_hi
+    return splines
 
 
 def _reindex(xmin, xmax, scale=2.0):
@@ -352,8 +341,7 @@ def _is_compact_source(
     return is_compact
 
 
-def _trace_image(shape, spline_models, spline_scales, spline_lobounds,
-                 spline_hibounds, region_map, alpha, slope_limit=0.1, pad=3):
+def _trace_image(shape, spline_models, region_map, alpha, slope_limit=0.1, pad=3):
     """
     Evaluate spline models at all pixels to generate a trace image.
 
@@ -368,12 +356,6 @@ def _trace_image(shape, spline_models, spline_scales, spline_lobounds,
         Data shape for the output image.
     spline_models : dict
         Spline models to evaluate.
-    spline_scales : dict
-        Scaling factors for spline models.
-    spline_lobounds : dict
-        Lower bounds for spline models
-    spline_hibounds : dict
-        Upper bounds for spline models
     region_map : ndarray
         2D image matching shape, mapping valid region numbers.
     alpha : ndarray
@@ -405,9 +387,6 @@ def _trace_image(shape, spline_models, spline_scales, spline_lobounds,
     spline_bkpt = None
     for slnum in spline_models:
         splines = spline_models[slnum]
-        scales = spline_scales[slnum]
-        lobound = spline_lobounds[slnum]
-        hibound = spline_hibounds[slnum]
 
         alpha_slice[:] = np.nan
         trace_slice[:] = np.nan
@@ -423,18 +402,20 @@ def _trace_image(shape, spline_models, spline_scales, spline_lobounds,
         for i in range(shape[-1]):
             if i not in splines:
                 continue
+            spline = splines[i]["model"]
+            scale = splines[i]["scale"]
+            lobound, hibound = splines[i]["bounds"]
 
             # Evaluate the spline model for relevant data
             col_alpha = alpha_slice[:, i]
-            valid_alpha = (np.isfinite(col_alpha) & (col_alpha >= lobound[i])
-                           & (col_alpha <= hibound[i]))
-            col_fit = splines[i](col_alpha[valid_alpha])
+            valid_alpha = np.isfinite(col_alpha) & (col_alpha >= lobound) & (col_alpha <= hibound)
+            col_fit = spline(col_alpha[valid_alpha])
 
             # Set the edges to NaN to avoid edge effects
             col_fit[0] = np.nan
             col_fit[-1] = np.nan
 
-            scaled_fit = scales[i] * col_fit
+            scaled_fit = scale * col_fit
             trace_slice[:, i][valid_alpha] = scaled_fit
 
             # Get the slope of the model fit prior to scaling
@@ -449,7 +430,7 @@ def _trace_image(shape, spline_models, spline_scales, spline_lobounds,
 
             # Get the number of spline breakpoints used from the first real model
             if spline_bkpt is None:
-                spline_bkpt = len(np.unique(splines[i].t)) - 1
+                spline_bkpt = len(np.unique(spline.t)) - 1
 
         full_trace[indx] = trace_slice[indx]
         if slope_limit <= 0:
@@ -607,30 +588,15 @@ def fit_all_regions(flux, alpha, region_map, signal_threshold, **fit_kwargs):
     Returns
     -------
     spline_models : dict
-        Keys are region numbers, values are dicts containing a spline model for
-        each column index in the region. If a spline model could not be fit, the
-        column index number is not present.
-    spline_scales : dict
-        Keys are region numbers, values are dicts containing a floating point scale
-        for each spline model, by column index number. If a spline model could not
-        be fit, the column index number is not present.
-    spline_lobounds : dict
-        Keys are region numbers, values are floating point for each spline model by
-        column index number giving the lower bound for which the spline model is valid.
-        If a spline model could not be fit, the column index number is not present.
-    spline_hibounds : dict
-        Keys are region numbers, values are floating point for each spline model by
-        column index number giving the upper bound for which the spline model is valid.
-        If a spline model could not be fit, the column index number is not present.
+        Keys are region numbers, values are dicts containing a spline model,
+        scale, and bounds for each column index in the region. If a spline model
+        could not be fit, the column index number is not present.
     """
     # Arrays to reset with NaNs for each slice
     data_slice = np.full_like(flux, np.nan)
     alpha_slice = np.full_like(flux, np.nan)
 
     spline_models = {}
-    spline_scales = {}
-    spline_lobounds = {}
-    spline_hibounds = {}
     slice_numbers = np.unique(region_map[region_map > 0])
 
     for slnum in slice_numbers:
@@ -662,20 +628,12 @@ def fit_all_regions(flux, alpha, region_map, signal_threshold, **fit_kwargs):
             dospline = True
 
         if dospline:
-            splines, scales, bounds_lo, bounds_hi = fit_2d_spline_trace(
-                data_slice, alpha_slice, fit_scale=runsum, **fit_kwargs
-            )
+            splines = fit_2d_spline_trace(data_slice, alpha_slice, fit_scale=runsum, **fit_kwargs)
         else:
             splines = {}
-            scales = {}
-            bounds_lo = {}
-            bounds_hi = {}
         spline_models[slnum] = splines
-        spline_scales[slnum] = scales
-        spline_lobounds[slnum] = bounds_lo
-        spline_hibounds[slnum] = bounds_hi
 
-    return spline_models, spline_scales, spline_lobounds, spline_hibounds
+    return spline_models
 
 
 def oversample_flux(
@@ -683,9 +641,6 @@ def oversample_flux(
     alpha,
     region_map,
     spline_models,
-    spline_scales,
-    spline_lobounds,
-    spline_hibounds,
     oversample_factor,
     alpha_os,
     require_ngood=10,
@@ -726,21 +681,9 @@ def oversample_flux(
         Map containing the slice or slit number for valid regions.
         Values are >0 for pixels in valid regions, 0 otherwise.
     spline_models : dict
-        Keys are region numbers, values are dicts containing a spline model for
-        each column index in the region. If a spline model could not be fit, the
-        column index number is not present.
-    spline_scales : dict
-        Keys are region numbers, values are dicts containing a floating point scale
-        for each spline model, by column index number. If a spline model could not
-        be fit, the column index number is not present.
-    spline_lobounds : dict
-        Keys are region numbers, values are dicts containing a floating point lower bound
-        for each spline model, by column index number. If a spline model could not
-        be fit, the column index number is not present.
-    spline_hibounds : dict
-        Keys are region numbers, values are dicts containing a floating point upper bound
-        for each spline model, by column index number. If a spline model could not
-        be fit, the column index number is not present.
+        Keys are region numbers, values are dicts containing a spline model,
+        scale, and bounds for each column index in the region. If a spline model
+        could not be fit, the column index number is not present.
     oversample_factor : float
         Scaling factor to oversample by.
     alpha_os : ndarray
@@ -841,18 +784,21 @@ def oversample_flux(
             # Check for a spline fit for this column
             if slnum not in spline_models or ii not in spline_models[slnum]:
                 continue
-            spline_model = spline_models[slnum][ii]
-            spline_scale = spline_scales[slnum][ii]
-            spline_lobound = spline_lobounds[slnum][ii]
-            spline_hibound = spline_hibounds[slnum][ii]
+            spline_model = spline_models[slnum][ii]["model"]
+            spline_scale = spline_models[slnum][ii]["scale"]
+            spline_lobound = spline_models[slnum][ii]["bounds"][0]
+            spline_hibound = spline_models[slnum][ii]["bounds"][1]
 
             # Get the number of spline breakpoints used from the first real model
             if spline_bkpt is None:
                 spline_bkpt = len(np.unique(spline_model.t)) - 1
 
             # Get valid input locations and evaluate the spline
-            valid_alpha = (np.isfinite(col_alpha) & (col_alpha >= spline_lobound)
-                           & (col_alpha <= spline_hibound))
+            valid_alpha = (
+                np.isfinite(col_alpha)
+                & (col_alpha >= spline_lobound)
+                & (col_alpha <= spline_hibound)
+            )
             col_fit = spline_model(col_alpha[valid_alpha])
             scaled_fit = col_fit * spline_scale
 
@@ -879,8 +825,9 @@ def oversample_flux(
             alpha_ptsource.append(col_alpha[valid_alpha][highslope])
 
             # Store the oversampled alpha values to check against later
-            inbounds = np.where((alpha_os[newy, ii] >= spline_lobound)
-                                & (alpha_os[newy, ii] <= spline_hibound))
+            inbounds = np.where(
+                (alpha_os[newy, ii] >= spline_lobound) & (alpha_os[newy, ii] <= spline_hibound)
+            )
             alpha_os_slice[newy[inbounds], ii] = alpha_os[newy[inbounds], ii]
 
             # Evaluate the bspline at the oversampled alpha for this column
@@ -1416,7 +1363,7 @@ def fit_and_oversample(
 
     # Fit spline models to all regions
     fit_kwargs = _set_fit_kwargs(detector, xsize)
-    spline_models, spline_scales, spline_lobounds, spline_hibounds = fit_all_regions(
+    spline_models = fit_all_regions(
         flux_orig, alpha_orig, region_map, signal_threshold, **fit_kwargs
     )
 
@@ -1430,9 +1377,6 @@ def fit_and_oversample(
         trace_used, full_trace = _trace_image(
             flux_orig.shape,
             spline_models,
-            spline_scales,
-            spline_lobounds,
-            spline_hibounds,
             region_map,
             alpha_orig,
             slope_limit=slope_limit,
@@ -1473,9 +1417,6 @@ def fit_and_oversample(
         alpha_orig,
         region_map,
         spline_models,
-        spline_scales,
-        spline_lobounds,
-        spline_hibounds,
         oversample_factor,
         alpha_os,
         slope_limit=slope_limit,

--- a/jwst/adaptive_trace_model/trace_model.py
+++ b/jwst/adaptive_trace_model/trace_model.py
@@ -174,11 +174,25 @@ def fit_2d_spline_trace(
                 verbose=False,
             )
 
-            # If this routine could not get a fit (returned None) use the saved fit
-            if bspline is None:
+            # If this routine could not get a fit (returned None) use the saved fit if available
+            # If no saved fit is available try the fitting routine again with slightly fewer breakpoints
+            # to resolve occasional numerical issues.
+            if ((bspline is None) & (spline_model_save is not None)):
                 spline_model = spline_model_save
+            elif ((bspline is None) & (spline_model_save is None)):
+                spline_model = bspline_fit(
+                    local_alpha,
+                    local_data,
+                    nbkpts=spline_bkpt - 3,
+                    wrapsig_low=2.5,
+                    wrapsig_high=2.5,
+                    wrapiter=3,
+                    space_ratio=space_ratio,
+                    verbose=False,
+                )
             else:
                 spline_model = bspline
+
         except (ValueError, RuntimeError) as err:
             log.warning(f"Spline fit failed at column {i}: {str(err)}")
             spline_model = spline_model_save
@@ -834,7 +848,7 @@ def oversample_flux(
 
     # Insert the bspline interpolated values into the final combined oversampled array,
     # starting from the linearly interpolated array
-    flux_os = flux_os_linear
+    flux_os = flux_os_linear.copy()
     indx = np.where(np.isfinite(flux_os_bspline_use))
     flux_os[indx] = flux_os_bspline_use[indx]
 
@@ -879,7 +893,7 @@ def _set_fit_kwargs(detector, xsize):
     # Empirical parameters for this mode
     if detector.startswith("NRS"):
         require_ngood = 15
-        spline_bkpt = 62
+        spline_bkpt = 68
         lrange = 50
 
         # This factor of 1.6 was dialed based on inspection of the results

--- a/jwst/adaptive_trace_model/trace_model.py
+++ b/jwst/adaptive_trace_model/trace_model.py
@@ -128,7 +128,6 @@ def fit_2d_spline_trace(
         Keys are column index numbers, values are floating point giving the upper bound
         for which the spline model is valid, to pair with the returned models. If a
         spline model could not be fit, the column index number is not present.
-
     """
     # Define a fallback spline model, initialize to None
     spline_model_save = None

--- a/jwst/adaptive_trace_model/trace_model.py
+++ b/jwst/adaptive_trace_model/trace_model.py
@@ -189,8 +189,8 @@ def fit_2d_spline_trace(
             )
 
             # If this routine could not get a fit (returned None) use the saved fit if available
-            # If no saved fit is available try the fitting routine again with slightly fewer breakpoints
-            # to resolve occasional numerical issues.
+            # If no saved fit is available try the fitting routine again with slightly fewer
+            # breakpoints to resolve occasional numerical issues.
             if ((bspline is None) & (spline_model_save is not None)):
                 spline_model = spline_model_save
                 spline_lobound = spline_lobound_save
@@ -427,7 +427,8 @@ def _trace_image(shape, spline_models, spline_scales, spline_lobounds,
 
             # Evaluate the spline model for relevant data
             col_alpha = alpha_slice[:, i]
-            valid_alpha = (np.isfinite(col_alpha) & (col_alpha >= lobound[i]) & (col_alpha <= hibound[i]))
+            valid_alpha = (np.isfinite(col_alpha) & (col_alpha >= lobound[i])
+                           & (col_alpha <= hibound[i]))
             col_fit = splines[i](col_alpha[valid_alpha])
 
             # Set the edges to NaN to avoid edge effects
@@ -851,7 +852,8 @@ def oversample_flux(
                 spline_bkpt = len(np.unique(spline_model.t)) - 1
 
             # Get valid input locations and evaluate the spline
-            valid_alpha = (np.isfinite(col_alpha) & (col_alpha >= spline_lobound) & (col_alpha <= spline_hibound))
+            valid_alpha = (np.isfinite(col_alpha) & (col_alpha >= spline_lobound)
+                           & (col_alpha <= spline_hibound))
             col_fit = spline_model(col_alpha[valid_alpha])
             scaled_fit = col_fit * spline_scale
 
@@ -878,7 +880,8 @@ def oversample_flux(
             alpha_ptsource.append(col_alpha[valid_alpha][highslope])
 
             # Store the oversampled alpha values to check against later
-            inbounds = np.where((alpha_os[newy, ii] >= spline_lobound) & (alpha_os[newy, ii] <= spline_hibound))
+            inbounds = np.where((alpha_os[newy, ii] >= spline_lobound)
+                                & (alpha_os[newy, ii] <= spline_hibound))
             alpha_os_slice[newy[inbounds], ii] = alpha_os[newy[inbounds], ii]
 
             # Evaluate the bspline at the oversampled alpha for this column


### PR DESCRIPTION
This PR addresses a couple minor bugs in the adaptive_trace_model routine implemented by JP-4035 revealed through further testing.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [x] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
