### PR TITLE
JP-4289: Handle zeroframe for superstripe exposures

### DIFF
--- a/changes/10494.refpix.rst
+++ b/changes/10494.refpix.rst
@@ -1,0 +1,1 @@
+Propagate a zeroframe array if present for superstripe modes.

--- a/changes/10494.superbias.rst
+++ b/changes/10494.superbias.rst
@@ -1,0 +1,1 @@
+Fix array indexing for zeroframe arrays with superstripe modes.

--- a/jwst/dq_init/tests/helpers.py
+++ b/jwst/dq_init/tests/helpers.py
@@ -194,9 +194,18 @@ def int_times_table(n_entry):
     return integration_table
 
 
-def make_superstripe_model(add_inttimes=False):
+def make_superstripe_model(add_inttimes=False, add_zeroframe=False):
     """
     Make a NIRISS SOSS superstripe raw ramp model.
+
+    Parameters
+    ----------
+    add_inttimes : bool, optional
+        If True, an `int_times` table will be attached to the output datamodel.
+    add_zeroframe : bool, optional
+        If True, a `zeroframe` array will be attached to the output datamodel.
+        In real data, the zeroframe is only used for NIRCam. It is attached to
+        this NIRISS model for testing convenience.
 
     Returns
     -------
@@ -235,6 +244,10 @@ def make_superstripe_model(add_inttimes=False):
 
     if add_inttimes:
         model.int_times = int_times_table(nints * nstripe)
+
+    if add_zeroframe:
+        model.meta.exposure.zero_frame = True
+        model.zeroframe = model.data[:, 0, :, :].copy()
 
     return model
 

--- a/jwst/lib/stripe_utils.py
+++ b/jwst/lib/stripe_utils.py
@@ -455,12 +455,15 @@ def collate_superstripes(input_model):
     sub_range = all_ranges["subarray"]
 
     # Initialize new array shapes in detector space
-    # TODO: add zeroframe handling
     newdata = np.full((nints_sci, ngroups, slow_size, fast_size), np.nan, dtype="float32")
     newgdq = np.full((nints_sci, ngroups, slow_size, fast_size), 0, dtype="uint8")
     newpdq = np.full(
         (slow_size, fast_size), datamodels.dqflags.pixel["REFERENCE_PIXEL"], dtype="uint32"
     )
+    if input_model.meta.exposure.zero_frame:
+        newzf = np.full((nints_sci, slow_size, fast_size), np.nan, dtype="float32")
+    else:
+        newzf = None
 
     # Transform old data to detector frame for indexing
     olddata = science_detector_frame_transform(input_model.data, fastaxis, slowaxis)
@@ -472,6 +475,14 @@ def collate_superstripes(input_model):
         oldpdq = None
     else:
         oldpdq = science_detector_frame_transform(input_model.pixeldq, fastaxis, slowaxis)
+    if (
+        newzf is None
+        or input_model.zeroframe is None
+        or input_model.zeroframe.shape != (nints, ny, nx)
+    ):
+        oldzf = None
+    else:
+        oldzf = science_detector_frame_transform(input_model.zeroframe, fastaxis, slowaxis)
 
     # Work through each set of stripes, pushing them into a common frame
     # Long term, there may be cases where stripes overlap.
@@ -501,15 +512,22 @@ def collate_superstripes(input_model):
                     else:
                         newpdq[f_reg[0] : f_reg[1], :] = oldpdq[stripe, s_reg[0] : s_reg[1]]
 
+                # Propagate zeroframe if present
+                if oldzf is not None:
+                    newzf[integ, f_reg[0] : f_reg[1], :] = oldzf[stripe_idx, s_reg[0] : s_reg[1], :]
+
     # Swap back to science frame
     newdata = detector_science_frame_transform(newdata, fastaxis, slowaxis)
     newgdq = detector_science_frame_transform(newgdq, fastaxis, slowaxis)
     newpdq = detector_science_frame_transform(newpdq, fastaxis, slowaxis)
+    if newzf is not None:
+        newzf = detector_science_frame_transform(newzf, fastaxis, slowaxis)
 
     new_model = datamodels.RampModel(
         data=newdata,
         groupdq=newgdq,
         pixeldq=newpdq,
+        zeroframe=newzf,
         int_times=input_model.int_times,
     )
     new_model.update(input_model)

--- a/jwst/lib/tests/test_stripe_utils.py
+++ b/jwst/lib/tests/test_stripe_utils.py
@@ -15,7 +15,7 @@ def substripe_model():
 
 @pytest.fixture(scope="module")
 def superstripe_model():
-    return make_superstripe_model(add_inttimes=True)
+    return make_superstripe_model(add_inttimes=True, add_zeroframe=True)
 
 
 @pytest.mark.parametrize("science_frame", [True, False])
@@ -528,12 +528,18 @@ def test_stripe_read_superstripe(superstripe_model):
 
 @pytest.mark.parametrize("with_dq", [True, False])
 @pytest.mark.parametrize("with_int_times", [True, False])
+@pytest.mark.parametrize("with_zeroframe", [True, False])
 @pytest.mark.parametrize("swap_axes", [True, False])
-def test_collate_superstripes(superstripe_model, with_dq, with_int_times, swap_axes):
+def test_collate_superstripes(
+    superstripe_model, with_dq, with_int_times, with_zeroframe, swap_axes
+):
     model = superstripe_model.copy()
 
     if not with_int_times:
         model.int_times = None
+    if not with_zeroframe:
+        model.meta.exposure.zero_frame = False
+        model.zeroframe = None
 
     if swap_axes:
         # transpose axes, use positive orientation
@@ -620,3 +626,8 @@ def test_collate_superstripes(superstripe_model, with_dq, with_int_times, swap_a
     else:
         assert collated.int_times is None
         assert collated.int_times_stripe is None
+
+    if with_zeroframe:
+        assert collated.zeroframe.shape == (nint_after, ny_after, nx_after)
+    else:
+        assert collated.zeroframe is None

--- a/jwst/refpix/tests/test_refpix.py
+++ b/jwst/refpix/tests/test_refpix.py
@@ -1266,7 +1266,7 @@ def test_refpix_bad_reference_pixels(monkeypatch, caplog):
 def test_refpix_superstripe(use_refpix, odd_even_columns):
     """Test superstripe handling."""
     # make ramp model
-    model = make_superstripe_model(add_inttimes=True)
+    model = make_superstripe_model(add_inttimes=True, add_zeroframe=True)
     nstripe = model.meta.subarray.num_superstripe
     stripe_size = model.meta.subarray.multistripe_reads1 + model.meta.subarray.multistripe_reads2
     model.pixeldq = np.zeros((nstripe, *model.data.shape[-2:]), dtype=np.uint32)
@@ -1309,6 +1309,7 @@ def test_refpix_superstripe(use_refpix, odd_even_columns):
     assert result.data.shape == (nint, ngroup, ny, nx)
     assert result.pixeldq.shape == (ny, nx)
     assert result.groupdq.shape == (nint, ngroup, ny, nx)
+    assert result.zeroframe.shape == (nint, ny, nx)
 
     # metadata is reset to regular subarray values
     assert model.meta.exposure.nints == nint * nstripe

--- a/jwst/saturation/saturation.py
+++ b/jwst/saturation/saturation.py
@@ -82,7 +82,6 @@ def flag_saturation(output_model, ref_model, n_pix_grow_sat, use_readpatt, bias_
         # Obtain the bias data, used for group 2 saturation flagging in frame-averaged groups
         bias = bias_model.data
 
-    # TODO: zero frame may need handling here too, for NIRCam superstripe data.
     num_superstripe = getattr(output_model.meta.subarray, "num_superstripe", None)
     if num_superstripe is not None and num_superstripe > 0:
         # Expand ref arrays to 4-D for ease of slicing

--- a/jwst/saturation/tests/helpers.py
+++ b/jwst/saturation/tests/helpers.py
@@ -265,7 +265,7 @@ def setup_nis_superstripe_cube():
     bias_model : `~stdatamodels.jwst.datamodels.SuperbiasModel`
         A corresponding superbias model.
     """
