### PR TITLE
remove unnecessary fitsrec assignments in unit tests

### DIFF
--- a/jwst/datamodels/utils/tests/test_flat_multispec.py
+++ b/jwst/datamodels/utils/tests/test_flat_multispec.py
@@ -253,7 +253,6 @@ def test_copy_column_units(input_spec, output_spec):
 
 def test_set_schema_units():
     model = dm.WFSSSpecModel((10,))
-    model.spec_table = model.spec_table.copy()
     set_schema_units(model)
 
     # get expected units from the schema

--- a/jwst/spectral_leak/tests/test_spectral_leak_step.py
+++ b/jwst/spectral_leak/tests/test_spectral_leak_step.py
@@ -15,9 +15,6 @@ def make_mrs_multispec(base_model="MRSMultiSpecModel"):
         multispec = datamodels.MultiSpecModel()
         one_spec = datamodels.SpecModel((10,))
 
-    # Assign the spec_table to convert it to a FITS record
-    one_spec.spec_table = one_spec.spec_table
-
     # Add some placeholder values
     one_spec.spec_table["WAVELENGTH"] = np.linspace(5, 28, 10)
     one_spec.spec_table["FLUX"] = 0.1


### PR DESCRIPTION
Related to https://github.com/spacetelescope/stdatamodels/pull/718

This PR removes a few lines of code which appear to be (from comments) intended to trigger `spec_table` attributes to become `FITS_rec` instances. These are unnecessary since in both cases `spec_table` is already a `FITS_rec`.

Regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/25077596759

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
