### PR TITLE
Fix cube_build memory leak: add missing reference decrements for x_det and y_det

### DIFF
--- a/changes/10474.cube_build.rst
+++ b/changes/10474.cube_build.rst
@@ -1,0 +1,1 @@
+Fix memory leak by adding missing reference decrements for x_det and y_det.

--- a/jwst/cube_build/src/cube_match_sky_driz.c
+++ b/jwst/cube_build/src/cube_match_sky_driz.c
@@ -642,6 +642,12 @@ cleanup:
     if (free_flux) {
         Py_XDECREF(flux);
     }
+    if (free_x_det) {
+        Py_XDECREF(x_det);
+    }
+    if (free_y_det) {
+        Py_XDECREF(y_det);
+    }
     if (free_err) {
         Py_XDECREF(err);
     }


### PR DESCRIPTION
While looking at regtest memory usage I found that some allocated memory within cube build was not being freed.

Taking one example `test_miri_mrs_spec3.py` I set a breakpoint just prior to `cube_wrapper_driz`: https://github.com/spacetelescope/jwst/blob/f3ce1b112eb39a4af01f311f76c76ba169f78966/jwst/cube_build/ifu_cube.py#L824
and wrote the arguments to an ASDF file. Rerunning this command several (10) times shows the leak:
<img width="1103" height="361" alt="Screenshot 2026-04-21 at 10 44 39 AM" src="https://github.com/user-attachments/assets/a349b7dc-3ba9-4895-9647-f1de0e2a4f30" />
(note the stair-step memory increase at the end of the graph).

With this PR and the same test the leak is removed:
<img width="1095" height="360" alt="Screenshot 2026-04-21 at 10 46 07 AM" src="https://github.com/user-attachments/assets/6563055b-4179-4350-8e25-807ded537604" />

Script, ASDF file and flamegraph files are available at: /grp/roman/scsb/bgraham/projects/260421_cube_build_leak/

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/24728542017

When I first saw the leak I asked copilot to find leaks in the file and this is one of the issues it reported. It also mentioned issues that could occur due to the 2 teardown paths (cleanup, failure) depending on when the path was taken and suggested merging them.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
