### PR TITLE
JP-4333: Updating the calweb_detector1 Documentation for the Calibrated 'ramp' File

### DIFF
--- a/docs/jwst/pipeline/calwebb_detector1.rst
+++ b/docs/jwst/pipeline/calwebb_detector1.rst
@@ -101,7 +101,7 @@ The ``calwebb_detector1`` pipeline has one optional argument::
   --save_calibrated_ramp  boolean  default=False
 
 If set to ``True``, the pipeline will save intermediate data to a file as it
-exists at the end of the :ref:`jump <jump_step>` step. The data
+exists just before entering the :ref:`ramp fitting <ramp_fitting>` step. The data
 at this stage of the pipeline are still in the form of the original 4D ramps
 (ncols x nrows x ngroups x nints) and have had all of the detector-level
 correction steps applied to it, including the detection and flagging of

--- a/docs/jwst/pipeline/calwebb_detector1.rst
+++ b/docs/jwst/pipeline/calwebb_detector1.rst
@@ -101,7 +101,7 @@ The ``calwebb_detector1`` pipeline has one optional argument::
   --save_calibrated_ramp  boolean  default=False
 
 If set to ``True``, the pipeline will save intermediate data to a file as it
-exists just before entering the :ref:`ramp fitting <ramp_fitting>` step. The data
+exists just before entering the :ref:`ramp fitting <ramp_fitting_step>` step. The data
 at this stage of the pipeline are still in the form of the original 4D ramps
 (ncols x nrows x ngroups x nints) and have had all of the detector-level
 correction steps applied to it, including the detection and flagging of


### PR DESCRIPTION
…ation in the pipeline steps where the calibrated 'ramp' file gets saved.

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4333](https://jira.stsci.edu/browse/JP-4333)

<!-- describe the changes comprising this PR here -->
This PR updates where in the `calweb_detector` pipeline, with respect to the steps in the pipeline, where the calibrated `ramp` file gets saved. Originally, the ramp fitting step happened immediately after the jump step, so the documentation specified the calibrated `ramp` file got saved right after the jump step. The pipeline has been modified, so there is now another step between the jump and ramp fitting step. The documentation has been updated to reflect that the calibrated `ramp` file is save just before the ramp fitting step.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
