### PR TITLE
DOC: Complete API for exp_to_source

### DIFF
--- a/docs/jwst/exp_to_source/api_ref.rst
+++ b/docs/jwst/exp_to_source/api_ref.rst
@@ -1,0 +1,14 @@
+===
+API
+===
+
+Public API
+==========
+
+.. automodapi:: jwst.exp_to_source.exp_to_source
+   :no-inheritance-diagram:
+
+Complete Developer API
+======================
+
+N/A

--- a/docs/jwst/exp_to_source/index.rst
+++ b/docs/jwst/exp_to_source/index.rst
@@ -8,5 +8,4 @@ Exposure to Source Conversion
    :maxdepth: 2
 
    main.rst
-
-.. automodapi:: jwst.exp_to_source
+   api_ref.rst

--- a/docs/jwst/exp_to_source/main.rst
+++ b/docs/jwst/exp_to_source/main.rst
@@ -1,12 +1,15 @@
 Description
-============
+===========
 
 ``exp_to_source`` is a data reorganization tool that is used to convert
 Stage 2 exposure-based data products to Stage 3 source-based data products.
 It is only used when there is a known source list for the exposure data,
 which is required in order to reorganize the data by source. Hence it is
-only usable for NIRSpec MOS, NIRSpec fixed-slit, NIRCam WFSS, MIRI WFSS,
-and NIRISS WFSS data. Details on the operation for each mode are given below.
+only usable for:
+
+* :ref:`expsource_nirspec_mos`
+* :ref:`expsource_nirspec_fs`
+* :ref:`expsource_wfss`
 
 The tool is run near the beginning of the :ref:`calwebb_spec3 <calwebb_spec3>`
 pipeline, immediately after the :ref:`master background <master_background_step>`
@@ -23,12 +26,14 @@ for 5 defined sources, then the output consists of a set of 5
 source-based "cal" products (one per source), each of which contains the
 data from the 3 exposures for each source. This is done as a convenience,
 in order to have all the data for a given source contained in a single
-product. All data arrays associated with a given source, e.g. SCI, ERR, DQ,
+product. All data arrays associated with a given source, e.g., SCI, ERR, DQ,
 WAVELENGTH, VAR_POISSON, etc., are copied from each input product into
 the corresponding output product.
 
+.. _expsource_nirspec_mos:
+
 NIRSpec MOS
-^^^^^^^^^^^
+-----------
 NIRSpec MOS observations are created at the APT level by defining a
 configuration of MSA slitlets with a source assigned to each slitlet.
 The source-to-slitlet linkage is carried along in the information contained
@@ -43,13 +48,15 @@ If fixed slit targets are planned as part of a NIRSpec MOS exposure, they
 will also have sources identified by the MSA metadata file.  The associated
 SRCNAME values are used to sort the data from these slits in the same way the
 MSA slitlets are sorted.  In this combined mode, the products containing
-MOS slitlets are marked with EXP_TYPE = "NRS_MSASPEC" after sorting; the models
-containing fixed slits are marked with EXP_TYPE = "NRS_FIXEDSLIT".
+MOS slitlets are marked with ``EXP_TYPE = "NRS_MSASPEC"`` after sorting; the models
+containing fixed slits are marked with ``EXP_TYPE = "NRS_FIXEDSLIT"``.
+
+.. _expsource_nirspec_fs:
 
 NIRSpec Fixed Slit
-^^^^^^^^^^^^^^^^^^
+------------------
 NIRSpec fixed slit observations do not have sources identified with each
-slit, so the slit names, e.g. S200A1, S1600A1, etc., are mapped to predefined
+slit, so the slit names, e.g., S200A1, S1600A1, etc., are mapped to predefined
 source ID values, as follows:
 
 =========  =========
@@ -65,24 +72,26 @@ S200B1         5
 The assigned source ID values are used by ``exp_to_source`` to sort the data
 from each slit into the appropriate source-based output product.
 
