### PR TITLE
Clean up a file that was created by a test

### DIFF
--- a/jwst/ramp_fitting/tests/test_ramp_fit_step.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit_step.py
@@ -390,6 +390,7 @@ def test_likely_output(tmp_path, setup_inputs):
         override_gain=gain,
         override_readnoise=rnModel,
         save_opt=True,
+        output_dir=str(tmp_path),
     )
 
     # Check the output slopes
@@ -399,7 +400,7 @@ def test_likely_output(tmp_path, setup_inputs):
 
     # Check the chisq output array
     chk_chisq = np.array([[0.43144223, 0.25806388]])
-    fname = "mock_likely_chisq.fits"
+    fname = tmp_path / "mock_likely_chisq.fits"
     with ImageModel(fname) as chisq:
         chisq_data = chisq.data
     np.testing.assert_allclose(chisq_data, chk_chisq, rtol=tol)


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
The test `jwst/ramp_fitting/tests/test_ramp_fit_step.py::test_likely_output` leaves behind a file that is not cleaned up when it is run. This PR redirects that file into the `tmp_path` fixture to avoid this.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
