### PR TITLE
JP-4296: Fix test for opened selfcal models

### DIFF
--- a/jwst/badpix_selfcal/badpix_selfcal_step.py
+++ b/jwst/badpix_selfcal/badpix_selfcal_step.py
@@ -114,7 +114,7 @@ class BadpixSelfcalStep(Step):
         In that case, the input exposure will be used as the sole background exposure,
         i.e., true self-calibration.
         """
-        input_sci, selfcal_models, bkg_models = self._parse_inputs(
+        input_sci, selfcal_models, bkg_models, selfcal_opened = self._parse_inputs(
             input_data, selfcal_list, bkg_list
         )
 
@@ -193,10 +193,9 @@ class BadpixSelfcalStep(Step):
 
         input_sci.meta.cal_step.badpix_selfcal = "COMPLETE"
 
-        # Since selfcal_models are not returned, close them here
-        for model in selfcal_models:
-            if model not in bkg_models:
-                model.close()
+        # Since selfcal_models are not returned, close them
+        for model in selfcal_opened:
+            model.close()
 
         return input_sci, bkg_models
 
@@ -229,6 +228,9 @@ class BadpixSelfcalStep(Step):
             Image datamodels to use for self-calibration.
         bkg_list : list
             Image datamodels to use as background exposures.
+        selfcal_opened : list
+            A reference to selfcal models opened here, so that they can be closed
+            later.
         """
         # Open the input, making a copy if needed
         output_model = self.prepare_output(input_data)
@@ -243,10 +245,10 @@ class BadpixSelfcalStep(Step):
         # copy if needed. They will be closed at the end of the step.
         if selfcal_list is None:
             selfcal_list = []
-        selfcal_list = [dm.open(selfcal) for selfcal in selfcal_list]
+        selfcal_opened = [dm.open(selfcal) for selfcal in selfcal_list]
 
         # Add any background models to the selfcal list
-        selfcal_list = selfcal_list + bkg_list
+        selfcal_list = selfcal_opened + bkg_list
 
         # find science and background exposures in association file
         if isinstance(output_model, dm.ModelContainer):
@@ -256,6 +258,7 @@ class BadpixSelfcalStep(Step):
 
             selfcal_list = selfcal_list + list(bkg_list_asn) + list(selfcal_list_asn)
             bkg_list += list(bkg_list_asn)
+            selfcal_opened += list(selfcal_list_asn)
 
             if len(sci_models) > 1:
                 raise ValueError(
@@ -272,7 +275,7 @@ class BadpixSelfcalStep(Step):
                 "Input data is not a ModelContainer, ImageModel, or IFUImageModel. Cannot continue."
             )
 
-        return output_sci, selfcal_list, bkg_list
+        return output_sci, selfcal_list, bkg_list, selfcal_opened
 
 
 def split_container_by_asn_exptype(container: dm.ModelContainer, exptypes: list) -> list:

--- a/jwst/badpix_selfcal/tests/test_badpix_selfcal.py
+++ b/jwst/badpix_selfcal/tests/test_badpix_selfcal.py
@@ -186,13 +186,14 @@ def test_input_parsing(asn, sci, background):
     step = BadpixSelfcalStep()
 
     # basic association case. Both background and selfcal get into the list
-    input_sci, selfcal_list, bkg_list = step._parse_inputs(asn, [], [])
+    input_sci, selfcal_list, bkg_list, selfcal_opened = step._parse_inputs(asn, [], [])
     assert isinstance(input_sci, dm.IFUImageModel)
     assert len(bkg_list) == 2
     assert len(selfcal_list) == 4
+    assert len(selfcal_opened) == 2
 
     # association with background_list provided
-    input_sci, selfcal_list, bkg_list = step._parse_inputs(
+    input_sci, selfcal_list, bkg_list, selfcal_opened = step._parse_inputs(
         asn,
         [],
         [
@@ -203,9 +204,10 @@ def test_input_parsing(asn, sci, background):
     assert isinstance(input_sci, dm.IFUImageModel)
     assert len(bkg_list) == 5
     assert len(selfcal_list) == 7
+    assert len(selfcal_opened) == 2
 
     # association with selfcal_list provided
-    input_sci, selfcal_list, bkg_list = step._parse_inputs(
+    input_sci, selfcal_list, bkg_list, selfcal_opened = step._parse_inputs(
         asn,
         [
             background,
@@ -216,15 +218,17 @@ def test_input_parsing(asn, sci, background):
     assert isinstance(input_sci, dm.IFUImageModel)
     assert len(bkg_list) == 2
     assert len(selfcal_list) == 7
+    assert len(selfcal_opened) == 5
 
     # single science exposure
-    input_sci, selfcal_list, bkg_list = step._parse_inputs(sci, [], [])
+    input_sci, selfcal_list, bkg_list, selfcal_opened = step._parse_inputs(sci, [], [])
     assert isinstance(input_sci, dm.IFUImageModel)
     assert len(bkg_list) == 0
     assert len(selfcal_list) == 0
+    assert len(selfcal_opened) == 0
 
     # single science exposure with selfcal_list and bkg_list provided
-    input_sci, selfcal_list, bkg_list = step._parse_inputs(
+    input_sci, selfcal_list, bkg_list, selfcal_opened = step._parse_inputs(
         sci,
         [
             background,
@@ -238,6 +242,7 @@ def test_input_parsing(asn, sci, background):
     assert isinstance(input_sci, dm.IFUImageModel)
     assert len(bkg_list) == 1
     assert len(selfcal_list) == 4
+    assert len(selfcal_opened) == 3
 
 
 def test_bad_input():


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4296](https://jira.stsci.edu/browse/JP-4296)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Fix a test for opened selfcal models, introduced in #10155 

This line: `if model not in bkg_models:` was crashing if the selfcal model *was* in the `bkg_models` list because the `in` check did a model equality comparison.  

The stdatamodels equality check appears to be buggy: it tries to compare array quantities with an `==` check.  The error raised is:
```
  File "jwst/badpix_selfcal/badpix_selfcal_step.py", line 203, in process
    if (model not in bkg_models
        ^^^^^^^^^^^^^^^^^^^^^^^
  File "stdatamodels/properties.py", line 372, in __eq__
    return self._instance == other._instance
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen _collections_abc>", line 834, in __eq__
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

Fix is to directly track opened selfcal models for closing later.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
