### PR TITLE
JP-4298: Handle string 'None' values in user_mask

### DIFF
--- a/changes/10389.clean_flicker_noise.rst
+++ b/changes/10389.clean_flicker_noise.rst
@@ -1,0 +1,1 @@
+Interpret string values of "none" or "None" as Python None, for the user_mask parameter.

--- a/jwst/clean_flicker_noise/clean_flicker_noise.py
+++ b/jwst/clean_flicker_noise/clean_flicker_noise.py
@@ -825,7 +825,7 @@ def _check_input(exp_type, fit_method):
 
 
 def _standardize_parameters(
-    exp_type, subarray, slowaxis, background_method, fit_by_channel, single_mask
+    user_mask, exp_type, subarray, slowaxis, background_method, fit_by_channel, single_mask
 ):
     """
     Standardize input parameters.
@@ -835,6 +835,8 @@ def _standardize_parameters(
 
     Parameters
     ----------
+    user_mask : str or None
+        Input user mask filename.
     exp_type : str
         Exposure type for the input data.
     subarray : str
@@ -864,6 +866,10 @@ def _standardize_parameters(
         Frequency cutoff values for use with FFT correction,
         by input subarray.
     """
+    # Standardize user mask input
+    if str(user_mask).lower() == "none":
+        user_mask = None
+
     # Get axis to correct, by instrument
     if exp_type.startswith("MIR"):
         # MIRI doesn't have 1/f-noise, but it does have a vertical flickering.
@@ -896,7 +902,7 @@ def _standardize_parameters(
     else:
         fc = (1061, 1211, 49943, 49957)
 
-    return axis_to_correct, background_method, fit_by_channel, single_mask, fc
+    return user_mask, axis_to_correct, background_method, fit_by_channel, single_mask, fc
 
 
 def _make_processed_rate_image(
@@ -1359,8 +1365,10 @@ def do_correction(
 
     # Get parameters needed for subsequent corrections, as appropriate
     # to the input data
-    axis_to_correct, background_method, fit_by_channel, single_mask, fc = _standardize_parameters(
-        exp_type, subarray, slowaxis, background_method, fit_by_channel, single_mask
+    (user_mask, axis_to_correct, background_method, fit_by_channel, single_mask, fc) = (
+        _standardize_parameters(
+            user_mask, exp_type, subarray, slowaxis, background_method, fit_by_channel, single_mask
+        )
     )
 
     # Read the flat and pastasoss files, if provided

--- a/jwst/clean_flicker_noise/tests/test_clean_flicker_noise.py
+++ b/jwst/clean_flicker_noise/tests/test_clean_flicker_noise.py
@@ -575,6 +575,22 @@ def test_do_correction_user_mask_mismatch_integ(tmp_path, log_watcher):
     cleaned.close()
 
 
+@pytest.mark.parametrize("none_value", [None, "none", "None"])
+def test_do_correction_user_mask_none(none_value):
+    ramp_model = helpers.make_small_ramp_model()
+
+    # User mask is ignored, even if it is a string: no error is raised
+    cleaned, _, _, _, status = cfn.do_correction(ramp_model, user_mask=none_value)
+
+    # uniform data, correction has no effect
+    assert cleaned.data.shape == ramp_model.shape
+    assert np.allclose(cleaned.data, ramp_model.data)
+    assert status == "COMPLETE"
+
+    ramp_model.close()
+    cleaned.close()
+
+
 @pytest.mark.parametrize("subarray", ["SUBS200A1", "ALLSLITS"])
 def test_do_correction_fft_subarray(subarray):
     ramp_model = helpers.make_small_ramp_model()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4298](https://jira.stsci.edu/browse/JP-4298)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Interpret string values of "none" or "None" as Python None, for the `user_mask` parameter for `clean_flicker_noise`.  This is necessary to handle current NIRISS parameter override files on CRDS that contain "user_mask: None".

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
