### PR TITLE
DOC: Complete API for lastframe

### DIFF
--- a/docs/jwst/lastframe/api_ref.rst
+++ b/docs/jwst/lastframe/api_ref.rst
@@ -1,0 +1,15 @@
+===
+API
+===
+
+Public Step API
+===============
+
+.. automodapi:: jwst.lastframe.lastframe_step
+   :no-inheritance-diagram:
+
+Complete Developer API
+======================
+
+.. automodapi:: jwst.lastframe.lastframe_sub
+   :no-inheritance-diagram:

--- a/docs/jwst/lastframe/arguments.rst
+++ b/docs/jwst/lastframe/arguments.rst
@@ -1,4 +1,0 @@
-Step Arguments
-==============
-
-The last frame correction has no step-specific arguments.

--- a/docs/jwst/lastframe/description.rst
+++ b/docs/jwst/lastframe/description.rst
@@ -1,7 +1,7 @@
 Description
 ===========
 
-:Class: `jwst.lastframe.LastFrameStep`
+:Class: `jwst.lastframe.lastframe_step.LastFrameStep`
 :Alias: lastframe
 
 The last frame correction step is only applied to MIRI data and flags the
@@ -14,6 +14,10 @@ No flags are added if ``NGROUPS <= 2``, because doing so would leave too few goo
 groups to work with in later steps.
 
 Only the GROUPDQ array is modified. The SCI, ERR, and PIXELDQ arrays are unchanged.
+
+Step Arguments
+--------------
+The ``lastframe`` step does not have any step-specific arguments.
 
 Reference Files
 ---------------

--- a/docs/jwst/lastframe/index.rst
+++ b/docs/jwst/lastframe/index.rst
@@ -8,6 +8,4 @@ Last Frame Correction
    :maxdepth: 2
 
    description.rst
-   arguments.rst
-
-.. automodapi:: jwst.lastframe
+   api_ref.rst

--- a/jwst/lastframe/lastframe_step.py
+++ b/jwst/lastframe/lastframe_step.py
@@ -1,3 +1,5 @@
+"""Set data quality flag of last group in MIRI data."""
+
 import logging
 
 from stdatamodels.jwst import datamodels
@@ -14,7 +16,7 @@ class LastFrameStep(Step):
     """
     Set data quality flags for the last group in MIRI ramps.
 
-    If the number of groups > 2, the GROUP
+    If the number of groups is greater than 2, the GROUP
     data quality flag for the final group will be set to DO_NOT_USE.
     """
 
@@ -25,7 +27,7 @@ class LastFrameStep(Step):
 
     def process(self, step_input):
         """
-        For MIRI data with more than 2 groups, set final group dq to DO_NOT_USE.
+        For MIRI data with more than 2 groups, set final group DQ to DO_NOT_USE.
 
         Parameters
         ----------

--- a/jwst/lastframe/lastframe_sub.py
+++ b/jwst/lastframe/lastframe_sub.py
@@ -1,6 +1,5 @@
-#
-#  Module for the lastframe correction for MIRI science data sets
-#
+"""Utility functions for the lastframe correction for MIRI science data sets."""
+
 import logging
 
 from stdatamodels.jwst.datamodels import dqflags
@@ -20,12 +19,12 @@ def do_correction(output):
 
     Parameters
     ----------
-    output : DataModel
+    output : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Science data to be corrected
 
     Returns
     -------
-    output : DataModel
+    output : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Lastframe-corrected science data
     """
     # Save some data params for easy use later


### PR DESCRIPTION
Towards [JP-4107](https://jira.stsci.edu/browse/JP-4107)

This PR addresses `lastframe` portion of https://github.com/spacetelescope/jwst/issues/9793 . Only touch docs so should not need RT.

On main:

* https://jwst-pipeline.readthedocs.io/en/latest/jwst/lastframe/index.html

With this patch:

* https://jwst-pipeline--10415.org.readthedocs.build/en/10415/jwst/lastframe/index.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
