### PR TITLE
JP-4309: Fix missing CUNIT in resampled images

### DIFF
--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -713,8 +713,8 @@ class ResampleImage(Resample):
             model.meta.wcsinfo.pc2_2 = transform.pc[1][1]
             model.meta.wcsinfo.ctype1 = w.wcs.ctype[0]
             model.meta.wcsinfo.ctype2 = w.wcs.ctype[1]
-            model.meta.wcsinfo.cunit1 = str(w.wcs.cunit[0])
-            model.meta.wcsinfo.cunit2 = str(w.wcs.cunit[1])
+            model.meta.wcsinfo.cunit1 = str(model.meta.wcs.output_frame.unit[0])
+            model.meta.wcsinfo.cunit2 = str(model.meta.wcs.output_frame.unit[1])
             model.meta.wcsinfo.radesys = w.wcs.radesys
 
         else:


### PR DESCRIPTION
Resolves [JP-4309](https://jira.stsci.edu/browse/JP-4309)

This PR is fixing the issue of missing `cunit` (or `'deg'`) failures in regression tests as the result of https://github.com/spacetelescope/jwst/pull/10379.

https://github.com/spacetelescope/RegressionTests/actions/runs/23987078027
Regression test failures show that units are now back.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [x] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
