### PR TITLE
JP-4322: Wrap average RA to 0-360

### DIFF
--- a/changes/10457.cube_build.rst
+++ b/changes/10457.cube_build.rst
@@ -1,0 +1,1 @@
+Wrap average RA values to the 0-360 degree range, to fix negative CRVAL1 values in output cubes.

--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -340,7 +340,7 @@ class IFUCubeData:
 
         # astropy circmean assumes angles are in radians,
         # we have angles in degrees
-        ra_ave = circmean(ravalues * u.deg).value
+        ra_ave = circmean(ravalues * u.deg).value % 360
 
         if self.ra_center is not None:
             self.crval1 = self.ra_center

--- a/jwst/cube_build/tests/test_cube_build_step.py
+++ b/jwst/cube_build/tests/test_cube_build_step.py
@@ -7,6 +7,7 @@ import os
 import numpy as np
 import pytest
 from astropy.io import fits
+from astropy.modeling.models import Identity, Shift
 from stdatamodels.jwst.datamodels import IFUImageModel
 
 from jwst.adaptive_trace_model import AdaptiveTraceModelStep
@@ -271,3 +272,22 @@ def test_cube_build_oversampled(request, oversample, dataset, output_shape):
 
     # Input data is flat, so output data should have the same mean value
     np.testing.assert_allclose(np.nanmean(cube.data), np.nanmean(model.data))
+
+
+@pytest.mark.parametrize("shift_ra", [True, False])
+def test_output_crval1_positive(miri_data, shift_ra):
+    model = miri_data.copy()
+
+    expected_ra = 164
+    if shift_ra:
+        # Shift RA by 100 degrees to make it > 180
+        model.meta.wcs.pipeline[-2].transform |= Shift(100) & Identity(2)
+        model.meta.wcsinfo.ra_ref += 100
+        model.meta.wcsinfo.s_region = model.meta.wcsinfo.s_region.replace("164", "264")
+        expected_ra += 100
+
+    result = CubeBuildStep.call(model)
+
+    # Output RA should be between 0 and 360
+    for cube in result:
+        assert np.isclose(cube.meta.wcsinfo.crval1, expected_ra, atol=1)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4322](https://jira.stsci.edu/browse/JP-4322)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Wrap mean RA values into the 0-360 degree range to make sure recorded CRVAL1 values are not negative.

Testing locally, this change seems to make a small difference to output cubes.  The most significant differences are near the spatial edges of the cube, so I expect the differences are precision/threshold related.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [x] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