-    data_model = make_superstripe_model()
+    data_model = make_superstripe_model(add_zeroframe=True)
     num_stripes = data_model.meta.subarray.num_superstripe
     data_model.pixeldq = np.zeros((num_stripes, *data_model.data.shape[-2:]), dtype=np.uint32)
 

--- a/jwst/saturation/tests/test_saturation.py
+++ b/jwst/saturation/tests/test_saturation.py
@@ -501,6 +501,7 @@ def test_superstripe(use_bias):
     data.data[:, 2, pix, pix] = satvalue  # Signal reaches saturation limit
     data.data[:, 3, pix, pix] = satvalue
     data.data[:, 4, pix, pix] = satvalue
+    data.zeroframe[:, pix, pix] = satvalue
 
     # Set saturation value in the saturation model at the
     # expected location for each stripe
@@ -522,12 +523,15 @@ def test_superstripe(use_bias):
     )
 
     # Make sure that groups with signal > saturation limit get flagged
-    satindex = np.argmax(output.data[:, :, pix - 1 : pix + 1, pix - 1 : pix + 1] == satvalue)
+    satindex = np.argmax(output.data[:, :, pix - 1 : pix + 2, pix - 1 : pix + 2] == satvalue)
     assert np.all(
-        output.groupdq[0, satindex:, pix - 1 : pix + 1, pix - 1 : pix + 1]
+        output.groupdq[0, satindex:, pix - 1 : pix + 2, pix - 1 : pix + 2]
         == dqflags.group["SATURATED"]
     )
 
     # Make sure the pixeldq is reset properly. No new flags are expected.
     assert output.pixeldq.shape == (nstripe, *data.data.shape[-2:])
     assert np.all(output.pixeldq == 0)
