### PR TITLE
JP-4289: Ref never matches sci for superstripe

### DIFF
--- a/jwst/dq_init/dq_initialization.py
+++ b/jwst/dq_init/dq_initialization.py
@@ -39,7 +39,6 @@ def do_dqinit(output_model, mask_model, user_dq=None):
     check_dimensions(output_model)
 
     # Extract subarray from reference data, if necessary
-    # TODO: is it possible for stripe mask to match the input model? If so, this will fail.
     if reffile_utils.ref_matches_sci(output_model, mask_model):
         mask_array = mask_model.dq
     else:

--- a/jwst/lib/reffile_utils.py
+++ b/jwst/lib/reffile_utils.py
@@ -79,6 +79,13 @@ def ref_matches_sci(sci_model, ref_model):
         `True` if the science model has the same subarray parameters
         as the reference model, `False` otherwise.
     """
+    # Check first for superstripe data: it should never match the ref model.
+    # Reference files for superstripe ramps are handled directly by
+    # get_multistripe_subarray_model.
+    nstripe = getattr(sci_model.meta.subarray, "num_superstripe", None)
+    if nstripe is not None and nstripe > 0:
+        return False
+
     # Get the reference file subarray parameters
     xstart_ref = ref_model.meta.subarray.xstart
     xsize_ref = ref_model.meta.subarray.xsize

--- a/jwst/lib/tests/test_reffile_utils.py
+++ b/jwst/lib/tests/test_reffile_utils.py
@@ -7,6 +7,7 @@ from jwst.lib.reffile_utils import (
     find_row,
     generate_stripe_array,
     get_subarray_model,
+    ref_matches_sci,
     science_detector_frame_transform,
 )
 
@@ -343,3 +344,42 @@ def test_roundtrip(fastaxis, slowaxis):
     forward = science_detector_frame_transform(test_array.copy(), fastaxis, slowaxis)
     reverse = detector_science_frame_transform(forward.copy(), fastaxis, slowaxis)
     assert np.allclose(reverse, test_array)
+
+
+def test_ref_matches_sci_nircam_subarray():
+    # Mock subarray ramp
+    sub_meta = {
+        "name": "SUBGRISM256",
+        "fastaxis": -1,
+        "slowaxis": 2,
+        "xsize": 2048,
+        "xstart": 1,
+        "ysize": 256,
+        "ystart": 1,
+    }
+    mock_sci = RampModel(data=np.ones((5, 5, 256, 2048)))
+    mock_sci.meta.subarray = sub_meta
+
+    # Mock full size readnoise
+    mock_rn = ReadnoiseModel(data=np.ones((2048, 2048), dtype=int))
+    mock_rn.meta.instrument.name = "NIRCAM"
+    generate_test_refmodel_metadata(mock_rn)
+
+    # Does not match science
+    assert not ref_matches_sci(mock_sci, mock_rn)
+
+    # Mock subarray RN
+    mock_sub_rn = ReadnoiseModel(data=np.ones((256, 2048), dtype=int))
+    mock_sub_rn.meta.instrument.name = "NIRCAM"
+    generate_test_refmodel_metadata(mock_sub_rn)
+    mock_sub_rn.meta.subarray = sub_meta
+
+    # Does match science
+    assert ref_matches_sci(mock_sci, mock_sub_rn)
+
+    # Mock superstripe model without any other changes
+    # This is unrealistic, but sufficient to check the handling in this function.
+    mock_sci.meta.subarray.num_superstripe = 3
+
+    # Does not match science: superstripes always need special handling
+    assert not ref_matches_sci(mock_sci, mock_rn)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Toward [JP-4289](https://jira.stsci.edu/browse/JP-4289)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Address a question about whether reference data for superstripe models will ever match the subarray for the input data.

Right now, all superstripe ramps need special handling for the reference files.  The special handling is in the `get_multistripe_subarray_model` function, called via `get_subarray_model`, but in most places, `get_subarray_model` is only called if `ref_matches_sci` returns False.  

It's technically possible to provide a reference file with metadata that matches the subarray characteristics of a superstripe exposure. In this case, `ref_matches_sci` would return True, and `get_multistripe_subarray_model` would not be called, even though special handling is still needed to extract the parts of the subarray matching each stripe.

This PR just closes that loophole, so that `get_multistripe_subarray_model` is always called if superstripes are present (i.e. the input is a SuperstripeRampModel, in the first few steps of detector1).  The underlying stripe utilities might still need updating to handle reference files matching the subarray, but they are all expected to be full-frame now, so we can handle that complexity if the need arises later.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
