### PR TITLE
DOC: Complete API for group_scale

### DIFF
--- a/docs/jwst/group_scale/api_ref.rst
+++ b/docs/jwst/group_scale/api_ref.rst
@@ -1,0 +1,15 @@
+===
+API
+===
+
+Public Step API
+===============
+
+.. automodapi:: jwst.group_scale.group_scale_step
+   :no-inheritance-diagram:
+
+Complete Developer API
+======================
+
+.. automodapi:: jwst.group_scale.group_scale
+   :no-inheritance-diagram:

--- a/docs/jwst/group_scale/arguments.rst
+++ b/docs/jwst/group_scale/arguments.rst
@@ -1,4 +1,0 @@
-Arguments
-=========
-
-The ``group_scale`` correction has no step-specific arguments.

--- a/docs/jwst/group_scale/description.rst
+++ b/docs/jwst/group_scale/description.rst
@@ -1,7 +1,7 @@
 Description
 ===========
 
-:Class: `jwst.group_scale.GroupScaleStep`
+:Class: `jwst.group_scale.group_scale_step.GroupScaleStep`
 :Alias: group_scale
 
 The ``group_scale`` step rescales pixel values in raw JWST science
@@ -26,9 +26,9 @@ power of 2. When NFRAMES is not a power of 2, the next largest
 divisor is used to perform the averaging. For example, when
 ``NFRAMES=5``, a divisor of 8 (bit shift of 3) is used to compute the
 average. This results in averaged values for each group that
-are too low by the factor NFRAMES/FRMDIVSR. This step rescales the
+are too low by the factor ``NFRAMES/FRMDIVSR``. This step rescales the
 pixel values by multiplying all groups in all integrations by the
-factor FRMDIVSR/NFRAMES.
+factor ``FRMDIVSR/NFRAMES``.
 
 The step decides whether rescaling is necessary by comparing the
 values of the NFRAMES and FRMDIVSR keywords. If they are equal,
@@ -62,10 +62,14 @@ per group and the number of groups per integration that are downlinked
 from the instrument are stored in the special keywords "MIRNFRMS" and
 "MIRNGRPS", respectively, so that their values are preserved. During
 Stage 1 processing in the pipeline, the value of the NFRAMES keyword is
-computed from MIRNFRMS * FRMDIVSR. The result is that when 4 frames
+computed from ```MIRNFRMS * FRMDIVSR``. The result is that when 4 frames
 are averaged together on board, both NFRAMES and FRMDIVSR will have a
 value of 4, which allows the ``group_scale`` step to correctly
 determine that no rescaling of the data is necessary.
+
+Step Arguments
+--------------
+The ``group_scale`` step does not have any step-specific arguments.
 
 Reference Files
 ---------------

--- a/docs/jwst/group_scale/index.rst
+++ b/docs/jwst/group_scale/index.rst
@@ -8,6 +8,4 @@ Group Scale Correction
    :maxdepth: 2
 
    description.rst
-   arguments.rst
-
-.. automodapi:: jwst.group_scale
+   api_ref.rst

--- a/jwst/group_scale/group_scale.py
+++ b/jwst/group_scale/group_scale.py
@@ -1,7 +1,4 @@
-#
-#  Module for rescaling grouped data for NFRAME
-#  not equal to a power of 2
-#
+"""Functions for rescaling grouped data for NFRAME not equal to a power of 2."""
 
 import logging
 

--- a/jwst/group_scale/group_scale_step.py
+++ b/jwst/group_scale/group_scale_step.py
@@ -1,3 +1,5 @@
+"""Perform the group scale step."""
+
 import logging
 import warnings
 


### PR DESCRIPTION
Towards [JP-4107](https://jira.stsci.edu/browse/JP-4107)

This PR addresses `group_scale` portion of https://github.com/spacetelescope/jwst/issues/9793 . Only touch docs so should not need RT.

On main:

* https://jwst-pipeline.readthedocs.io/en/latest/jwst/group_scale/index.html

With this patch:

* https://jwst-pipeline--10425.org.readthedocs.build/en/10425/jwst/group_scale/index.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
