### PR TITLE
JP-4129: Allow run to accept kwargs (Capture pre-pipeline CRDS checks in ASDF log)

### DIFF
--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -356,21 +356,24 @@ class JwstStep(_Step):
         """
         return remove_suffix(name)
 
-    def run(self, *args):
+    def run(self, *args, **kwargs):
         """
         Run the step.
 
         Parameters
         ----------
-        *args
-            Arguments passed to `stpipe.Step.run`.
+        *args : tuple
+            Positional arguments passed to :meth:`stpipe.Step.run`.
+
+        **kwargs : dict
+            Keyword arguments passed to :meth:`stpipe.Step.run`.
 
         Returns
         -------
         result : Any
             The step output
         """
-        result = super().run(*args)
+        result = super().run(*args, **kwargs)
         if not self.parent:
             log.info(f"Results used jwst version: {__version__}")
         return result


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4129](https://jira.stsci.edu/browse/JP-4129)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR addresses #9864 if we choose to go with:

* https://github.com/spacetelescope/stpipe/pull/309

Since the actual fix is upstream and upstream PR already have a change log, probably no need for change log here?

While this change is backward compatible, it would also be meaningless if we reject spacetelescope/stpipe#309 and also this reverts some of https://github.com/spacetelescope/jwst/pull/9878

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
