### PR TITLE
JP-4303: Fix indexing bug in wfss_contam slit matching

### DIFF
--- a/changes/10402.wfss_contam.rst
+++ b/changes/10402.wfss_contam.rst
@@ -1,0 +1,1 @@
+Fix indexing bug in matching simulation with virtual slit cutouts

--- a/jwst/wfss_contam/tests/test_wfss_contam.py
+++ b/jwst/wfss_contam/tests/test_wfss_contam.py
@@ -9,7 +9,6 @@ from jwst.wfss_contam.wfss_contam import (
     _cut_frame_to_match_slit,
     _find_matching_simul_slit,
     _validate_orders_against_reference,
-    match_backplane_encompass_both,
     match_backplane_prefer_first,
 )
 
@@ -73,27 +72,7 @@ def test_cut_frame_to_match_slit(slit0, contam):
     assert np.all(cut_contam == 0.1)
 
 
-def test_common_slit_encompass(slit0, slit1):
-    slit0_final, slit1_final = match_backplane_encompass_both(slit0.copy(), slit1.copy())
-
-    # check indexing in metadata
-    assert slit0_final.xstart == slit1_final.xstart
-    assert slit0_final.ystart == slit1_final.ystart
-    assert slit0_final.xsize == slit1_final.xsize
-    assert slit0_final.ysize == slit1_final.ysize
-    assert slit0_final.data.shape == slit1_final.data.shape
-
-    # check data overlap
-    assert np.count_nonzero(slit0_final.data) == 15
-    assert np.count_nonzero(slit1_final.data) == 16
-    assert np.count_nonzero(slit0_final.data * slit1_final.data) == 6
-
-    # check data values
-    assert np.all(slit0_final.data[1:6, 0:3] == 1)
-    assert np.all(slit1_final.data[0:4, 1:5] == 0.5)
-
-
-def test_common_slit_prefer(slit0, slit1):
+def test_match_backplane_prefer_first(slit0, slit1):
     slit0_final, slit1_final = match_backplane_prefer_first(slit0.copy(), slit1.copy())
     assert slit0_final.xstart == slit0.xstart
     assert slit0_final.ystart == slit0.ystart
@@ -108,6 +87,41 @@ def test_common_slit_prefer(slit0, slit1):
     assert slit1_final.ysize == slit0.ysize
     assert slit1_final.data.shape == slit0.data.shape
     assert np.count_nonzero(slit1_final.data) == 6
+
+
+def test_match_backplane_prefer_first_yoffset():
+    """
+    Cover an indexing bug in match_backplane_prefer_first.
+
+    When slit1 starts below slit0 (y1 > 0), the old code dropped the first y1 rows
+    of data1 and placed the wrong rows in the output.
+    """
+    slit0 = SlitModel(data=np.zeros((4, 4)))
+    slit0.xstart, slit0.ystart = 0, 0  # origin at (0, 0)
+    slit0.xsize, slit0.ysize = 4, 4
+
+    # Give each row a distinct value so we can tell which rows end up where.
+    data1 = np.array([[1.0] * 4, [2.0] * 4, [3.0] * 4, [4.0] * 4])
+    wl1 = np.array([[0.1] * 4, [0.2] * 4, [0.3] * 4, [0.4] * 4])
+    slit1 = SlitModel(data=data1.copy())
+    slit1.wavelength = wl1.copy()
+    slit1.xstart, slit1.ystart = 0, 2  # starts 2 rows below slit0
+    slit1.xsize, slit1.ysize = 4, 4
+
+    _, slit1_out = match_backplane_prefer_first(slit0.copy(), slit1)
+
+    # Overlap: slit1 rows 0-1 (values 1.0, 2.0) map to backplane rows 2-3.
+    # Rows 0-1 of the backplane are outside slit1 so should be zero.
+    assert slit1_out.data.shape == (4, 4)
+    assert np.all(slit1_out.data[0:2, :] == 0.0)
+    assert np.all(slit1_out.data[2, :] == 1.0)
+    assert np.all(slit1_out.data[3, :] == 2.0)
+
+    # Wavelength array should be reprojected with the same offsets.
+    assert slit1_out.wavelength.shape == (4, 4)
+    assert np.all(slit1_out.wavelength[0:2, :] == 0.0)
+    assert np.all(slit1_out.wavelength[2, :] == pytest.approx(0.1))
+    assert np.all(slit1_out.wavelength[3, :] == pytest.approx(0.2))
 
 
 def test_common_slit_prefer_expected_raise(slit0, slit2):

