### PR TITLE
DOC: Complete API for firstframe

### DIFF
--- a/docs/jwst/firstframe/api_ref.rst
+++ b/docs/jwst/firstframe/api_ref.rst
@@ -1,0 +1,15 @@
+===
+API
+===
+
+Public Step API
+===============
+
+.. automodapi:: jwst.firstframe.firstframe_step
+   :no-inheritance-diagram:
+
+Complete Developer API
+======================
+
+.. automodapi:: jwst.firstframe.firstframe_sub
+   :no-inheritance-diagram:

--- a/docs/jwst/firstframe/arguments.rst
+++ b/docs/jwst/firstframe/arguments.rst
@@ -4,11 +4,11 @@ Step Arguments
 The ``firstframe`` step has the following step-specific arguments.
 
 ``--bright_use_group1`` (boolean, default=True)
-    If True, setting the group 1 groupdq to DO_NOT_USE will not be done
+    If True, setting the group 1 ``groupdq`` to DO_NOT_USE will not be done
     for pixels that have the saturation flag set for group 3.
     This will allow a slope to be determined for pixels that saturate in group 3.
     This change in flagging will only impact pixels that saturate in group 3, the behavior
     for all other pixels will be unchanged.
     The ``bright_use_group1`` flag can be set for all data, only data/pixels that saturate
     in group 3 will see a difference in behavior. These pixels will be marked with
-    the FLUX_ESTIMATED DQ flag in the pixeldq image.
+    the FLUX_ESTIMATED DQ flag in the ``pixeldq`` image.

--- a/docs/jwst/firstframe/description.rst
+++ b/docs/jwst/firstframe/description.rst
@@ -1,11 +1,13 @@
 Description
 ===========
 
-:Class: `jwst.firstframe.FirstFrameStep`
+:Class: `jwst.firstframe.firstframe_step.FirstFrameStep`
 :Alias: firstframe
 
-The ``firstframe`` step has been deprecated and will be removed
-in a future release. Flagging the first group  has been added to the RSCD step.
+.. warning::
+    The ``firstframe`` step has been deprecated and will be removed
+    in a future release. Flagging the first group  has been added to
+    the :ref:`RSCD step <rscd_step>`.
 
 The MIRI first frame correction step flags the first group in every integration
 as bad (the "DO_NOT_USE" data quality flag is added to the GROUPDQ array), but

--- a/docs/jwst/firstframe/index.rst
+++ b/docs/jwst/firstframe/index.rst
@@ -4,10 +4,14 @@
 First Frame Correction
 ======================
 
+.. warning::
+    The ``firstframe`` step has been deprecated and will be removed
+    in a future release. Flagging the first group  has been added to
+    the :ref:`RSCD step <rscd_step>`.
+
 .. toctree::
    :maxdepth: 2
 
    description.rst
    arguments.rst
-
-.. automodapi:: jwst.firstframe
+   api_ref.rst

--- a/jwst/firstframe/firstframe_step.py
+++ b/jwst/firstframe/firstframe_step.py
@@ -1,3 +1,5 @@
+"""Set data quality flag of first group in MIRI data."""
+
 import logging
 import warnings
 

--- a/jwst/firstframe/firstframe_sub.py
+++ b/jwst/firstframe/firstframe_sub.py
@@ -21,7 +21,7 @@ def do_correction(output, bright_use_group1=False):
 
     Parameters
     ----------
-    output : DataModel
+    output : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Science data to be corrected
     bright_use_group1 : bool
         If True, setting first group data quality flag to DO_NOT_USE will not be
@@ -29,7 +29,7 @@ def do_correction(output, bright_use_group1=False):
 
     Returns
     -------
-    output : DataModel
+    output : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Firstframe-corrected science data
     """
     # Save some data params for easy use later


### PR DESCRIPTION
Towards [JP-4107](https://jira.stsci.edu/browse/JP-4107)

This PR addresses `firstframe` portion of https://github.com/spacetelescope/jwst/issues/9793 . Only touch docs so should not need RT.

On main:

* https://jwst-pipeline.readthedocs.io/en/latest/jwst/firstframe/index.html

With this patch:

* https://jwst-pipeline--10411.org.readthedocs.build/en/10411/jwst/firstframe/index.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