+.. _expsource_wfss:
+
 NIRCam, MIRI, and NIRISS WFSS
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------
 Wide-Field Slitless Spectroscopy (WFSS) modes do not have a predefined
 source list, but a source list is created by the
 :ref:`calwebb_image3 <calwebb_image3>` pipeline when it processes the
 direct image exposures that are included in a WFSS observation. That
 source catalog is then used during :ref:`calwebb_spec2 <calwebb_spec2>`
 processing of the grism exposures to define and create cutouts for each
-identified source. Like NIRSpec MOS mode, each "slit" instance is identified
+identified source. Like :ref:`expsource_nirspec_mos`, each "slit" instance is identified
 by the source ID number from the catalog and is used by the ``exp_to_source``
 tool to reorganize exposures into source-based products.
 
 File Name Syntax
-^^^^^^^^^^^^^^^^
+----------------
 The input exposure-based "cal" products have file names that follow the
 standard Stage 2 exposure syntax, such as::
 
- jw93065002001_02101_00001_nrs1_cal.fits
+   jw93065002001_02101_00001_nrs1_cal.fits
 
 See :ref:`exposure-based file names <exp_file_names>` for more details
 on the meaning of each field in the file names.
@@ -90,7 +99,7 @@ on the meaning of each field in the file names.
 The FITS file naming scheme for the source-based "cal" products follows
 the standard Stage 3 syntax, such as::
 
- jw10006-o010_s000000061_nirspec_f170lp-g235m_cal.fits
+   jw10006-o010_s000000061_nirspec_f170lp-g235m_cal.fits
 
 where "s000000061" in this example is the source ID.
 See :ref:`source-based file names <src_file_names>` for more details

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -1,4 +1,4 @@
-"""Reformat Level2b multi-source data to be source-based."""
+"""Conversion of Stage 2b exposure-based data products to Stage 3 source-based data products."""
 
 import logging
 from collections import defaultdict
@@ -17,18 +17,24 @@ def exp_to_source(inputs):
     """
     Reformat exposure-based MSA data to source-based.
 
+    There is a command-line interface for this function;
+    For help, use::
+
+        exp_to_source -h
+
     Parameters
     ----------
-    inputs : [~jwst.datamodels.MultiSlitModel, ...]
-        List of MultiSlitModel instances to reformat.
+    inputs : list of `~stdatamodels.jwst.datamodels.MultiSlitModel`
+        List of `~stdatamodels.jwst.datamodels.MultiSlitModel` instances to reformat.
 
     Returns
     -------
     multiexposures : dict
-        Returns a dict of MultiExposureModel instances wherein each
+        Returns a dictionary of `~stdatamodels.jwst.datamodels.MultiExposureModel`
+        instances wherein each
         instance contains slits belonging to the same source.
-        The key is the ID of each source, i.e. ``source_id``.
-    """
+        The key is the ID of each source, i.e., ``source_id``.
+    """  # fmt: skip
     result = defaultdict(MultiExposureModel)
 
     for exposure in inputs:
@@ -94,16 +100,20 @@ def multislit_to_container(inputs):
 
     Parameters
     ----------
-    inputs : [~jwst.datamodels.MultiSlitModel, ...]
-        List of MultiSlitModel instances to reformat, or just a
-        ModelContainer full of MultiSlitModels.
+    inputs : list of `~stdatamodels.jwst.datamodels.MultiSlitModel`
+        List of `~stdatamodels.jwst.datamodels.MultiSlitModel`
+        instances to reformat, or just a
+        `~jwst.datamodels.container.ModelContainer` full of
+        `~stdatamodels.jwst.datamodels.MultiSlitModel`.
 
     Returns
     -------
     containers : dict
-        Returns a dict of ModelContainer instances wherein each
-        instance contains ImageModels of slits belonging to the same source.
-        The key is the ID of each slit, i.e. ``source_id``.
+        Returns a dictionary of `~jwst.datamodels.container.ModelContainer`
+        instances wherein each instance contains
+        `~stdatamodels.jwst.datamodels.ImageModel` of slits belonging
+        to the same source.
+        The key is the ID of each slit, i.e., ``source_id``.
     """
     containers = exp_to_source(inputs)
     for container_id in containers:

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -33,7 +33,7 @@ def exp_to_source(inputs):
         Returns a dictionary of `~stdatamodels.jwst.datamodels.MultiExposureModel`
         instances wherein each
         instance contains slits belonging to the same source.
