### PR TITLE
DOC: Complete API for gain_scale

### DIFF
--- a/docs/jwst/gain_scale/api_ref.rst
+++ b/docs/jwst/gain_scale/api_ref.rst
@@ -1,0 +1,15 @@
+===
+API
+===
+
+Public Step API
+===============
+
+.. automodapi:: jwst.gain_scale.gain_scale_step
+   :no-inheritance-diagram:
+
+Complete Developer API
+======================
+
+.. automodapi:: jwst.gain_scale.gain_scale
+   :no-inheritance-diagram:

--- a/docs/jwst/gain_scale/arguments.rst
+++ b/docs/jwst/gain_scale/arguments.rst
@@ -1,4 +1,0 @@
-Arguments
-=========
-
-The gain_scale correction has no step-specific arguments.

--- a/docs/jwst/gain_scale/description.rst
+++ b/docs/jwst/gain_scale/description.rst
@@ -1,7 +1,7 @@
 Description
-============
+===========
 
-:Class: `jwst.gain_scale.GainScaleStep`
+:Class: `jwst.gain_scale.gain_scale_step.GainScaleStep`
 :Alias: gain_scale
 
 The ``gain_scale`` step rescales pixel values in JWST countrate
@@ -14,9 +14,9 @@ This currently only applies to NIRSpec exposures that are read out
 using a subarray pattern, in which case a gain setting of 2 is used
 instead of the standard setting of 1. Note that this only applies
 to NIRSpec subarray data obtained after April 2017, which is when
-the change was made in the instrument flight software to use gain=2.
+the change was made in the instrument flight software to use ``gain=2``.
 NIRSpec subarray data obtained previous to that time used the
-standard gain=1 setting.
+standard ``gain=1`` setting.
 
 The ``gain_scale`` step is applied at the end of the
 :ref:`calwebb_detector1 <calwebb_detector1>` pipeline, after the
@@ -29,20 +29,24 @@ variance (VAR_POISSON) and read noise variance (VAR_RNOISE) arrays
 are multiplied by the square of the gain factor.
 
 The scaling factor is obtained from the "GAINFACT" keyword in the
-header of the gain reference file. Normally the
+header of the :ref:`gain_reffile`. Normally the
 :ref:`ramp_fit <ramp_fitting_step>` step
 reads that keyword value during its execution and stores the value in
-the science data "GAINFACT" keyword, so that the gain reference file
+the science data "GAINFACT" keyword, so that the :ref:`gain_reffile`
 does not have to be loaded again by the ``gain_scale`` step. If, however,
 the step does not find that keyword populated in the science data, it
-loads the gain reference file to retrieve it. If all attempts to
+loads the :ref:`gain_reffile` to retrieve it. If all attempts to
 find the scaling factor fail, the step is skipped.
 
-Gain reference files for instruments or modes that use the standard
+:ref:`gain_reffile` for instruments or modes that use the standard
 gain setting will typically not have the "GAINFACT" keyword in their
 header, which causes the ``gain_scale`` step to be skipped. Alternatively,
-gain reference files for modes that use the standard gain can have
-GAINFACT=1.0, in which case the correction is benign.
+:ref:`gain_reffile` for modes that use the standard gain can have
+``GAINFACT=1.0``, in which case the correction is benign.
 
 Upon successful completion of the step, the "S_GANSCL" keyword in the
 science data is set to "COMPLETE".
+
+Step Arguments
+--------------
+The ``gain_scale`` correction has no step-specific arguments.

--- a/docs/jwst/gain_scale/index.rst
+++ b/docs/jwst/gain_scale/index.rst
@@ -8,8 +8,5 @@ Gain Scale Correction
    :maxdepth: 2
 
    description.rst
-   arguments.rst
    reference_files.rst
-
-.. automodapi:: jwst.gain_scale
-
+   api_ref.rst

--- a/jwst/gain_scale/gain_scale.py
+++ b/jwst/gain_scale/gain_scale.py
@@ -9,22 +9,22 @@ __all__ = ["do_correction"]
 
 def do_correction(output_model, gain_factor):
     """
-    Rescale all integrations in an exposure by gain_factor.
+    Rescale all integrations in an exposure by gain factor.
 
-    Rescales all integrations in an exposure by gain_factor, to
+    Rescales all integrations in an exposure by gain factor, to
     account for non-standard detector gain settings. The SCI,
     ERR, and variance arrays are rescaled.
 
     Parameters
     ----------
-    output_model : `~jwst.datamodels.JwstDataModel`
+    output_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Input datamodel to be corrected.
     gain_factor : float
         Scale gain factor.
 
     Returns
     -------
-    output_model : `~jwst.datamodels.JwstDataModel`
+    output_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Output datamodel with rescaled data.
     """
     # Apply the gain factor to the SCI and ERR arrays

--- a/jwst/gain_scale/gain_scale_step.py
+++ b/jwst/gain_scale/gain_scale_step.py
@@ -1,3 +1,5 @@
+"""Perform gain scale step."""
+
 import logging
 
 from stdatamodels.jwst import datamodels


### PR DESCRIPTION
Towards [JP-4107](https://jira.stsci.edu/browse/JP-4107)

This PR addresses `gain_scale` portion of https://github.com/spacetelescope/jwst/issues/9793 . Only touch docs so should not need RT.

On main:

* https://jwst-pipeline.readthedocs.io/en/latest/jwst/gain_scale/index.html

With this patch:

* https://jwst-pipeline--10424.org.readthedocs.build/en/10424/jwst/gain_scale/index.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
