### PR TITLE
Pathloss bug fix

### DIFF
--- a/changes/10305.pathloss.rst
+++ b/changes/10305.pathloss.rst
@@ -1,0 +1,1 @@
+Fixed bug in application of pixel scale to user-provided cross-slit source position

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -1248,7 +1248,7 @@ def _corrections_for_lrs(data, pathloss, user_slit_loc):
             data.meta.wcs, location, disp_axis=data.meta.wcsinfo.dispersion_direction
         )
         scale_arcsec = scale_degrees * 3600.0
-        user_slit_loc_pix = user_slit_loc * scale_arcsec
+        user_slit_loc_pix = user_slit_loc / scale_arcsec
         yusr_recenter = ycenter + user_slit_loc_pix
         _, pathloss_vector, is_inside_slit = calculate_pathloss_vector(
             pathloss_data, pathloss_wcs, xcenter, yusr_recenter, calc_wave=False


### PR DESCRIPTION
Corrected incorrect arcsec to pixel coordinate conversion operation.

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR fixes a bug in the pathloss correction for MIRI LRS slit. Specifically, the conversion from arcsec to pixel coordinates was incorrect for user-supplied slit target positions.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
