### PR TITLE
JP-4103: Set FAILED status for steps that did not succeed

### DIFF
--- a/changes/10497.stpipe.rst
+++ b/changes/10497.stpipe.rst
@@ -1,0 +1,1 @@
+Allow the ``cal_step`` status keyword to be set to FAILED (instead of SKIPPED) for steps that were attempted but did not succeed.

--- a/docs/jwst/references_general/references_general.rst
+++ b/docs/jwst/references_general/references_general.rst
@@ -481,8 +481,8 @@ As each pipeline step is applied to a science data product, it will record a sta
 header keyword of the science data product. The current list of step status keyword names is given
 in the following table. These status keywords may be included in the primary header of reference
 files, in order to maintain a history of the data that went into creating the reference file.
-Allowed values for the status keywords are 'COMPLETE' and 'SKIPPED'. Absence of a particular keyword
-is understood to mean that step was not even attempted.
+Allowed values for the status keywords are 'COMPLETE', 'SKIPPED', or 'FAILED'. Absence of a particular
+keyword is understood to mean that step was not even attempted.
 
 Table 1.  Keywords Documenting Which Pipeline Steps Have Been Performed.
 
@@ -540,6 +540,7 @@ S_STRAY     Straylight correction
 S_SUPERB    Superbias subtraction
 S_TACNTR    Source position from TA verification image
 S_TELEMI    Telescope emission correction
+S_TRCMOD    Adaptive trace modeling
 S_TSPHOT    TSO imaging photometry
 S_TWKREG    Tweakreg image alignment
 S_WAVCOR    Wavelength correction