--- a/jwst/wfss_contam/wfss_contam.py
+++ b/jwst/wfss_contam/wfss_contam.py
@@ -126,67 +126,20 @@ def match_backplane_prefer_first(slit0, slit1):
             f"order {slit0.meta.wcsinfo.spectral_order}. "
             "setting contamination correction to zero for that slit."
         )
-
-    backplane1[i0:i1, j0:j1] = data1[i0:i1, j0:j1]
+    di = i0 - y1  # offset into data1's own row axis
+    dj = j0 - x1  # offset into data1's own col axis
+    backplane1[i0:i1, j0:j1] = data1[di : di + (i1 - i0), dj : dj + (j1 - j0)]
 
     slit1.data = backplane1
+    # Anticipate slits carrying around wavelength arrays for future changes
+    if getattr(slit1, "wavelength", None) is not None and slit1.wavelength.shape == data1.shape:
+        wl_backplane = np.zeros_like(data0)
+        wl_backplane[i0:i1, j0:j1] = slit1.wavelength[di : di + (i1 - i0), dj : dj + (j1 - j0)]
+        slit1.wavelength = wl_backplane
     slit1.xstart = slit0.xstart
     slit1.ystart = slit0.ystart
     slit1.xsize = slit0.xsize
     slit1.ysize = slit0.ysize
-
-    return slit0, slit1
-
-
-def match_backplane_encompass_both(slit0, slit1):
-    """
-    Put data from the two slits into a common backplane, encompassing both.
-
-    Slits are zero-padded where their new extent does not overlap with the original data.
-
-    Parameters
-    ----------
-    slit0, slit1 : `~stdatamodels.jwst.datamodels.SlitModel`
-        Slit model for the first and second slit.
-
-    Returns
-    -------
-    slit0, slit1 : `~stdatamodels.jwst.datamodels.SlitModel`
-        Reshaped slit models slit0, slit1.
-    """
-    data0 = slit0.data
-    data1 = slit1.data
-
-    shape = (max(data0.shape[0], data1.shape[0]), max(data0.shape[1], data1.shape[1]))
-    xmin = min(slit0.xstart, slit1.xstart)
-    ymin = min(slit0.ystart, slit1.ystart)
-    shape = (
-        max(
-            slit0.xsize + slit0.xstart - xmin,
-            slit1.xsize + slit1.xstart - xmin,
-        ),
-        max(
-            slit0.ysize + slit0.ystart - ymin,
-            slit1.ysize + slit1.ystart - ymin,
-        ),
-    )
-    x0 = slit0.xstart - xmin
-    y0 = slit0.ystart - ymin
-    x1 = slit1.xstart - xmin
-    y1 = slit1.ystart - ymin
-
-    backplane0 = np.zeros(shape).T
-    backplane0[y0 : y0 + data0.shape[0], x0 : x0 + data0.shape[1]] = data0
-    backplane1 = np.zeros(shape).T
-    backplane1[y1 : y1 + data1.shape[0], x1 : x1 + data1.shape[1]] = data1
-
-    slit0.data = backplane0
-    slit1.data = backplane1
-    for slit in [slit0, slit1]:
-        slit.xstart = xmin
-        slit.ystart = ymin
-        slit.xsize = shape[0]
-        slit.ysize = shape[1]
 
     return slit0, slit1
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4303](https://jira.stsci.edu/browse/JP-4303)

<!-- describe the changes comprising this PR here -->
This PR fixes a bug where the simulated image was being incorrectly matched to the location of the virtual slits in some cases, leading to a spatial offset.  That spatial offset was propagated as a dipole pattern into the assumed contamination for a given slit, so the contamination correction was being improperly applied to the output.

The full-frame simulation is unaffected but other output files will be modified.

I have also removed the unused `match_backplane_encompass_both` for which tests were inadequate to see if the same bug existed.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
