### PR TITLE
JP-4281: Add 360 wrap for sky_orientation angle

### DIFF
--- a/changes/10380.source_catalog.rst
+++ b/changes/10380.source_catalog.rst
@@ -1,0 +1,1 @@
+Wrap ``sky_orientation`` angles into the range 0-360 degrees.

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -381,7 +381,7 @@ class JWSTSourceCatalog:
         )
         _, _, angle = pixel_scale_angle_at_skycoord(skycoord, self.wcs)
 
-        return (180.0 * u.deg) - angle + self.orientation
+        return ((180.0 * u.deg) - angle + self.orientation) % (360 * u.deg)
 
     def _make_aperture_colnames(self, name):
         """

--- a/jwst/source_catalog/tests/test_source_catalog.py
+++ b/jwst/source_catalog/tests/test_source_catalog.py
@@ -49,25 +49,25 @@ def test_source_catalog(nircam_model, npixels, nsources):
 
     if npixels == 5 and nsources == 2:
         # test values of some specific computed quantities
-        assert np.isclose(cat["xcentroid"][1], 19.453064764431833)
-        assert np.isclose(cat["ycentroid"][1], 41.963065678485115)
-        assert np.isclose(cat["aper_bkg_flux"][1].value, 5.62e-8)
-        assert np.isclose(cat["aper_bkg_flux_err"][1].value, 8.52237054e-09)
-        assert np.isclose(cat["CI_50_30"][1], 1.9655824649976499)
-        assert np.isclose(cat["sharpness"][1], 0.9102634628764403)
-        assert np.isclose(cat["roundness"][1], 1.5954264)
-        assert np.isclose(cat["nn_dist"][1].value, 53.07168773319497)
-        assert np.isclose(cat["isophotal_flux"][1].value, 7.940753383195442e-05)
+        assert np.isclose(cat["xcentroid"][1], 19.453, atol=0.001)
+        assert np.isclose(cat["ycentroid"][1], 41.963, atol=0.001)
+        assert np.isclose(cat["aper_bkg_flux"][1].value, 5.62e-8, rtol=0.1)
+        assert np.isclose(cat["aper_bkg_flux_err"][1].value, 8.52e-09, rtol=0.1)
+        assert np.isclose(cat["CI_50_30"][1], 1.965, atol=0.001)
+        assert np.isclose(cat["sharpness"][1], 0.910, atol=0.001)
+        assert np.isclose(cat["roundness"][1], 1.595, atol=0.001)
+        assert np.isclose(cat["nn_dist"][1].value, 53.072, atol=0.001)
+        assert np.isclose(cat["isophotal_flux"][1].value, 7.94e-05, rtol=0.1)
         assert cat["isophotal_flux_err"][1].unit == "Jy"
-        assert np.isclose(cat["isophotal_flux_err"][1].value, 3.6102634e-07)
-        assert np.isclose(cat["isophotal_abmag"][1], 19.150345729246215)
-        assert np.isclose(cat["semimajor_sigma"][1].value, 18.84372169911978)
-        assert np.isclose(cat["semiminor_sigma"][1].value, 7.024931388267103)
-        assert np.isclose(cat["ellipticity"][1].value, 0.62720043)
-        assert np.isclose(cat["orientation"][1].value, -72.78329207140818) or np.isclose(
-            cat["orientation"][1].value, 287.2167079285918
+        assert np.isclose(cat["isophotal_flux_err"][1].value, 3.61e-07, rtol=0.1)
+        assert np.isclose(cat["isophotal_abmag"][1], 19.150, atol=0.001)
+        assert np.isclose(cat["semimajor_sigma"][1].value, 18.844, atol=0.001)
+        assert np.isclose(cat["semiminor_sigma"][1].value, 7.025, atol=0.001)
+        assert np.isclose(cat["ellipticity"][1].value, 0.627, atol=0.001)
+        assert np.isclose(cat["orientation"][1].value, -72.783, atol=0.001) or np.isclose(
+            cat["orientation"][1].value, 287.217, atol=0.001
         )
-        assert np.isclose(cat["sky_orientation"][1].value, 77.21670804980704)
+        assert np.isclose(cat["sky_orientation"][1].value, 77.217, atol=0.001)
 
 
 def test_source_catalog_no_sources(nircam_model, monkeypatch):

--- a/jwst/source_catalog/tests/test_source_catalog.py
+++ b/jwst/source_catalog/tests/test_source_catalog.py
@@ -67,6 +67,7 @@ def test_source_catalog(nircam_model, npixels, nsources):
         assert np.isclose(cat["orientation"][1].value, -72.78329207140818) or np.isclose(
             cat["orientation"][1].value, 287.2167079285918
         )
+        assert np.isclose(cat["sky_orientation"][1].value, 77.21670804980704)
 
 
 def test_source_catalog_no_sources(nircam_model, monkeypatch):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-4281](https://jira.stsci.edu/browse/JP-4281)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Add a 360 degree wrap for `sky_orientation`.  This quantity is derived from `orientation`, which will wrap to 0-360 degrees in an upcoming photutils version (see https://github.com/astropy/photutils/pull/2224).

~I think this doesn't need a change log since it shouldn't cause any differences until the orientation angle is wrapped, but let me know if you think I should add one.~
Added a change log since negative angles are now wrapped for sky_orientation values.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
