### PR TITLE
JP-4334: Catch NIRSpec WCS errors in clean_flicker_noise; use FAILED cal_step status

### DIFF
--- a/changes/10501.clean_flicker_noise.rst
+++ b/changes/10501.clean_flicker_noise.rst
@@ -1,0 +1,1 @@
+Catch NIRSpec-specific WCS errors and exit the step gracefully. Set the cal_step status to FAILED in this case and others for which processing was attempted but did not complete.

--- a/jwst/clean_flicker_noise/clean_flicker_noise.py
+++ b/jwst/clean_flicker_noise/clean_flicker_noise.py
@@ -7,6 +7,7 @@ from stdatamodels.jwst.datamodels import dqflags
 
 from jwst import datamodels
 from jwst.assign_wcs import AssignWcsStep, nirspec
+from jwst.assign_wcs.util import MSAFileError, NoDataOnDetectorError
 from jwst.clean_flicker_noise.background_level import background_level, clip_to_background
 from jwst.clean_flicker_noise.nsclean import NSClean, NSCleanSubarray
 from jwst.clean_flicker_noise.tso_median_image import make_median_image
@@ -1341,13 +1342,13 @@ def do_correction(
         Background model to be saved or None.
     noise_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Background model to be saved or None.
-    status : {'COMPLETE', 'SKIPPED'}
-        Completion status.  If errors were encountered, status is set to 'SKIPPED'
+    status : {'COMPLETE', 'FAILED'}
+        Completion status.  If errors were encountered, status is set to 'FAILED'
         and the output data matches the input data.  Otherwise,
         status is set to 'COMPLETE'.
     """
     # Track the completion status, for various failure conditions
-    status = "SKIPPED"
+    status = "FAILED"
 
     detector = input_model.meta.instrument.detector.upper()
     subarray = input_model.meta.subarray.name.upper()
@@ -1376,15 +1377,20 @@ def do_correction(
 
     # Make a rate file if needed
     if user_mask is None or background_method == "median_image":
-        image_model = _make_processed_rate_image(
-            input_model,
-            single_mask,
-            input_dir,
-            exp_type,
-            mask_science_regions,
-            flat,
-            background_method,
-        )
+        try:
+            image_model = _make_processed_rate_image(
+                input_model,
+                single_mask,
+                input_dir,
+                exp_type,
+                mask_science_regions,
+                flat,
+                background_method,
+            )
+        except (MSAFileError, NoDataOnDetectorError):
+            # Catch some specific errors for WCS failures and FAIL the step
+            log.error("Cannot assign a WCS. Skipping corrections for this file.")
+            return input_model, None, None, None, status
     else:
         image_model = input_model
 

--- a/jwst/clean_flicker_noise/clean_flicker_noise_step.py
+++ b/jwst/clean_flicker_noise/clean_flicker_noise_step.py
@@ -144,7 +144,7 @@ class CleanFlickerNoiseStep(Step):
                     "Skipping: median_image processing is not available "
                     f"for SOSS subarray {subarray}."
                 )
-                output_model.meta.cal_step.clean_flicker_noise = "SKIPPED"
+                output_model.meta.cal_step.clean_flicker_noise = "FAILED"
                 return output_model
 
             pastasoss = self.get_reference_file(output_model, "pastasoss")
@@ -156,7 +156,7 @@ class CleanFlickerNoiseStep(Step):
                         "Skipping: median_image processing is not available "
                         "for SOSS without a pastasoss file."
                     )
-                    output_model.meta.cal_step.clean_flicker_noise = "SKIPPED"
+                    output_model.meta.cal_step.clean_flicker_noise = "FAILED"
                     return output_model
 
             else:

--- a/jwst/clean_flicker_noise/tests/test_clean_flicker_noise.py
+++ b/jwst/clean_flicker_noise/tests/test_clean_flicker_noise.py
@@ -4,6 +4,7 @@ import pytest
 from numpy.testing import assert_allclose
 from stdatamodels.jwst import datamodels
 
+from jwst.assign_wcs.util import MSAFileError, NoDataOnDetectorError
 from jwst.clean_flicker_noise import clean_flicker_noise as cfn
 from jwst.clean_flicker_noise.tests import helpers
 
@@ -438,8 +439,36 @@ def test_do_correction_unsupported(log_watcher):
     watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise", message="not supported")
     cleaned, _, _, _, status = cfn.do_correction(ramp_model)
     assert cleaned is ramp_model
-    assert status == "SKIPPED"
+    assert status == "FAILED"
     watcher.assert_seen()
+
+    ramp_model.close()
+
+
+@pytest.mark.parametrize("error_type", [NoDataOnDetectorError, MSAFileError, ValueError])
+def test_do_correction_wcs_failure(
+    caplog,
+    monkeypatch,
+    error_type,
+):
+    ramp_model = helpers.make_small_ramp_model()
+
+    # mock an error in the _make_processed_rate_image function
+    def mock_wcs_error(*args, **kwargs):
+        raise error_type("test error")
+
+    monkeypatch.setattr(cfn, "_make_processed_rate_image", mock_wcs_error)
+
+    if error_type in [NoDataOnDetectorError, MSAFileError]:
+        # specific errors are caught and handled gracefully
+        cleaned, _, _, _, status = cfn.do_correction(ramp_model)
+        assert cleaned is ramp_model
+        assert status == "FAILED"
+        assert "Cannot assign a WCS" in caplog.text
+    else:
+        # other errors are just raised
+        with pytest.raises(error_type, match="test error"):
+            cfn.do_correction(ramp_model)
 
     ramp_model.close()
 
@@ -473,7 +502,7 @@ def test_do_correction_fft_not_allowed(log_watcher, exptype):
     )
     cleaned, _, _, _, status = cfn.do_correction(ramp_model, fit_method="fft")
     assert cleaned is ramp_model
-    assert status == "SKIPPED"
+    assert status == "FAILED"
     watcher.assert_seen()
 
     ramp_model.close()
@@ -543,7 +572,7 @@ def test_do_correction_user_mask_mismatch(tmp_path, input_type, log_watcher):
     )
 
     watcher.assert_seen()
-    assert status == "SKIPPED"
+    assert status == "FAILED"
     assert output_mask is None
 
     model.close()
@@ -568,7 +597,7 @@ def test_do_correction_user_mask_mismatch_integ(tmp_path, log_watcher):
     )
 
     watcher.assert_seen()
-    assert status == "SKIPPED"
+    assert status == "FAILED"
     assert output_mask is None
 
     model.close()
@@ -648,10 +677,10 @@ def test_do_correction_clean_fails(monkeypatch, log_watcher):
     watcher = log_watcher("jwst.clean_flicker_noise.clean_flicker_noise", message="Cleaning failed")
     cleaned, _, _, _, status = cfn.do_correction(output_model, fit_method="fft")
 
-    # Error message issued, status is skipped,
+    # Error message issued, status is failed,
     # output data is the same as input
     watcher.assert_seen()
-    assert status == "SKIPPED"
+    assert status == "FAILED"
     assert np.allclose(cleaned.data, ramp_model.data)
 
     ramp_model.close()
@@ -805,7 +834,7 @@ def test_do_correction_median_image_one_int(caplog):
     data_copy = model.data.copy()
 
     cleaned, _, _, _, status = cfn.do_correction(model, background_method="median_image")
-    assert status == "SKIPPED"
+    assert status == "FAILED"
     assert "cannot be used with nints=1" in caplog.text
 
     # output data is unchanged
@@ -826,7 +855,7 @@ def test_do_correction_median_image_failure(caplog, monkeypatch):
     monkeypatch.setattr(cfn, "make_median_image", mock_make_median)
 
     cleaned, _, _, _, status = cfn.do_correction(model, background_method="median_image")
-    assert status == "SKIPPED"
+    assert status == "FAILED"
     assert "could not be created" in caplog.text
 
     # output data is unchanged

--- a/jwst/clean_flicker_noise/tests/test_clean_flicker_noise_step.py
+++ b/jwst/clean_flicker_noise/tests/test_clean_flicker_noise_step.py
@@ -26,8 +26,9 @@ def test_output_type(skip):
     # Run call with skip option
     cleaned = CleanFlickerNoiseStep.call(input_model, skip=skip)
 
-    # output is a ramp model either way
+    # output is a ramp model either way: the process always runs, called standalone
     assert isinstance(cleaned, datamodels.RampModel)
+    assert cleaned.meta.cal_step.clean_flicker_noise == "COMPLETE"
 
     input_model.close()
     cleaned.close()
@@ -257,7 +258,7 @@ def test_missing_pastasoss(caplog):
     assert "No PASTASOSS reference file" in caplog.text
     assert "median_image processing is not available" in caplog.text
     assert cleaned.meta.ref_file.pastasoss.name == "N/A"
-    assert cleaned.meta.cal_step.clean_flicker_noise == "SKIPPED"
+    assert cleaned.meta.cal_step.clean_flicker_noise == "FAILED"
     input_model.close()
     cleaned.close()
 
@@ -267,6 +268,6 @@ def test_soss_full_frame(caplog):
     input_model.meta.subarray.name = "FULL"
     cleaned = CleanFlickerNoiseStep.call(input_model, background_method="median_image")
     assert "median_image processing is not available for SOSS subarray FULL" in caplog.text
-    assert cleaned.meta.cal_step.clean_flicker_noise == "SKIPPED"
+    assert cleaned.meta.cal_step.clean_flicker_noise == "FAILED"
     input_model.close()
     cleaned.close()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4334](https://jira.stsci.edu/browse/JP-4334)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
For clean_flicker_noise, catch a couple specific NIRSpec WCS errors and exit the step gracefully.  Set the cal_step status to FAILED in this case.

Also, set the status to FAILED in other cases where processing was attempted but did not complete (incompatible data or arguments, missing reference files, etc.)

Requires https://github.com/spacetelescope/stdatamodels/pull/722 (merged)

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