--- a/jwst/assign_mtwcs/tests/test_mtwcs.py
+++ b/jwst/assign_mtwcs/tests/test_mtwcs.py
@@ -107,7 +107,7 @@ def test_output_is_not_input(monkeypatch, success):
     that performance is the most important thing and extra copies are
     not desired.
     """
-    # Mock a failure in the ModelLibrary init, to exercise the "skipped" condition
+    # Mock a failure in the ModelLibrary init, to exercise the "failed" condition
     if not success:
 
         def raise_error(*args, **kwargs):
@@ -127,7 +127,7 @@ def test_output_is_not_input(monkeypatch, success):
                 if success:
                     assert im.meta.cal_step.assign_mtwcs == "COMPLETE"
                 else:
-                    assert im.meta.cal_step.assign_mtwcs == "SKIPPED"
+                    assert im.meta.cal_step.assign_mtwcs == "FAILED"
                 assert im is not input_im
                 assert input_im.meta.cal_step.assign_mtwcs is None
 

--- a/jwst/master_background/master_background_mos_step.py
+++ b/jwst/master_background/master_background_mos_step.py
@@ -124,11 +124,11 @@ class MasterBackgroundMosStep(Pipeline):
                 log.warning(
                     "No background slits available for creating master background. Skipping"
                 )
-                record_step_status(output_model, "master_background", status="SKIPPED")
+                record_step_status(output_model, "master_background", status="FAILED")
                 return output_model
             elif num_src == 0:
                 log.warning("No source slits for applying master background. Skipping")
-                record_step_status(output_model, "master_background", status="SKIPPED")
+                record_step_status(output_model, "master_background", status="FAILED")
                 return output_model
 
             log.info("Calculating master background")

--- a/jwst/master_background/master_background_mos_step.py
+++ b/jwst/master_background/master_background_mos_step.py
@@ -106,7 +106,7 @@ class MasterBackgroundMosStep(Pipeline):
             output_model.meta.cal_step.master_background,
         ]:
             log.info("Background subtraction has already occurred. Skipping.")
-            record_step_status(output_model, "master_background", success=False)
+            record_step_status(output_model, "master_background", status="SKIPPED")
             return output_model
 
         if self.user_background:
@@ -124,11 +124,11 @@ class MasterBackgroundMosStep(Pipeline):
                 log.warning(
                     "No background slits available for creating master background. Skipping"
                 )
-                record_step_status(output_model, "master_background", False)
+                record_step_status(output_model, "master_background", status="SKIPPED")
                 return output_model
             elif num_src == 0:
                 log.warning("No source slits for applying master background. Skipping")
-                record_step_status(output_model, "master_background", False)
+                record_step_status(output_model, "master_background", status="SKIPPED")
                 return output_model
 
             log.info("Calculating master background")
@@ -139,7 +139,7 @@ class MasterBackgroundMosStep(Pipeline):
         # Check that a master background was actually determined.
         if master_background is None:
             log.info("No master background could be calculated. Skipping.")
-            record_step_status(output_model, "master_background", False)
+            record_step_status(output_model, "master_background", status="FAILED")
             return output_model
 
         # Now apply the de-calibrated background to the original science
@@ -148,7 +148,7 @@ class MasterBackgroundMosStep(Pipeline):
         )
 
         # Mark as completed and setup return data
-        record_step_status(result, "master_background", True)
+        record_step_status(result, "master_background", status="COMPLETE")
         if self.save_background:
             self.save_model(master_background, suffix="masterbg1d", force=True)
             self.save_model(mb_multislit, suffix="masterbg2d", force=True)

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -53,7 +53,7 @@ class MasterBackgroundStep(Step):
 
         # First check if we should even do the subtraction.  If not, bail.
         if not self._do_sub(output_model):
-            record_step_status(output_model, "master_background", success=False)
+            record_step_status(output_model, "master_background", status="SKIPPED")
             return output_model
 
         # Check that data is a supported datamodel. If not, bail.
@@ -70,7 +70,7 @@ class MasterBackgroundStep(Step):
             log.warning(
                 f"Input {input_data} of type {type(output_model)} cannot be handled.  Step skipped."
             )
-            record_step_status(output_model, "master_background", success=False)
+            record_step_status(output_model, "master_background", status="SKIPPED")
             return output_model
 
         # If user-supplied master background, subtract it
@@ -114,7 +114,7 @@ class MasterBackgroundStep(Step):
                     f"Input {input_data} of type {type(output_model)} cannot be "
                     "handled without user-supplied background.  Step skipped."
                 )
-                record_step_status(output_model, "master_background", success=False)
+                record_step_status(output_model, "master_background", status="SKIPPED")
                 return output_model
 
             result, background_data = split_container(output_model)
@@ -124,7 +124,7 @@ class MasterBackgroundStep(Step):
                     "and no user-supplied background provided.  Skipping step."
                 )
                 log.warning(msg)
-                record_step_status(output_model, "master_background", success=False)
+                record_step_status(output_model, "master_background", status="SKIPPED")
                 return output_model
             asn_id = result.asn_table["asn_id"]
 
@@ -189,7 +189,7 @@ class MasterBackgroundStep(Step):
                     background_2d_collection, suffix="masterbg2d", force=True, asn_id=asn_id
                 )
 
-        record_step_status(result, "master_background", success=True)
+        record_step_status(result, "master_background", status="COMPLETE")
 
         # Clean up intermediate background models
         background_2d_collection.close()

--- a/jwst/master_background/master_background_step.py
+++ b/jwst/master_background/master_background_step.py
@@ -70,7 +70,7 @@ class MasterBackgroundStep(Step):
             log.warning(
                 f"Input {input_data} of type {type(output_model)} cannot be handled.  Step skipped."
             )
-            record_step_status(output_model, "master_background", status="SKIPPED")
+            record_step_status(output_model, "master_background", status="FAILED")
             return output_model
 
         # If user-supplied master background, subtract it
@@ -114,7 +114,7 @@ class MasterBackgroundStep(Step):
                     f"Input {input_data} of type {type(output_model)} cannot be "
                     "handled without user-supplied background.  Step skipped."
                 )
-                record_step_status(output_model, "master_background", status="SKIPPED")
+                record_step_status(output_model, "master_background", status="FAILED")
                 return output_model
 
             result, background_data = split_container(output_model)
@@ -124,7 +124,7 @@ class MasterBackgroundStep(Step):
                     "and no user-supplied background provided.  Skipping step."
                 )
                 log.warning(msg)
-                record_step_status(output_model, "master_background", status="SKIPPED")
+                record_step_status(output_model, "master_background", status="FAILED")
                 return output_model
             asn_id = result.asn_table["asn_id"]
 

--- a/jwst/master_background/tests/test_master_background.py
+++ b/jwst/master_background/tests/test_master_background.py
@@ -322,7 +322,7 @@ def test_split_container(tmp_path):
 def test_skip_unsupported_type(caplog):
     model = datamodels.SlitModel()
     result = MasterBackgroundStep.call(model)
-    assert result.meta.cal_step.master_background == "SKIPPED"
+    assert result.meta.cal_step.master_background == "FAILED"
     assert "SlitModel'> cannot be handled" in caplog.text
 
     # Input is not modified
@@ -333,7 +333,7 @@ def test_skip_unsupported_type(caplog):
 def test_skip_unsupported_without_user_bg(caplog):
     model = datamodels.ImageModel()
     result = MasterBackgroundStep.call(model)
-    assert result.meta.cal_step.master_background == "SKIPPED"
+    assert result.meta.cal_step.master_background == "FAILED"
     assert "ImageModel'> cannot be handled without user-supplied" in caplog.text
 
     # Input is not modified

--- a/jwst/master_background/tests/test_master_background_mos.py
+++ b/jwst/master_background/tests/test_master_background_mos.py
@@ -265,9 +265,9 @@ def test_skip_no_master_bg(monkeypatch, nirspec_msa_extracted2d):
     # mock a failure in master bg creation
     monkeypatch.setattr(step, "_extend_bg_slits", lambda *args, **kwargs: None)
 
-    # Step is skipped
+    # Step is marked FAILED
     result = step.run(model)
-    assert result.meta.cal_step.master_background == "SKIPPED"
+    assert result.meta.cal_step.master_background == "FAILED"
 
     # Input is not modified
     assert result is not model

--- a/jwst/master_background/tests/test_master_background_mos.py
+++ b/jwst/master_background/tests/test_master_background_mos.py
@@ -233,9 +233,9 @@ def test_skip_no_bg_slits(nirspec_msa_extracted2d):
     for i, slit in enumerate(model.slits):
         slit.source_name = f"SRC{i}"
 
-    # Step is skipped
+    # Step is failed
     result = MasterBackgroundMosStep.call(model)
-    assert result.meta.cal_step.master_background == "SKIPPED"
+    assert result.meta.cal_step.master_background == "FAILED"
 
     # Input is not modified
     assert result is not model
@@ -249,9 +249,9 @@ def test_skip_no_src_slits(nirspec_msa_extracted2d):
     for i, slit in enumerate(model.slits):
         slit.source_name = f"BKG{i}"
 
-    # Step is skipped
+    # Step is failed
     result = MasterBackgroundMosStep.call(model)
-    assert result.meta.cal_step.master_background == "SKIPPED"
+    assert result.meta.cal_step.master_background == "FAILED"
 
     # Input is not modified
     assert result is not model

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -171,7 +171,7 @@ class OutlierDetectionStep(Step):
             log.error(f"Outlier detection failed for unknown/unsupported mode: {mode}")
             record_step_status(result_models, "outlier_detection", False)
 
-        if query_step_status(result_models, "outlier_detection") != "SKIPPED":
+        if query_step_status(result_models, "outlier_detection") not in ("SKIPPED", "FAILED"):
             record_step_status(result_models, "outlier_detection", True)
         return result_models
 

--- a/jwst/outlier_detection/tests/test_ifu.py
+++ b/jwst/outlier_detection/tests/test_ifu.py
@@ -9,8 +9,8 @@ def test_ifu_one_exposure(miri_ifu_rate):
     input_model = miri_ifu_rate
     result = OutlierDetectionStep.call([input_model])
 
-    # Step is skipped
-    assert result[0].meta.cal_step.outlier_detection == "SKIPPED"
+    # Step is failed
+    assert result[0].meta.cal_step.outlier_detection == "FAILED"
 
     # Input is not modified
     assert result[0] is not input_model

--- a/jwst/outlier_detection/tests/test_imaging.py
+++ b/jwst/outlier_detection/tests/test_imaging.py
@@ -274,7 +274,7 @@ def test_skip_one_exposure_imaging():
     result = step.run(input_models)
 
     # Step is skipped
-    assert query_step_status(result, "outlier_detection") == "SKIPPED"
+    assert query_step_status(result, "outlier_detection") == "FAILED"
 
     # Input is not modified
     assert result is not model

--- a/jwst/outlier_detection/tests/test_outlier_detection.py
+++ b/jwst/outlier_detection/tests/test_outlier_detection.py
@@ -117,7 +117,7 @@ def test_guess_mode_assigned(caplog, mode):
     step.mode = mode
     result = step.run(input_model)
 
-    assert result.meta.cal_step.outlier_detection == "SKIPPED"
+    assert result.meta.cal_step.outlier_detection == "FAILED"
     assert isinstance(result, datamodels.ImageModel)
 
     # If mode was unrecognized, error message is issued
@@ -137,8 +137,8 @@ def test_skip_unknown_mode_file(tmp_path, caplog):
     input_model.save(input_file)
     result = OutlierDetectionStep.call(input_file)
 
-    # Step is skipped with an error message
-    assert result.meta.cal_step.outlier_detection == "SKIPPED"
+    # Step is failed with an error message
+    assert result.meta.cal_step.outlier_detection == "FAILED"
     assert isinstance(result, datamodels.ImageModel)
     assert "ERROR" in caplog.text
 
@@ -152,8 +152,8 @@ def test_skip_unknown_mode_image_model():
     input_model = datamodels.ImageModel()
     result = OutlierDetectionStep.call(input_model)
 
-    # Step is skipped
-    assert result.meta.cal_step.outlier_detection == "SKIPPED"
+    # Step is failed
+    assert result.meta.cal_step.outlier_detection == "FAILED"
 
     # Input is not modified
     assert result is not input_model
@@ -165,8 +165,8 @@ def test_skip_unknown_mode_container():
     container = ModelContainer([input_model])
     result = OutlierDetectionStep.call(container)
 
-    # Step is skipped
-    assert result[0].meta.cal_step.outlier_detection == "SKIPPED"
+    # Step is failed
+    assert result[0].meta.cal_step.outlier_detection == "FAILED"
 
     # Input is not modified
     assert result[0] is not input_model

--- a/jwst/outlier_detection/tests/test_spec.py
+++ b/jwst/outlier_detection/tests/test_spec.py
@@ -122,8 +122,8 @@ def test_skip_one_exposure_spec():
     # it should skip and return a copy of the input with the status set
     result = step.run(input_models)
 
-    # Step is skipped
-    assert result[0].meta.cal_step.outlier_detection == "SKIPPED"
+    # Step is failed
+    assert result[0].meta.cal_step.outlier_detection == "FAILED"
 
     # Input is not modified
     assert result[0] is not model

--- a/jwst/pixel_replace/pixel_replace_step.py
+++ b/jwst/pixel_replace/pixel_replace_step.py
@@ -59,7 +59,7 @@ class PixelReplaceStep(Step):
             log.error(f"Input is of type {str(output_model)} for which")
             log.error("pixel_replace does not have an algorithm.")
             log.error("Pixel replacement will be skipped.")
-            output_model.meta.cal_step.pixel_replace = "SKIPPED"
+            record_step_status(output_model, "pixel_replace", success=False)
             return output_model
 
         pars = {

--- a/jwst/pixel_replace/tests/test_pixel_replace.py
+++ b/jwst/pixel_replace/tests/test_pixel_replace.py
@@ -360,8 +360,8 @@ def test_skip_unexpected_type():
     bad_model = datamodels.RampModel()
     result = PixelReplaceStep.call(bad_model)
 
-    # Step is skipped
-    assert result.meta.cal_step.pixel_replace == "SKIPPED"
+    # Step is failed
+    assert result.meta.cal_step.pixel_replace == "FAILED"
 
     # Input is not modified
     assert result is not bad_model
@@ -373,8 +373,8 @@ def test_skip_unexpected_type_in_container():
     container = ModelContainer([bad_model])
     result = PixelReplaceStep.call(container)
 
-    # Step is skipped
-    assert result[0].meta.cal_step.pixel_replace == "SKIPPED"
+    # Step is failed
+    assert result[0].meta.cal_step.pixel_replace == "FAILED"
 
     # Input is not modified
     assert result[0] is not bad_model

--- a/jwst/regtest/test_niriss_image.py
+++ b/jwst/regtest/test_niriss_image.py
@@ -263,7 +263,7 @@ def test_niriss_tweakreg_no_sources(rtdata, fitsdiff_default_kwargs, log_watcher
     # Check the status of the step is set correctly in the files.
     mc = datamodels.ModelContainer(rtdata.input)
     for model in mc:
-        assert model.meta.cal_step.tweakreg != "SKIPPED"
+        assert model.meta.cal_step.tweakreg is None
 
     watcher = log_watcher(
         "jwst.tweakreg.tweakreg_catalog", message="No sources found in the image", level="warning"
@@ -272,7 +272,7 @@ def test_niriss_tweakreg_no_sources(rtdata, fitsdiff_default_kwargs, log_watcher
     watcher.assert_seen()
     with result:
         for model in result:
-            assert model.meta.cal_step.tweakreg == "SKIPPED"
+            assert model.meta.cal_step.tweakreg == "FAILED"
             result.shelve(model, modify=False)
 
 

--- a/jwst/stpipe/tests/test_utilities.py
+++ b/jwst/stpipe/tests/test_utilities.py
@@ -1,5 +1,6 @@
 """Test utility funcs"""
 
+import pytest
 from stdatamodels.jwst import datamodels
 
 import jwst.pipeline
@@ -20,26 +21,28 @@ def test_all_steps():
     assert not diff, f"Steps not accounted for. Confirm and check suffix and CRDS calpars.\n{diff}"
 
 
-def test_record_query_step_status():
+@pytest.mark.parametrize("fail_status", [None, "SKIPPED", "FAILED"])
+def test_record_query_step_status(fail_status):
     # single model case
     model = dm.MultiSpecModel()
     record_step_status(model, "test_step", success=True)
     assert query_step_status(model, "test_step") == "COMPLETE"
 
-    # modelcontainer case where all skipped
+    # modelcontainer case where all failed
     model2 = dm.ModelContainer()
     model2.append(dm.MultiSpecModel())
     model2.append(dm.MultiSpecModel())
-    record_step_status(model2, "test_step", success=False)
-    assert model2[0].meta.cal_step.instance["test_step"] == "SKIPPED"
-    assert model2[1].meta.cal_step.instance["test_step"] == "SKIPPED"
-    assert query_step_status(model2, "test_step") == "SKIPPED"
+    record_step_status(model2, "test_step", success=False, status=fail_status)
+    expected = fail_status if fail_status is not None else "FAILED"
+    assert model2[0].meta.cal_step.instance["test_step"] == expected
+    assert model2[1].meta.cal_step.instance["test_step"] == expected
+    assert query_step_status(model2, "test_step") == expected
 
     # modelcontainer case with at least one complete
-    # currently the zeroth is checked, so this should return SKIPPED
+    # currently the zeroth is checked, so this should return FAILED
     model2.append(dm.MultiSpecModel())
     model2[2].meta.cal_step.instance["test_step"] = "COMPLETE"
-    assert query_step_status(model2, "test_step") == "SKIPPED"
+    assert query_step_status(model2, "test_step") == expected
 
     # test query not set
     model3 = dm.MultiSpecModel()
@@ -49,9 +52,15 @@ def test_record_query_step_status():
     model4 = dm.ModelLibrary([model])
     assert query_step_status(model4, "test_step") == "COMPLETE"
     model5 = dm.ModelLibrary(model2)
-    assert query_step_status(model5, "test_step") == "SKIPPED"
+    assert query_step_status(model5, "test_step") == expected
     model6 = dm.ModelLibrary([model3])
     assert query_step_status(model6, "test_step") == NOT_SET
+
+
+def test_record_status_invalid_value():
+    model = dm.MultiSpecModel()
+    with pytest.raises(ValueError, match="BAD_VALUE not in allowed values"):
+        record_step_status(model, "test_step", status="BAD_VALUE")
 
 
 def change_name_func(model):

--- a/jwst/stpipe/utilities.py
+++ b/jwst/stpipe/utilities.py
@@ -25,9 +25,8 @@ NON_STEPS = [
     "SystemCall",
 ]
 
+ALLOWED_STEP_STATUS = ("COMPLETE", "SKIPPED", "FAILED")
 NOT_SET = "NOT SET"
-COMPLETE = "COMPLETE"
-SKIPPED = "SKIPPED"
 
 __all__ = [
     "all_steps",
@@ -134,7 +133,7 @@ def folder_traverse(folder_path, basename_regex=".+", path_exclude_regex="^$"):
                 yield os.path.join(root, file)  # noqa: PTH118
 
 
-def record_step_status(datamodel, cal_step, success=True):
+def record_step_status(datamodel, cal_step, success=True, status=None):
     """
     Record whether or not a step completed in ``meta.cal_step``.
 