-        The key is the ID of each source, i.e., ``source_id``.
+        The key is the ``source_id`` of each source.
     """  # fmt: skip
     result = defaultdict(MultiExposureModel)
 
@@ -100,11 +100,10 @@ def multislit_to_container(inputs):
 
     Parameters
     ----------
-    inputs : list of `~stdatamodels.jwst.datamodels.MultiSlitModel`
+    inputs : list or `~jwst.datamodels.container.ModelContainer` of \
+             `~stdatamodels.jwst.datamodels.MultiSlitModel`
         List of `~stdatamodels.jwst.datamodels.MultiSlitModel`
-        instances to reformat, or just a
-        `~jwst.datamodels.container.ModelContainer` full of
-        `~stdatamodels.jwst.datamodels.MultiSlitModel`.
+        instances to reformat
 
     Returns
     -------

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -17,11 +17,6 @@ def exp_to_source(inputs):
     """
     Reformat exposure-based MSA data to source-based.
 
-    There is a command-line interface for this function;
-    For help, use::
-
-        exp_to_source -h
-
     Parameters
     ----------
     inputs : list of `~stdatamodels.jwst.datamodels.MultiSlitModel`
@@ -34,7 +29,7 @@ def exp_to_source(inputs):
         instances wherein each
         instance contains slits belonging to the same source.
         The key is the ``source_id`` of each source.
-    """  # fmt: skip
+    """
     result = defaultdict(MultiExposureModel)
 
     for exposure in inputs:

--- a/jwst/exp_to_source/main.py
+++ b/jwst/exp_to_source/main.py
@@ -13,22 +13,21 @@ class Main:
     """
     Convert exposure-based slits data to source-based data.
 
-    Command-line interface to the exp_to_source step. For help, use
-    exp_to_source -h. See also the exp_to_source readthedocs page:
-    https://jwst-pipeline.readthedocs.io/en/latest/api/jwst.exp_to_source.exp_to_source.html#jwst.exp_to_source.exp_to_source
-    """
+    Command-line interface to the exp_to_source step. For help, use::
+
+        exp_to_source -h
+
+    See also the exp_to_source readthedocs page: :ref:`exp_to_source`
+
+    Parameters
+    ----------
+    args : str or [str, ...] or None
+        The command-line arguments. This is passed to
+        :py:func:`argparse.parse_args`. If None, ``sys.argv``
+        is used.
+    """  # fmt: skip
 
     def __init__(self, args=None):
-        """
-        Initialize and run the exp_to_source step.
-
-        Parameters
-        ----------
-        args : str or [str,...]
-            The command-line arguments. This is passed to
-            `argparse.parse_args`. If None, `sys.argv`
-            is used.
-        """
         if args is None:
             args = sys.argv[1:]
         if isinstance(args, str):


### PR DESCRIPTION
Towards [JP-4107](https://jira.stsci.edu/browse/JP-4107)

This PR addresses `exp_to_source` portion of https://github.com/spacetelescope/jwst/issues/9793 . Only touch docs so should not need RT.

On main:

* https://jwst-pipeline.readthedocs.io/en/latest/jwst/exp_to_source/index.html

With this patch:

* https://jwst-pipeline--10397.org.readthedocs.build/en/10397/jwst/exp_to_source/index.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