+
+    # Zero frame data should be set to zero at saturated locations
+    assert np.all(output.zeroframe[:, pix - 1 : pix + 2, pix - 1 : pix + 2] == 0)

--- a/jwst/superbias/bias_sub.py
+++ b/jwst/superbias/bias_sub.py
@@ -62,15 +62,18 @@ def subtract_bias(output, bias):
     output : stdatamodels.jwst.datamodels.ramp.RampModel
         Bias-subtracted science data
     """
-    # combine the science and superbias DQ arrays
+    # Combine the science and superbias DQ arrays
     output.pixeldq |= bias.dq
 
+    # Expand bias data to match science data if needed
     num_superstripe = getattr(output.meta.subarray, "num_superstripe", None)
     if num_superstripe is not None and num_superstripe > 0:
+        # Bias data is 3D, (nstripe, ny, nx)
         nints, ngroups, _, _ = output.data.shape
         bias_data = bias.data[:, np.newaxis, :, :].repeat(ngroups, axis=1)
         bias_data = np.tile(bias_data, reps=(nints // num_superstripe, 1, 1, 1))
     else:
+        # Bias data is 2D, (ny, nx)
         bias_data = bias.data
 
     # Subtract the superbias image from all groups and integrations
@@ -79,10 +82,13 @@ def subtract_bias(output, bias):
 
     # If ZEROFRAME is present, subtract the super bias.  Zero values
     # indicate bad data, so should be kept zero.
-    # TODO: this may need different handling for superstripe data.
     if output.meta.exposure.zero_frame:
         wh_zero = np.where(output.zeroframe == 0.0)
-        output.zeroframe -= bias.data
+        if bias_data.ndim == 4:
+            # use the first group from the bias data for superstripe
+            output.zeroframe -= bias_data[:, 0, :, :]
+        else:
+            output.zeroframe -= bias_data
         output.zeroframe[wh_zero] = 0.0  # Zero values indicate unusable data
 
     return output

--- a/jwst/superbias/tests/test_bias_sub.py
+++ b/jwst/superbias/tests/test_bias_sub.py
@@ -166,3 +166,7 @@ def test_superstripe_correction():
     # Make sure the output has correct dimensions and expected bias was subtracted
     assert output.data.shape == data.data.shape
     np.testing.assert_equal(output.data, data.data - blevel)
+
+    # Zeroframe also handled
+    assert output.zeroframe.shape == data.zeroframe.shape
+    np.testing.assert_equal(output.zeroframe, data.zeroframe - blevel)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Toward [JP-4289](https://jira.stsci.edu/browse/JP-4289)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Add handling for zeroframe arrays associated with superstripe exposures.  This is not expected for NIRISS SOSS superstripe data, but will be needed to support NIRCam superstripe modes.

This PR is built on top of #10482 because there is some overlap in how arrays are handled and reassembled.  I will keep this one in draft until the other PR is merged.  Changes for this PR are all in the last commit: [a8f45b4](https://github.com/spacetelescope/jwst/pull/10494/commits/a8f45b41e1000f0ca17c696f025dbbf296baded0).

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
