### PR TITLE
unpin crds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "asdf>=4.2,<6",
     "astropy>=6.1",
     "BayesicFitting>=3.2.2",
-    "crds>=12.0.3,<13.1.15",
+    "crds>=12.0.3,!=13.1.15",
     "gwcs>=1.0.3,<2",
     "numpy>=1.25",
     "photutils>=2.1.0,<3",


### PR DESCRIPTION
Remove the crds upper pin added in https://github.com/spacetelescope/jwst/pull/10496
replace with a `!=` since we don't historically upper pin crds.

I did not run regtests for just this PR as stdatamodels has an upper pin.

Regtests for this combined with https://github.com/spacetelescope/stdatamodels/pull/733 (which removes the stdatamodels upper pin):
https://github.com/spacetelescope/RegressionTests/actions/runs/25454074998

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
