### PR TITLE
JP-4340: Add refpix DQ plane to soss background mask

### DIFF
--- a/changes/10490.background.rst
+++ b/changes/10490.background.rst
@@ -1,0 +1,1 @@
+Fix a bug that included reference pixel values in the SOSS background threshold mask generation.

--- a/changes/10490.bkg_subtract.rst
+++ b/changes/10490.bkg_subtract.rst
@@ -1,0 +1,1 @@
+Fix a bug that included reference pixel values in the SOSS background threshold mask generation.

--- a/changes/10490.bkg_subtract.rst
+++ b/changes/10490.bkg_subtract.rst
@@ -1,1 +1,0 @@
-Fix a bug that included reference pixel values in the SOSS background threshold mask generation.

--- a/jwst/background/background_sub_soss.py
+++ b/jwst/background/background_sub_soss.py
@@ -154,12 +154,15 @@ def subtract_soss_bkg(
         )
         return None
 
-    # Generate exclusion mask from data array flux threshold, then OR in the DNU dq plane.
-    finite_data = np.isfinite(input_model.data)  # Ensure only finite values are considered
-    threshold = np.nanpercentile(input_model.data[finite_data], soss_source_percentile)
+    # Generate mask from DQ flags indicating pixels not to be considered.
+    flags = datamodels.dqflags.pixel["DO_NOT_USE"] | datamodels.dqflags.pixel["REFERENCE_PIXEL"]
+    flag_mask = (input_model.dq & flags) > 0
 
-    data_mask = finite_data & (input_model.data >= threshold)
-    data_mask |= (input_model.dq & 1) > 0
+    # Gather all finite science pixels
+    finite_data = np.isfinite(input_model.data) & ~flag_mask
+    # Use finite science pixels to generate mask excluding those above a threshold
+    threshold = np.nanpercentile(input_model.data[finite_data], soss_source_percentile)
+    data_mask = finite_data & (input_model.data >= threshold) | flag_mask
 
     # Most SOSS data will be multi-integration - but if input data array is 2-D, cast into
     # 3-D array for ease of computation


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4340](https://jira.stsci.edu/browse/JP-4340)

<!-- describe the changes comprising this PR here -->
This PR removes reference pixels from consideration during fitting and scaling of the SOSS background templates.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
