### PR TITLE
JP-4224: Remove correction_pars

### DIFF
--- a/changes/10432.breaking.rst
+++ b/changes/10432.breaking.rst
@@ -1,0 +1,4 @@
+Remove the "use_correction_pars" step parameter and the ``correction_pars`` attribute from the
+``barshadow``, ``flat_field``, ``master_background_mos``, ``pathloss``, and ``photom`` steps.
+These were intended for internal support for the ``master_background_mos`` step in the ``calwebb_spec2``
+pipeline but are no longer needed.

--- a/changes/10432.pipeline.rst
+++ b/changes/10432.pipeline.rst
@@ -1,0 +1,1 @@
+Remove ``correction_pars`` handling from all steps in ``calwebb_spec2`` to avoid storing correction arrays longer than they are needed.

--- a/jwst/barshadow/bar_shadow.py
+++ b/jwst/barshadow/bar_shadow.py
@@ -25,11 +25,7 @@ __all__ = [
 
 
 def do_correction(
-    input_model,
-    barshadow_model=None,
-    inverse=False,
-    source_type=None,
-    correction_pars=None,
+    input_model, barshadow_model=None, inverse=False, source_type=None, return_corrections=True
 ):
     """
     Correct MSA data for bar shadows.
@@ -44,15 +40,16 @@ def do_correction(
         Invert the math operations used to apply the flat field.
     source_type : str or None, optional
         Force processing using the specified source type.
-    correction_pars : dict or None, optional
-        Correction parameters to use instead of recalculation.
+    return_corrections : bool, optional
+        If True, a model containing the applied corrections is returned.
 
     Returns
     -------
     input_model : `~stdatamodels.jwst.datamodels.MultiSlitModel`
         Science data model with correction applied and barshadow extensions added.
-    corrections : `~stdatamodels.jwst.datamodels.MultiSlitModel`
-        A model of the correction arrays.
+    corrections : `~stdatamodels.jwst.datamodels.MultiSlitModel`, optional
+        A model of the correction arrays, returned if ``return_corrections``
+        is True.
     """
     # Input is a MultiSlitModel science data model.
     # A MultislitModel has a member ".slits" that behaves like
@@ -71,14 +68,11 @@ def do_correction(
 
     # Loop over all the slits in the input model
     corrections = datamodels.MultiSlitModel()
-    for slit_idx, slitlet in enumerate(input_model.slits):
+    for slitlet in input_model.slits:
         slitlet_number = slitlet.slitlet_id
         log.info(f"Working on slitlet {slitlet_number}")
 
-        if correction_pars:
-            correction = correction_pars.slits[slit_idx]
-        else:
-            correction = _calc_correction(slitlet, barshadow_model, source_type)
+        correction = _calc_correction(slitlet, barshadow_model, source_type)
         corrections.slits.append(correction)
 
         if correction is None:
@@ -114,7 +108,11 @@ def do_correction(
                 slitlet.var_flat *= correction.data**2
         slitlet.barshadow = correction.data
 
-    return input_model, corrections
+    if return_corrections:
+        return input_model, corrections
+    else:
+        corrections.close()
+        return input_model
 
 
 def _calc_correction(slitlet, barshadow_model, source_type):

--- a/jwst/barshadow/barshadow_step.py
+++ b/jwst/barshadow/barshadow_step.py
@@ -54,37 +54,27 @@ class BarShadowStep(Step):
             output_model.meta.cal_step.barshadow = "SKIPPED"
             return output_model
 
-        if self.use_correction_pars:
-            correction_pars = self.correction_pars
-            barshadow_model = None
-        else:
-            correction_pars = None
+        # Get the name of the bar shadow reference file to use
+        barshadow_name = self.get_reference_file(output_model, "barshadow")
+        log.info(f"Using BARSHADOW reference file {barshadow_name}")
 
-            # Get the name of the bar shadow reference file to use
-            barshadow_name = self.get_reference_file(output_model, "barshadow")
-            log.info(f"Using BARSHADOW reference file {barshadow_name}")
-
-            # Check for a valid reference file
-            if barshadow_name == "N/A":
-                log.warning("No BARSHADOW reference file found")
-                log.warning("Bar shadow step will be skipped")
-                output_model.meta.cal_step.barshadow = "SKIPPED"
-                return output_model
-
-            # Open the barshadow ref file data model
-            barshadow_model = datamodels.BarshadowModel(barshadow_name)
+        # Check for a valid reference file
+        if barshadow_name == "N/A":
+            log.warning("No BARSHADOW reference file found")
+            log.warning("Bar shadow step will be skipped")
+            output_model.meta.cal_step.barshadow = "SKIPPED"
+            return output_model
 
         # Do the bar shadow correction
-        output_model, self.correction_pars = bar_shadow.do_correction(
-            output_model,
-            barshadow_model,
-            inverse=self.inverse,
-            source_type=self.source_type,
-            correction_pars=correction_pars,
-        )
+        with datamodels.BarshadowModel(barshadow_name) as barshadow_model:
+            output_model = bar_shadow.do_correction(
+                output_model,
+                barshadow_model,
+                inverse=self.inverse,
+                source_type=self.source_type,
+                return_corrections=False,
+            )
 
-        if barshadow_model:
-            barshadow_model.close()
         output_model.meta.cal_step.barshadow = "COMPLETE"
 
         return output_model

--- a/jwst/barshadow/tests/test_barshadow_step.py
+++ b/jwst/barshadow/tests/test_barshadow_step.py
@@ -161,7 +161,7 @@ def test_barshadow_wrong_exptype():
     result.close()
 
 
-def test_barshadow_correction_pars(nirspec_mos_model):
+def test_barshadow_inverse(nirspec_mos_model):
     model = nirspec_mos_model.copy()
     step = BarShadowStep()
     result = step.run(model)
@@ -170,10 +170,8 @@ def test_barshadow_correction_pars(nirspec_mos_model):
     nnan = ~np.isnan(model.slits[0].data) & ~np.isnan(result.slits[0].data)
     assert not np.allclose(result.slits[0].data[nnan], model.slits[0].data[nnan])
 
-    # use the computed correction and invert
+    # run again but invert
     new_step = BarShadowStep()
-    new_step.use_correction_pars = True
-    new_step.correction_pars = step.correction_pars
     new_step.inverse = True
     inverse_result = new_step.run(result)
 

--- a/jwst/flatfield/flat_field_step.py
+++ b/jwst/flatfield/flat_field_step.py
@@ -66,15 +66,6 @@ class FlatFieldStep(Step):
         """
         Perform the flat field step.
 
-        For repeating or undoing the correction, this step makes use of
-        two special attributes:
-
-            correction_pars : dict
-                After the step has successfully run, the flat field applied is
-                stored, as ``{'flat': DataModel}``.
-            use_correction_pars : bool
-                Use the flat stored in ``correction_pars``.
-
         Parameters
         ----------
         input_data : str or `~stdatamodels.jwst.datamodels.JwstDataModel`
@@ -128,17 +119,6 @@ class FlatFieldStep(Step):
             flat_ref_file = reference_file_models["user_supplied_flat"].meta.filename
             self._reference_files_used.append(("flat", flat_ref_file))
             log.info("Using flat field reference file: %s", flat_ref_file)
-        elif self.use_correction_pars:
-            log.info(f"Using flat field from correction pars {self.correction_pars['flat']}")
-            reference_file_models = {
-                "user_supplied_flat": datamodels.open(self.correction_pars["flat"])
-            }
-
-            # Record the flat as the FLAT reference type for recording
-            # in the result header.
-            self._reference_files_used.append(
-                ("flat", reference_file_models["user_supplied_flat"].meta.filename)
-            )
         else:
             reference_file_models = self._get_references(output_model, exposure_type)
 
@@ -157,10 +137,6 @@ class FlatFieldStep(Step):
         if self.save_interpolated_flat and flat_applied is not None:
             ff_path = self.save_model(flat_applied, suffix=self.flat_suffix, force=True)
             log.info(f'Interpolated flat written to "{ff_path}".')
-
-        if not self.correction_pars:
-            self.correction_pars = {}
-        self.correction_pars["flat"] = flat_applied
 
         return output_model
 

--- a/jwst/master_background/master_background_mos_step.py
+++ b/jwst/master_background/master_background_mos_step.py
@@ -8,6 +8,7 @@ from stpipe.step import preserve_step_pars
 from jwst.barshadow import barshadow_step
 from jwst.extract_1d import extract_1d_step
 from jwst.flatfield import flat_field_step
+from jwst.lib.basic_utils import disable_logging
 from jwst.master_background import nirspec_utils
 from jwst.pathloss import pathloss_step
 from jwst.photom import photom_step
@@ -271,6 +272,10 @@ class MasterBackgroundMosStep(Pipeline):
             self.barshadow.source_type = "EXTENDED"
             self.photom.source_type = "EXTENDED"
 
+            log.info(
+                "Applying flat_field, pathloss, barshadow, and photom "
+                "corrections for background data "
+            )
             pre_calibrated = self.flat_field.run(pre_calibrated)
             pre_calibrated = self.pathloss.run(pre_calibrated)
             pre_calibrated = self.barshadow.run(pre_calibrated)
@@ -310,9 +315,15 @@ class MasterBackgroundMosStep(Pipeline):
             self.pathloss.inverse = True
             self.flat_field.inverse = True
 
-            mb_multislit = self.photom.run(mb_multislit)
-            mb_multislit = self.barshadow.run(mb_multislit)
-            mb_multislit = self.pathloss.run(mb_multislit)
-            mb_multislit = self.flat_field.run(mb_multislit)
+            # Disable logs for the second time through
+            log.info(
+                "Inverting photom, barshadow, pathloss, and flat_field "
+                "corrections for background data "
+            )
+            with disable_logging(level=logging.WARNING):
+                mb_multislit = self.photom.run(mb_multislit)
+                mb_multislit = self.barshadow.run(mb_multislit)
+                mb_multislit = self.pathloss.run(mb_multislit)
+                mb_multislit = self.flat_field.run(mb_multislit)
 
         return master_background, mb_multislit, bkg_x1d_spectra

--- a/jwst/master_background/master_background_mos_step.py
+++ b/jwst/master_background/master_background_mos_step.py
@@ -70,21 +70,6 @@ class MasterBackgroundMosStep(Pipeline):
         twice. Once, to calibrate background slits and create a master background.
         Then, a second time to calibrate science using the master background.
 
-        For repeating or undoing the correction, this step makes use of
-        two special attributes:
-
-            correction_pars : dict
-                The master background information from a previous invocation of the step.
-                Keys are:
-
-                - "masterbkg_1d": `~stdatamodels.jwst.datamodels.CombinedSpecModel`
-                    The 1D version of the master background.
-                - "masterbkg_2d": `~stdatamodels.jwst.datamodels.MultiSlitModel`
-                    The 2D slit-based version of the master background.
-
-            use_correction_pars : bool
-                Use the corrections stored in ``correction_pars``.
-
         Parameters
         ----------
         data : `~stdatamodels.jwst.datamodels.MultiSlitModel`
@@ -123,7 +108,6 @@ class MasterBackgroundMosStep(Pipeline):
             record_step_status(output_model, "master_background", success=False)
             return output_model
 
-        bkg_x1d_spectra = None
         if self.user_background:
             log.info(
                 "Calculating master background from "
@@ -133,10 +117,6 @@ class MasterBackgroundMosStep(Pipeline):
                 master_background, mb_multislit, bkg_x1d_spectra = self._calc_master_background(
                     output_model, user_background
                 )
-        elif self.use_correction_pars:
-            log.info("Using pre-calculated correction parameters.")
-            master_background = self.correction_pars["masterbkg_1d"]
-            mb_multislit = self.correction_pars["masterbkg_2d"]
         else:
             num_bkg, num_src = self._classify_slits(output_model)
             if num_bkg == 0:
@@ -168,14 +148,15 @@ class MasterBackgroundMosStep(Pipeline):
 
         # Mark as completed and setup return data
         record_step_status(result, "master_background", True)
-        self.correction_pars = {"masterbkg_1d": master_background, "masterbkg_2d": mb_multislit}
         if self.save_background:
             self.save_model(master_background, suffix="masterbg1d", force=True)
             self.save_model(mb_multislit, suffix="masterbg2d", force=True)
             if bkg_x1d_spectra is not None:
                 self.save_model(bkg_x1d_spectra, suffix="bkgx1d", force=True)
 
-        # Close intermediate models that are not held in correction_pars
+        # Close intermediate models
+        master_background.close()
+        mb_multislit.close()
         if bkg_x1d_spectra is not None:
             bkg_x1d_spectra.close()
 

--- a/jwst/master_background/master_background_mos_step.py
+++ b/jwst/master_background/master_background_mos_step.py
@@ -304,15 +304,10 @@ class MasterBackgroundMosStep(Pipeline):
             mb_multislit = nirspec_utils.map_to_science_slits(pre_calibrated, master_background)
 
             # Now that the master background is pretending to be science,
-            # walk backwards through the steps to uncalibrate, using the
-            # calibration factors carried from `pre_calibrated`.
-            self.photom.use_correction_pars = True
+            # walk backwards through the steps to uncalibrate
             self.photom.inverse = True
-            self.barshadow.use_correction_pars = True
             self.barshadow.inverse = True
-            self.pathloss.use_correction_pars = True
             self.pathloss.inverse = True
-            self.flat_field.use_correction_pars = True
             self.flat_field.inverse = True
 
             mb_multislit = self.photom.run(mb_multislit)

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -389,8 +389,8 @@ def do_correction(
     pathloss_model=None,
     inverse=False,
     source_type=None,
-    correction_pars=None,
     user_slit_loc=None,
+    return_corrections=True,
 ):
     """
     Execute all tasks for Path Loss Correction.
@@ -406,39 +406,32 @@ def do_correction(
         Invert the math operations used to apply the pathloss correction.
     source_type : str or None, optional
         Force processing using the specified source type.
-    correction_pars : dict or None, optional
-        Correction parameters to use instead of recalculation.
     user_slit_loc : float, optional
         User-provided slit location in units of arcsec, where (0,0)
         is the center and the edges are +/-0.255 arcsec.
+    return_corrections : bool, optional
+        If True, a model containing the applied corrections is returned.
 
     Returns
     -------
-    input_model, corrections : tuple of `~stdatamodels.jwst.datamodels.JwstDataModel`
-        2-tuple of the corrected science data with pathloss extensions added, and a
-        model of the correction arrays.
+    input_model: `~stdatamodels.jwst.datamodels.JwstDataModel`
+        The corrected science data with pathloss extensions added.
+    corrections: `~stdatamodels.jwst.datamodels.JwstDataModel`, optional
+        A model of the correction arrays, returned if ``return_corrections``
+        is True.
     """
-    if not pathloss_model and not correction_pars:
-        raise RuntimeError(
-            "Neither a PathLossModel nor PathLossStep correction parameters given."
-            " One needs to be specified."
-        )
+    if not pathloss_model:
+        raise RuntimeError("A PathlossModel must be specified.")
     exp_type = input_model.meta.exposure.type
     log.info(f"Input exposure type is {exp_type}")
 
     corrections = None
     if exp_type == "NRS_MSASPEC":
-        corrections = do_correction_mos(
-            input_model, pathloss_model, inverse, source_type, correction_pars
-        )
+        corrections = do_correction_mos(input_model, pathloss_model, inverse, source_type)
     elif exp_type in ["NRS_FIXEDSLIT", "NRS_BRIGHTOBJ"]:
-        corrections = do_correction_fixedslit(
-            input_model, pathloss_model, inverse, source_type, correction_pars
-        )
+        corrections = do_correction_fixedslit(input_model, pathloss_model, inverse, source_type)
     elif exp_type == "NRS_IFU":
-        corrections = do_correction_ifu(
-            input_model, pathloss_model, inverse, source_type, correction_pars
-        )
+        corrections = do_correction_ifu(input_model, pathloss_model, inverse, source_type)
     elif exp_type in ["MIR_LRS-FIXEDSLIT", "MIR_WFSS"]:
         # only apply correction to LRS fixed-slit if target is point source
         if is_pointsource(input_model.meta.target.source_type):
@@ -447,10 +440,7 @@ def do_correction(
             log.warning("Not a point source; skipping correction for LRS.")
             input_model.meta.cal_step.pathloss = "SKIPPED"
     elif exp_type == "NIS_SOSS":
-        if correction_pars:
-            log.warning("Use of correction_pars with NIS_SOSS is not implemented. Skipping")
-            input_model.meta.cal_step.pathloss = "SKIPPED"
-        elif inverse:
+        if inverse:
             log.warning("Use of inversion with NIS_SOSS is not implemented. Skipping")
             input_model.meta.cal_step.pathloss = "SKIPPED"
         elif source_type is not None:
@@ -459,7 +449,10 @@ def do_correction(
         else:
             do_correction_soss(input_model, pathloss_model)
 
-    return input_model, corrections
+    if return_corrections:
+        return input_model, corrections
+    else:
+        return input_model
 
 
 def interpolate_onto_grid(wavelength_grid, wavelength_vector, pathloss_vector):
@@ -554,7 +547,7 @@ def is_pointsource(srctype):
         return False
 
 
-def do_correction_mos(data, pathloss, inverse=False, source_type=None, correction_pars=None):
+def do_correction_mos(data, pathloss, inverse=False, source_type=None):
     """
     Path loss correction for NIRSpec MOS.
 
@@ -574,9 +567,6 @@ def do_correction_mos(data, pathloss, inverse=False, source_type=None, correctio
     source_type : str or None
         Force processing using the specified source type.
 
-    correction_pars : jwst.datamodels.MultiSlitModel or None
-        The precomputed pathloss to apply instead of recalculation.
-
     Returns
     -------
     corrections : jwst.datamodels.MultiSlitModel
@@ -590,10 +580,7 @@ def do_correction_mos(data, pathloss, inverse=False, source_type=None, correctio
     for slit_number, slit in enumerate(data.slits):
         log.info(f"Working on slit {slit_number}")
 
-        if correction_pars:
-            correction = correction_pars.slits[slit_number]
-        else:
-            correction = _corrections_for_mos(slit, pathloss, exp_type, source_type)
+        correction = _corrections_for_mos(slit, pathloss, exp_type, source_type)
         corrections.slits.append(correction)
 
         # Apply the correction
@@ -632,7 +619,7 @@ def do_correction_mos(data, pathloss, inverse=False, source_type=None, correctio
     return corrections
 
 
-def do_correction_fixedslit(data, pathloss, inverse=False, source_type=None, correction_pars=None):
+def do_correction_fixedslit(data, pathloss, inverse=False, source_type=None):
     """
     Path loss correction for NIRSpec fixed-slit modes.
 
@@ -652,9 +639,6 @@ def do_correction_fixedslit(data, pathloss, inverse=False, source_type=None, cor
     source_type : str or None
         Force processing using the specified source type.
 
-    correction_pars : jwst.datamodels.MultiSlitModel or None
-        The precomputed pathloss to apply instead of recalculation.
-
     Returns
     -------
     corrections : jwst.datamodels.MultiSlitModel
@@ -668,10 +652,7 @@ def do_correction_fixedslit(data, pathloss, inverse=False, source_type=None, cor
     for slit_number, slit in enumerate(data.slits):
         log.info(f"Working on slit {slit.name}")
 
-        if correction_pars:
-            correction = correction_pars.slits[slit_number]
-        else:
-            correction = _corrections_for_fixedslit(slit, pathloss, exp_type, source_type)
+        correction = _corrections_for_fixedslit(slit, pathloss, exp_type, source_type)
         corrections.slits.append(correction)
 
         # Apply the correction
@@ -715,7 +696,7 @@ def do_correction_fixedslit(data, pathloss, inverse=False, source_type=None, cor
     return corrections
 
 
-def do_correction_ifu(data, pathloss, inverse=False, source_type=None, correction_pars=None):
+def do_correction_ifu(data, pathloss, inverse=False, source_type=None):
     """
     Path loss correction for NIRSpec IFU.
 
@@ -735,18 +716,12 @@ def do_correction_ifu(data, pathloss, inverse=False, source_type=None, correctio
     source_type : str or None
         Force processing using the specified source type.
 
-    correction_pars : jwst.datamodels.JwstDataModel or None
-        The precomputed pathloss to apply instead of recalculation.
-
     Returns
     -------
     corrections : jwst.datamodels.JwstDataModel
         The pathloss corrections applied.
     """
-    if correction_pars:
-        correction = correction_pars
-    else:
-        correction = _corrections_for_ifu(data, pathloss, source_type)
+    correction = _corrections_for_ifu(data, pathloss, source_type)
 
     # For IFU, the pathloss correction type is not stored in the model.
     # Just log it here.

--- a/jwst/pathloss/pathloss_step.py
+++ b/jwst/pathloss/pathloss_step.py
@@ -45,37 +45,31 @@ class PathLossStep(Step):
         # Open the input data model
         output_model = self.prepare_output(input_data)
 
-        if self.use_correction_pars:
-            correction_pars = self.correction_pars
-            pathloss_model = None
+        # Get the name of the pathloss reference file to use
+        pathloss_name = self.get_reference_file(output_model, "pathloss")
+        log.info(f"Using PATHLOSS reference file {pathloss_name}")
+
+        # Check for a valid reference file
+        if pathloss_name == "N/A":
+            log.warning("No PATHLOSS reference file found")
+            log.warning("Pathloss step will be skipped")
+            output_model.meta.cal_step.pathloss = "SKIPPED"
+            return output_model
+
+        # Open the pathloss ref file data model
+        if output_model.meta.exposure.type.upper() in ["MIR_LRS-FIXEDSLIT", "MIR_WFSS"]:
+            pathloss_model = datamodels.MirLrsPathlossModel(pathloss_name)
         else:
-            correction_pars = None
-
-            # Get the name of the pathloss reference file to use
-            pathloss_name = self.get_reference_file(output_model, "pathloss")
-            log.info(f"Using PATHLOSS reference file {pathloss_name}")
-
-            # Check for a valid reference file
-            if pathloss_name == "N/A":
-                log.warning("No PATHLOSS reference file found")
-                log.warning("Pathloss step will be skipped")
-                output_model.meta.cal_step.pathloss = "SKIPPED"
-                return output_model
-
-            # Open the pathloss ref file data model
-            if output_model.meta.exposure.type.upper() in ["MIR_LRS-FIXEDSLIT", "MIR_WFSS"]:
-                pathloss_model = datamodels.MirLrsPathlossModel(pathloss_name)
-            else:
-                pathloss_model = datamodels.PathlossModel(pathloss_name)
+            pathloss_model = datamodels.PathlossModel(pathloss_name)
 
         # Do the pathloss correction
-        output_model, self.correction_pars = pathloss.do_correction(
+        output_model = pathloss.do_correction(
             output_model,
             pathloss_model,
             inverse=self.inverse,
             source_type=self.source_type,
-            correction_pars=correction_pars,
             user_slit_loc=self.user_slit_loc,
+            return_corrections=False,
         )
 
         if pathloss_model:

--- a/jwst/pathloss/tests/test_pathloss.py
+++ b/jwst/pathloss/tests/test_pathloss.py
@@ -456,9 +456,7 @@ def test_do_correction_nis_soss_aperture_is_none():
     assert result.meta.cal_step.pathloss == "SKIPPED"
 
 
-@pytest.mark.parametrize(
-    "param,value", [("inverse", True), ("source_type", "POINT"), ("correction_pars", {1: 2})]
-)
+@pytest.mark.parametrize("param,value", [("inverse", True), ("source_type", "POINT")])
 def test_do_correction_nis_soss_unexpected_pars(caplog, param, value):
     """Skip correction for SOSS if unexpected parameters are provided."""
 
@@ -475,7 +473,7 @@ def test_do_correction_nis_soss_unexpected_pars(caplog, param, value):
 
 def test_do_correction_no_pathloss():
     model = ImageModel()
-    msg = "Neither a PathLossModel nor PathLossStep correction parameters given"
+    msg = "A PathlossModel must be specified"
     with pytest.raises(RuntimeError, match=msg):
         pl.do_correction(model)
 

--- a/jwst/pathloss/tests/test_pathloss_step.py
+++ b/jwst/pathloss/tests/test_pathloss_step.py
@@ -433,15 +433,13 @@ def test_pathloss_step_niriss_soss_pupil_out_of_range(niriss_soss_model):
 @pytest.mark.parametrize(
     "dataset", ["nirspec_fs_model_point", "nirspec_mos_model_point", "nirspec_ifu_model_point"]
 )
-def test_pathloss_correction_pars(request, dataset):
+def test_pathloss_inverse(request, dataset):
     model = request.getfixturevalue(dataset).copy()
     step = PathLossStep()
     result = step.run(model)
 
-    # use the computed correction and invert
+    # run again but invert
     new_step = PathLossStep()
-    new_step.use_correction_pars = True
-    new_step.correction_pars = step.correction_pars
     new_step.inverse = True
     inverse_result = new_step.run(result)
 

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -101,7 +101,6 @@ class DataSet:
         inverse=False,
         source_type=None,
         apply_time_correction=True,
-        correction_pars=None,
     ):
         """
         Instantiate a DataSet object.
@@ -116,41 +115,33 @@ class DataSet:
             Force processing using the specified source type.
         apply_time_correction : bool
             Switch to apply/not apply a time correction, if available.
-        correction_pars : dict
-            Correction meta-data from a previous run.
         """
         # Set up attributes necessary for calculation.
-        if correction_pars:
-            self.update(correction_pars["dataset"])
-        else:
-            self.band = None
-            if model.meta.instrument.band is not None:
-                self.band = model.meta.instrument.band.upper()
-            self.instrument = model.meta.instrument.name.upper()
-            self.detector = model.meta.instrument.detector.upper()
-            self.exptype = model.meta.exposure.type.upper()
-            self.filter = None
-            if model.meta.instrument.filter is not None:
-                self.filter = model.meta.instrument.filter.upper()
-            self.grating = None
-            if model.meta.instrument.grating is not None:
-                self.grating = model.meta.instrument.grating.upper()
-            self.order = None
-            if (
-                model.meta.hasattr("wcsinfo")
-                and model.meta.wcsinfo.hasattr("spectral_order")
-                and model.meta.wcsinfo.spectral_order is not None
-            ):
-                self.order = model.meta.wcsinfo.spectral_order
-            self.pupil = None
-            if model.meta.instrument.pupil is not None:
-                self.pupil = model.meta.instrument.pupil.upper()
-            self.subarray = None
-            if model.meta.subarray.name is not None:
-                self.subarray = model.meta.subarray.name.upper()
-            correction_pars = {}
-        correction_pars["dataset"] = self.attributes
-        self.correction_pars = correction_pars
+        self.band = None
+        if model.meta.instrument.band is not None:
+            self.band = model.meta.instrument.band.upper()
+        self.instrument = model.meta.instrument.name.upper()
+        self.detector = model.meta.instrument.detector.upper()
+        self.exptype = model.meta.exposure.type.upper()
+        self.filter = None
+        if model.meta.instrument.filter is not None:
+            self.filter = model.meta.instrument.filter.upper()
+        self.grating = None
+        if model.meta.instrument.grating is not None:
+            self.grating = model.meta.instrument.grating.upper()
+        self.order = None
+        if (
+            model.meta.hasattr("wcsinfo")
+            and model.meta.wcsinfo.hasattr("spectral_order")
+            and model.meta.wcsinfo.spectral_order is not None
+        ):
+            self.order = model.meta.wcsinfo.spectral_order
+        self.pupil = None
+        if model.meta.instrument.pupil is not None:
+            self.pupil = model.meta.instrument.pupil.upper()
+        self.subarray = None
+        if model.meta.subarray.name is not None:
+            self.subarray = model.meta.subarray.name.upper()
 
         # Initialize other non-correction pars attributes.
         self.slitnum = -1
@@ -194,37 +185,6 @@ class DataSet:
             log.info(" grating: %s", self.grating)
         if self.band is not None:
             log.info(" band: %s", self.band)
-
-    @property
-    def attributes(self):
-        """
-        Retrieve DataSet attributes.
-
-        Returns
-        -------
-        attributes : dict
-            A dict of `DataSet` attributes.
-        """
-        attributes = vars(self)
-
-        # Remove some attributes
-        for attribute in ["correction_pars", "input", "inverse", "slitnum", "source_type"]:
-            if attribute in attributes:
-                del attributes[attribute]
-
-        return attributes
-
-    def update(self, attributes):
-        """
-        Set DataSet attributes.
-
-        Parameters
-        ----------
-        attributes : dict
-            The attributes to be set on DataSet.
-        """
-        for key, value in attributes.items():
-            setattr(self, key, value)
 
     def calc_nirspec(self, ftab, area_fname):
         """

--- a/jwst/photom/photom_step.py
+++ b/jwst/photom/photom_step.py
@@ -65,15 +65,8 @@ class PhotomStep(Step):
 
         # Setup reference files and whether previous correction information
         # should be used.
-        if self.use_correction_pars and self.correction_pars:
-            log.info("Using previously specified correction parameters.")
-            correction_pars = self.correction_pars
-            phot_filename = correction_pars["refs"]["photom"]
-            area_filename = correction_pars["refs"]["area"]
-        else:
-            correction_pars = None
-            phot_filename = self.get_reference_file(output_model, "photom")
-            area_filename = self.get_reference_file(output_model, "area")
+        phot_filename = self.get_reference_file(output_model, "photom")
+        area_filename = self.get_reference_file(output_model, "area")
 
         log.info("Using photom reference file: %s", phot_filename)
         log.info("Using area reference file: %s", area_filename)
@@ -92,12 +85,9 @@ class PhotomStep(Step):
                 self.inverse,
                 self.source_type,
                 self.apply_time_correction,
-                correction_pars,
             )
             result = phot.apply_photom(phot_filename, area_filename)
             result.meta.cal_step.photom = "COMPLETE"
-            self.correction_pars = phot.correction_pars
-            self.correction_pars["refs"] = {"photom": phot_filename, "area": area_filename}
 
         except photom.DataModelTypeError:
             # should trip e.g. for NIRISS SOSS data in FULL subarray

--- a/jwst/photom/tests/test_photom_step.py
+++ b/jwst/photom/tests/test_photom_step.py
@@ -84,7 +84,7 @@ def test_photom_fail(caplog):
     cube.close()
 
 
-def test_photom_correction_pars(input_model):
+def test_photom_inverse(input_model):
     step = PhotomStep()
     result = step.run(input_model)
 
@@ -92,10 +92,8 @@ def test_photom_correction_pars(input_model):
     nnan = ~np.isnan(input_model.slits[0].data) & ~np.isnan(result.slits[0].data)
     assert not np.allclose(result.slits[0].data[nnan], input_model.slits[0].data[nnan])
 
-    # use the computed correction and invert
+    # run again but invert
     new_step = PhotomStep()
-    new_step.use_correction_pars = True
-    new_step.correction_pars = step.correction_pars
     new_step.inverse = True
     inverse_result = new_step.run(result)
 

--- a/jwst/regtest/test_nirspec_fs_spec2.py
+++ b/jwst/regtest/test_nirspec_fs_spec2.py
@@ -201,24 +201,6 @@ def test_nirspec_fs_spec2_pixel_replace(
     assert diff.identical, diff.report()
 
 
-def test_pathloss_corrpars(rtdata):
-    """Test PathLossStep using correction_pars"""
-    basename = "jw02072002001_05101_00001_nrs1_flatfieldstep"
-    with dm.open(rtdata.get_data(f"nirspec/fs/{basename}.fits")) as data:
-        pls = PathLossStep()
-        corrected = pls.run(data)
-
-        pls.use_correction_pars = True
-        corrected_corrpars = pls.run(data)
-
-    bad_slits = []
-    for idx, slits in enumerate(zip(corrected.slits, corrected_corrpars.slits)):
-        corrected_slit, corrected_corrpars_slit = slits
-        if not np.allclose(corrected_slit.data, corrected_corrpars_slit.data, equal_nan=True):
-            bad_slits.append(idx)
-    assert not bad_slits, f"correction_pars failed for slits {bad_slits}"
-
-
 def test_pathloss_inverse(rtdata):
     """Test PathLossStep using inversion"""
     basename = "jw02072002001_05101_00001_nrs1_flatfieldstep"
@@ -237,22 +219,6 @@ def test_pathloss_inverse(rtdata):
                 bad_slits.append(idx)
 
     assert not bad_slits, f"Inversion failed for slits {bad_slits}"
-
-
-def test_pathloss_source_type(rtdata):
-    """Test PathLossStep forcing source type"""
-    basename = "jw02072002001_05101_00001_nrs1_flatfieldstep"
-    with dm.open(rtdata.get_data(f"nirspec/fs/{basename}.fits")) as data:
-        pls = PathLossStep()
-        pls.source_type = "extended"
-        pls.run(data)
-
-    bad_slits = []
-    for idx, slit in enumerate(pls.correction_pars.slits):
-        if slit:
-            if not np.allclose(slit.data, slit.pathloss_uniform, equal_nan=True):
-                bad_slits.append(idx)
-    assert not bad_slits, f"Force to uniform failed for slits {bad_slits}"
 
 
 def test_nirspec_fs_rateints_spec2(rtdata_module):

--- a/jwst/regtest/test_nirspec_image2.py
+++ b/jwst/regtest/test_nirspec_image2.py
@@ -53,27 +53,3 @@ def test_ff_inv(rtdata, fitsdiff_default_kwargs):
 
         # make sure NaNs are only at do_not_use pixels
         assert np.all(unflatted.dq[is_nan] & dm.dqflags.pixel["DO_NOT_USE"])
-
-
-@pytest.mark.bigdata
-def test_correction_pars(rtdata, fitsdiff_default_kwargs):
-    """Test use of correction parameters"""
-    input_file = "nirspec/imaging/jw03290001001_03101_00001_nrs2_assign_wcs.fits"
-    with dm.open(rtdata.get_data(input_file)) as data:
-        # First use of FlatFieldStep will store the correction.
-        # The next use will use that correction
-        step = FlatFieldStep()
-        flatted = step.run(data)
-        assert step.correction_pars["flat"] is not None
-
-        step.use_correction_pars = True
-        reflatted = step.run(data)
-
-        # flat fielding may set some new NaN values - ignore these in test
-        is_nan = np.isnan(reflatted.data)
-        assert np.allclose(flatted.data[~is_nan], reflatted.data[~is_nan]), (
-            "Re-run with correction parameters failed"
-        )
-
-        # make sure NaNs are only at do_not_use pixels
-        assert np.all(reflatted.dq[is_nan] & dm.dqflags.pixel["DO_NOT_USE"])

--- a/jwst/regtest/test_nirspec_masterbackground.py
+++ b/jwst/regtest/test_nirspec_masterbackground.py
@@ -71,25 +71,6 @@ def test_masterbkg_rerun(rtdata):
     assert not bad_slits, f"rerun failed for slits {bad_slits}"
 
 
-def test_masterbkg_corrpars(rtdata):
-    """Test for correction parameters"""
-    with dm.open(
-        rtdata.get_data("nirspec/mos/jw01448011001_02101_00001_nrs2_srctype.fits")
-    ) as data:
-        mbs = MasterBackgroundMosStep()
-        corrected = mbs.run(data)
-
-        mbs.use_correction_pars = True
-        corrected_corrpars = mbs.run(data)
-
-    bad_slits = []
-    for idx, slits in enumerate(zip(corrected.slits, corrected_corrpars.slits)):
-        corrected_slit, corrected_corrpars_slit = slits
-        if not np.allclose(corrected_slit.data, corrected_corrpars_slit.data, equal_nan=True):
-            bad_slits.append(idx)
-    assert not bad_slits, f"correction_pars failed for slits {bad_slits}"
-
-
 @pytest.mark.parametrize("suffix", ["masterbg1d", "masterbg2d", "bkgx1d", "cal", "s2d", "x1d"])
 def test_nirspec_mos_mbkg(suffix, run_spec2_mbkg, fitsdiff_default_kwargs):
     """Run spec2 with master background"""

--- a/jwst/regtest/test_nirspec_mos_spec2_steps.py
+++ b/jwst/regtest/test_nirspec_mos_spec2_steps.py
@@ -56,26 +56,6 @@ def test_ff_inv(rtdata, fitsdiff_default_kwargs):
 
 
 @pytest.mark.bigdata
-def test_pathloss_corrpars(rtdata):
-    """Test PathLossStep using correction_pars"""
-    with dm.open(
-        rtdata.get_data("nirspec/mos/jw01345066001_05101_00001_nrs1_wavecorr.fits")
-    ) as data:
-        pls = PathLossStep()
-        corrected = pls.run(data)
-
-        pls.use_correction_pars = True
-        corrected_corrpars = pls.run(data)
-
-    bad_slits = []
-    for idx, slits in enumerate(zip(corrected.slits, corrected_corrpars.slits)):
-        corrected_slit, corrected_corrpars_slit = slits
-        if not np.allclose(corrected_slit.data, corrected_corrpars_slit.data, equal_nan=True):
-            bad_slits.append(idx)
-    assert not bad_slits, f"correction_pars failed for slits {bad_slits}"
-
-
-@pytest.mark.bigdata
 def test_pathloss_inverse(rtdata):
     """Test PathLossStep using inversion"""
     with dm.open(
@@ -95,44 +75,6 @@ def test_pathloss_inverse(rtdata):
                 bad_slits.append(idx)
 
     assert not bad_slits, f"Inversion failed for slits {bad_slits}"
-
-
-@pytest.mark.bigdata
-def test_pathloss_source_type(rtdata):
-    """Test PathLossStep forcing source type"""
-    with dm.open(
-        rtdata.get_data("nirspec/mos/jw01345066001_05101_00001_nrs1_wavecorr.fits")
-    ) as data:
-        pls = PathLossStep()
-        pls.source_type = "extended"
-        pls.run(data)
-
-    bad_slits = []
-    for idx, slit in enumerate(pls.correction_pars.slits):
-        if slit:
-            if not np.allclose(slit.data, slit.pathloss_uniform, equal_nan=True):
-                bad_slits.append(idx)
-    assert not bad_slits, f"Force to uniform failed for slits {bad_slits}"
-
-
-@pytest.mark.bigdata
-def test_barshadow_corrpars(rtdata):
-    """BarShadowStep using correction_pars"""
-    with dm.open(
-        rtdata.get_data("nirspec/mos/jw01345066001_05101_00001_nrs1_wavecorr.fits")
-    ) as data:
-        pls = BarShadowStep()
-        corrected = pls.run(data)
-
-        pls.use_correction_pars = True
-        corrected_corrpars = pls.run(data)
-
-    bad_slits = []
-    for idx, slits in enumerate(zip(corrected.slits, corrected_corrpars.slits)):
-        corrected_slit, corrected_corrpars_slit = slits
-        if not np.allclose(corrected_slit.data, corrected_corrpars_slit.data, equal_nan=True):
-            bad_slits.append(idx)
-    assert not bad_slits, f"correction_pars failed for slits {bad_slits}"
 
 
 @pytest.mark.bigdata
@@ -172,26 +114,6 @@ def test_barshadow_source_type(rtdata):
         if np.allclose(slit.barshadow, np.ones(slit.data.shape), equal_nan=True):
             bad_slits.append(idx)
     assert not bad_slits, f"Force to uniform failed for slits {bad_slits}"
-
-
-@pytest.mark.bigdata
-def test_photom_corrpars(rtdata):
-    """Test for photom correction parameters"""
-    with dm.open(
-        rtdata.get_data("nirspec/mos/jw01345066001_05101_00001_nrs1_wavecorr.fits")
-    ) as data:
-        pls = PhotomStep()
-        corrected = pls.run(data)
-
-        pls.use_correction_pars = True
-        corrected_corrpars = pls.run(data)
-
-    bad_slits = []
-    for idx, slits in enumerate(zip(corrected.slits, corrected_corrpars.slits)):
-        corrected_slit, corrected_corrpars_slit = slits
-        if not np.allclose(corrected_slit.data, corrected_corrpars_slit.data, equal_nan=True):
-            bad_slits.append(idx)
-    assert not bad_slits, f"correction_pars failed for slits {bad_slits}"
 
 
 @pytest.mark.bigdata

--- a/jwst/regtest/test_nirspec_steps_spec2.py
+++ b/jwst/regtest/test_nirspec_steps_spec2.py
@@ -83,24 +83,8 @@ def test_ff_inv(rtdata, fitsdiff_default_kwargs):
 
 @pytest.mark.slow
 @pytest.mark.bigdata
-def test_pathloss_corrpars(rtdata):
-    """Test PathLossStep using correction_pars"""
-    with dm.open(
-        rtdata.get_data("nirspec/ifu/jw01251004001_03107_00001_nrs1_flat_field.fits")
-    ) as data:
-        pls = PathLossStep()
-        corrected = pls.run(data)
-
-        pls.use_correction_pars = True
-        corrected_corrpars = pls.run(data)
-
-    assert np.allclose(corrected.data, corrected_corrpars.data, equal_nan=True)
-
-
-@pytest.mark.slow
-@pytest.mark.bigdata
 def test_pathloss_inverse(rtdata):
-    """Test PathLossStep using correction_pars"""
+    """Test PathLossStep inversion"""
     with dm.open(
         rtdata.get_data("nirspec/ifu/jw01251004001_03107_00001_nrs1_flat_field.fits")
     ) as data:
@@ -112,19 +96,3 @@ def test_pathloss_inverse(rtdata):
         non_nan = ~np.isnan(corrected_inverse.data)
 
     assert np.allclose(corrected.data[non_nan], corrected_inverse.data[non_nan])
-
-
-@pytest.mark.slow
-@pytest.mark.bigdata
-def test_pathloss_source_type(rtdata):
-    """Test PathLossStep forcing source type"""
-    with dm.open(
-        rtdata.get_data("nirspec/ifu/jw01251004001_03107_00001_nrs1_flat_field.fits")
-    ) as data:
-        pls = PathLossStep()
-        pls.source_type = "extended"
-        pls.run(data)
-
-    assert np.allclose(
-        pls.correction_pars.data, pls.correction_pars.pathloss_uniform, equal_nan=True
-    )


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4224](https://jira.stsci.edu/browse/JP-4224)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Remove unnecessary storage of correction models as an attribute on the following steps: flat_field, pathloss, barshadow, photom, and master_background_mos.

Just recomputing the corrections instead of storing them only adds a small amount of processing time to the master_background_mos step (~4s running the regtest example locally), but it improves peak memory use in stage 2 for all modes that use these steps.

Discussion still needed about whether we need to deprecate these attributes.  So far, I have just removed them, but I can add deprecation support back in.

~This PR is built on top of #10421, since they touch the same step and the additional unit test coverage was useful here.  I can separate them out if need be.~ (those changes have been merged; this PR is rebased)

Initial regression tests here:
https://github.com/spacetelescope/RegressionTests/actions/runs/24090988005
There is one header diff for master background MOS processing, because the interpolated flat is recreated instead of provided as a custom reference file. I think the existing value was misleading anyway.  Also shows memory improvements above the threshold for NIRCam imaging and spectra as well as NIRISS SOSS.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [x] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
