### PR TITLE
Fix runtime bottleneck in wfss_contam create_pixel_list

### DIFF
--- a/changes/10301.wfss_contam.rst
+++ b/changes/10301.wfss_contam.rst
@@ -1,0 +1,1 @@
+Remove unnecessary loop during setup of disperse, improving runtime. For one NIRISS case tested, contam step runtime was cut by 35 percent

--- a/jwst/wfss_contam/observations.py
+++ b/jwst/wfss_contam/observations.py
@@ -187,7 +187,6 @@ class Observation:
 
     def _create_pixel_list(self):
         """Create flat lists of pixels to be dispersed, grouped per object ID."""
-        # Single pass: np.nonzero(self.seg) returns all non-zero (non-background) pixels
         self.ys, self.xs = np.nonzero(self.seg)
         self.source_ids_per_pixel = self.seg[self.ys, self.xs]
         self.fluxes = self.dimage[self.ys, self.xs]

--- a/jwst/wfss_contam/observations.py
+++ b/jwst/wfss_contam/observations.py
@@ -186,7 +186,7 @@ class Observation:
         self.simulated_image = np.zeros(self.dims, float)
 
     def _create_pixel_list(self):
-        """Create flat lists of pixels to be dispersed, grouped per object ID."""
+        """Create flat lists of pixels to be dispersed."""
         self.ys, self.xs = np.nonzero(self.seg)
         self.source_ids_per_pixel = self.seg[self.ys, self.xs]
         self.fluxes = self.dimage[self.ys, self.xs]

--- a/jwst/wfss_contam/observations.py
+++ b/jwst/wfss_contam/observations.py
@@ -187,20 +187,10 @@ class Observation:
 
     def _create_pixel_list(self):
         """Create flat lists of pixels to be dispersed, grouped per object ID."""
-        self.xs = []
-        self.ys = []
-        self.source_ids_per_pixel = []
-        self.fluxes = []
-        for source_id in self.source_ids:
-            ys, xs = np.nonzero(self.seg == source_id)
-            self.xs.extend(xs)
-            self.ys.extend(ys)
-            self.source_ids_per_pixel.extend([source_id] * len(xs))
-            self.fluxes.extend(self.dimage[ys, xs])
-        self.xs = np.array(self.xs)
-        self.ys = np.array(self.ys)
-        self.fluxes = np.array(self.fluxes)
-        self.source_ids_per_pixel = np.array(self.source_ids_per_pixel)
+        # Single pass: np.nonzero(self.seg) returns all non-zero (non-background) pixels
+        self.ys, self.xs = np.nonzero(self.seg)
+        self.source_ids_per_pixel = self.seg[self.ys, self.xs]
+        self.fluxes = self.dimage[self.ys, self.xs]
 
     def chunk_sources(
         self, order, wmin, wmax, sens_waves, sens_response, selected_ids=None, max_pixels=1e5

--- a/jwst/wfss_contam/tests/test_observations.py
+++ b/jwst/wfss_contam/tests/test_observations.py
@@ -114,4 +114,4 @@ def test_disperse_order(observation, segmentation_map):
     assert slit.data.shape == (slit.ysize, slit.xsize)
 
     # check for regression by hard-coding one value of slit.data
-    assert np.isclose(slit.data[5, 60], 0.09994397)
+    assert np.isclose(slit.data[5, 60], 0.09994397, atol=1e-5)


### PR DESCRIPTION
see [JP-4261](https://jira.stsci.edu/browse/JP-4261)

<!-- describe the changes comprising this PR here -->
This PR removes an unnecessary and slow loop in the setup of `wfss_contam` that was noticed during testing of https://github.com/spacetelescope/jwst/pull/9956

The new version no longer sorts by `source_id`, but this sorting was not necessary as it already takes place later, within `chunk_sources`.

For one NIRISS case tested on a single core, the runtime of `Observation.__init__` decreased from 87 seconds to 1 second, improving overall runtime of `WfssContamStep` from 248s to 162s.

For one NIRCam case tested on a single core, the runtime of `Observation.__init__` decreased from 23 seconds to 1 second, and overall runtime improved from 437s to 390s.

Fractional runtime improvement depends a lot on how many sources are in the field, how many sources have been requested via the magnitude limit, and how many cores are used for multiprocessing.
This bottleneck occurs _before_ splitting sources up for multiprocessing, so it's relatively more impactful with multiprocessing turned on.

Not sure how to capture this appropriately in the changelog.

https://github.com/spacetelescope/RegressionTests/actions/runs/22728565446/attempts/1
Regression tests are failing in a similar way and for a similar reason to the differences shown in [JP-4169](https://jira.stsci.edu/browse/JP-4169) - the reference pixel from which the native wavelength array was derived has changed.

The plot below shows the `_simul` files for the failing regression test on the main branch and on the PR branch.  We can see that the fractional differences are only large where the absolute flux values are very small.

<img width="2250" height="750" alt="diff" src="https://github.com/user-attachments/assets/652cab5a-b880-4bea-81ab-b8b1353f8e14" />


<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