@@ -144,17 +143,22 @@ def record_step_status(datamodel, cal_step, success=True):
                 `~jwst.datamodels.container.ModelContainer`, \
                 `~jwst.datamodels.library.ModelLibrary`
         This is the datamodel or container of datamodels to modify in place
-
     cal_step : str
         The attribute in meta.cal_step for recording the status of the step
-
-    success : bool
-        If True, then 'COMPLETE' is recorded.  If False, then 'SKIPPED'
+    success : bool, optional
+        If True, set the status to "COMPLETE". If False, set "FAILED".
+        Ignored if ``status`` is not None.
+    status : {"COMPLETE", "SKIPPED", "FAILED"}, optional
+        The step status to record.
     """
-    if success:
-        status = COMPLETE
-    else:
-        status = SKIPPED
+    if status is None:
+        if success:
+            status = "COMPLETE"
+        else:
+            status = "FAILED"
+
+    if status not in ALLOWED_STEP_STATUS:
+        raise ValueError(f"Step status {status} not in allowed values: {ALLOWED_STEP_STATUS}")
 
     if isinstance(datamodel, Sequence):
         for model in datamodel:
@@ -166,8 +170,6 @@ def record_step_status(datamodel, cal_step, success=True):
                 datamodel.shelve(model)
     else:
         datamodel.meta.cal_step.instance[cal_step] = status
-
-    # TODO: standardize cal_step naming to point to the official step name
 
 
 def query_step_status(datamodel, cal_step):
@@ -184,14 +186,14 @@ def query_step_status(datamodel, cal_step):
                 `~jwst.datamodels.container.ModelContainer`, \
                 `~jwst.datamodels.library.ModelLibrary`
         The datamodel or container of datamodels to check
-
     cal_step : str
         The attribute in meta.cal_step to check
 
     Returns
     -------
-    status : str
-        The status of the step in ``meta.cal_step``, typically 'COMPLETE' or 'SKIPPED'
+    status : {"COMPLETE", "SKIPPED", "FAILED"}
+        The status of the step in ``meta.cal_step``.  If not set, "NOT SET"
+        will be returned.
 
     Notes
     -----

--- a/jwst/tweakreg/tests/test_tweakreg.py
+++ b/jwst/tweakreg/tests/test_tweakreg.py
@@ -208,10 +208,10 @@ def test_src_confusion_pars(example_input, alignment_type):
     step = tweakreg_step.TweakRegStep(**pars)
     result = step.run(example_input)
 
-    # check that step was skipped
+    # check that step was failed
     with result:
         for model, input_model in zip(result, example_input, strict=True):
-            assert model.meta.cal_step.tweakreg == "SKIPPED"
+            assert model.meta.cal_step.tweakreg == "FAILED"
 
             # Input model is not modified
             assert model is not input_model
@@ -228,10 +228,10 @@ def test_ngroup_1(caplog, example_input):
     result = tweakreg_step.TweakRegStep.call(example_input)
     assert "At least two exposures are required" in caplog.text
 
-    # check that step was skipped
+    # check that step was failed
     with result:
         for model, input_model in zip(result, example_input, strict=True):
-            assert model.meta.cal_step.tweakreg == "SKIPPED"
+            assert model.meta.cal_step.tweakreg == "FAILED"
 
             # Input model is not modified
             assert model is not input_model


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4103](https://jira.stsci.edu/browse/JP-4103)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Update `stpipe` utility functions `record_step_status` and `query_step_status` to expect three possible values for calibration step status: COMPLETE, SKIPPED, or FAILED.

The `record_step_status` currently has one parameter (`success`), which was setting COMPLETE if True, SKIPPED if False.  In most use cases for this function, success=False is used to indicate that the step attempted to run but couldn't complete, either because of an internal error, or the input data was invalid for the processing.  The status "FAILED" seems more appropriate to these cases, so I changed the default for success=False to FAILED instead of SKIPPED.  I also added an option to directly set a status instead, and used it in a few places where SKIPPED seemed more appropriate than FAILED.

Steps affected by this default change are:
- assign_mtwcs
- cube_build
- master_background
- master_background_mos
- outlier_detection
- pixel_replace
- tweakreg

The other steps directly set SKIPPED or COMPLETE -- we can update those on a case by case basis as needed.

Requires https://github.com/spacetelescope/stdatamodels/pull/722 (merged)

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [x] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
