### PR TITLE
DOC: Complete API for pathloss

### DIFF
--- a/docs/jwst/pathloss/api_ref.rst
+++ b/docs/jwst/pathloss/api_ref.rst
@@ -1,0 +1,15 @@
+===
+API
+===
+
+Public Step API
+===============
+
+.. automodapi:: jwst.pathloss.pathloss_step
+   :no-inheritance-diagram:
+
+Complete Developer API
+======================
+
+.. automodapi:: jwst.pathloss.pathloss
+   :no-inheritance-diagram:

--- a/docs/jwst/pathloss/arguments.rst
+++ b/docs/jwst/pathloss/arguments.rst
@@ -5,7 +5,7 @@ the behavior of the processing.
 
 ``--inverse`` (boolean, default=False)
   A flag to indicate whether the math operations used to apply the
-  flat-field should be inverted (i.e. multiply the pathloss into
+  flat-field should be inverted (i.e., multiply the pathloss into
   the science data, instead of the usual division).
 
 ``--source_type`` (string, default=None)

--- a/docs/jwst/pathloss/description.rst
+++ b/docs/jwst/pathloss/description.rst
@@ -1,7 +1,7 @@
 Description
 ===========
 
-:Class: `jwst.pathloss.PathLossStep`
+:Class: `jwst.pathloss.pathloss_step.PathLossStep`
 :Alias: pathloss
 
 Overview
@@ -57,33 +57,33 @@ The MSA reference file contains 2 entries: one for a 1x1 slit and one for a 1x3 
 Each entry contains the pathloss correction for point source and uniform sources.
 The former depends on the position of the target in the fiducial shutter and
 wavelength, whereas the latter depends on wavelength only.  The point source
-entry consists of a 3-d array, where 2 of the dimensions map to the location
+entry consists of a 3-D array, where 2 of the dimensions map to the location
 of the source (ranging from -0.5 to 0.5 in both X and Y), while the third dimension
 carries the wavelength dependence.  The 1x3 shutter is 3 times as large in Y as in X.
 
-The entry to use for a point source target is determined by looking at the shutter_state
+The entry to use for a point source target is determined by looking at the ``shutter_state``
 attribute of the slit used.  This is a string with a length equal to the number
 of shutters that make up the slit, with 1 denoting an open shutter, 0 a closed
 shutter and x the fiducial (target) shutter.  The reference entry is determined
 by how many shutters next to the fiducial shutter are open:
 
 If both adjacent shutters are closed, the 1x1 entry is used.  A matching
-shutter_state might be 'x' or '10x01'
+``shutter_state`` might be ``'x'`` or ``'10x01'``.
 
 If both adjacent shutters are open, the center region of the 1x3 entry is used.
-This would be the case for a slit with shutter state '1x1' or '1011x1'.
+This would be the case for a slit with shutter state ``'1x1'`` or ``'1011x1'``.
 
 If one adjacent shutter is open and one closed, the 1x3 entry is used.  If the
 shutter below the fiducial is open and the shutter above closed, then the upper
 region of the 1x3 pathloss array is used.  This is implemented by adding 1 to the
 Y coordinate of the target position (bringing it into the range +0.5 to +1.5),
 moving it to the upper third of the pathloss array.  A matching shutter state
-might be '1x' or '11x011'
+might be ``'1x'`` or ``'11x011'``.
 
 Similarly, if the shutter below the fiducial is closed and that above is open, the
 lower third of the pathloss array is used by subtracting 1 from the Y coordinate of
 the target position (bringing it into the range -1.5 to -0.5).  A matching shutter
-state could be 'x111' or '110x1'.
+state could be ``'x111'`` or ``'110x1'``.
 
 Once the X and Y coordinates of the source are mapped into a pixel location in the
 spatial dimensions of the pathloss array using the WCS of the transformation of position
@@ -95,17 +95,15 @@ array, since each pixel has a different wavelength, and the correction is applie
 to the science pixel array.
 
 For uniform sources, there is no dependence of the pathloss correction on position,
-so the correction arrays are just 1-d arrays of correction and wavelength.  The
+so the correction arrays are just 1-D arrays of correction and wavelength.  The
 correction depends only on the number of shutters in the slit:
 
-If there is 1 shutter, the 1x1 entry is used
+* If there is 1 shutter, the 1x1 entry is used.
+* If there are 3 or more shutters, the 1x3 entry is used.
+* If there are 2 shutters, the correction used is the average of the 1x1
+  and 1x3 entries.
 
-If there are 3 or more shutters, the 1x3 entry is used
-
-If there are 2 shutters, the correction used is the average of the 1x1
-and 1x3 entries.
-
-Like for the point source case, the 1-d arrays of pathloss correction and wavelength
+For the point source case, the 1-D arrays of pathloss correction and wavelength
 are used to interpolate the correction for each pixel in the science data, using the
 wavelength of each pixel to interpolate into the pathloss correction array.
 
@@ -141,7 +139,7 @@ position (keyword PWCPOS).  It is provided in the reference file as a FITS image
 3 dimensions (to be compatible with the NIRSpec reference file format).  The first
 dimension is a dummy, while the second gives the dependence with row number, and the
 third with Pupil Wheel position.  For the SUBSTEP96 subarray, the reference file
-data has shape (1, 2040, 17).
+data has shape ``(1, 2040, 17)``.
 
 The algorithm calculates the correction for each column by simply interpolating
 along the Pupil Wheel position dimension of the reference file using linear

--- a/docs/jwst/pathloss/description.rst
+++ b/docs/jwst/pathloss/description.rst
@@ -103,7 +103,7 @@ correction depends only on the number of shutters in the slit:
 * If there are 2 shutters, the correction used is the average of the 1x1
   and 1x3 entries.
 
-For the point source case, the 1-D arrays of pathloss correction and wavelength
+As for the point source case, the 1-D arrays of pathloss correction and wavelength
 are used to interpolate the correction for each pixel in the science data, using the
 wavelength of each pixel to interpolate into the pathloss correction array.
 

--- a/docs/jwst/pathloss/index.rst
+++ b/docs/jwst/pathloss/index.rst
@@ -10,5 +10,4 @@ Pathloss Correction
    description.rst
    arguments.rst
    reference_files.rst
-
-.. automodapi:: jwst.pathloss
+   api_ref.rst

--- a/docs/jwst/references_general/pathloss_reffile.inc
+++ b/docs/jwst/references_general/pathloss_reffile.inc
@@ -20,11 +20,11 @@ the following keywords are *required* in PATHLOSS reference files,
 because they are used as CRDS selectors
 (see :ref:`pathloss_selectors`):
 
-=========  ==============================
+=========  ========================
 Keyword    Data Model Name
-=========  ==============================
+=========  ========================
 EXP_TYPE   model.meta.exposure.type
-=========  ==============================
+=========  ========================
 
 Reference File Format
 +++++++++++++++++++++
@@ -66,7 +66,7 @@ point sources and one pair for uniform sources.  In each pair, there are
 either 3-D arrays for point sources, because the pathloss correction depends
 on the position of the source in the aperture, or 1-D arrays for uniform
 sources.  The pair of arrays are the pathloss correction itself as a function
-of decenter in the aperture (pointsource only) and wavelength, and the variance
+of decenter in the aperture (point source only) and wavelength, and the variance
 on this measurement (currently estimated). The data apply equally to all IFU
 slices. The structure of the FITS file is as follows:
 
@@ -140,7 +140,7 @@ HDU  EXTNAME XTENSION    Dimensions    Data type
 ==== ======= ========== =============  ==========
 
 The PS extension contains a 3-D array of correction values.
-The third dimension (length = 1) is a dummy to
+The third dimension (``length=1``) is a dummy to
 force the array dimensionality to be the same as the NIRSpec reference file
 arrays.  The other 2 dimensions refer to the number of columns in the correction
 (the same as the number of columns in the science data) and the range of

--- a/docs/jwst/references_general/pathloss_selection.inc
+++ b/docs/jwst/references_general/pathloss_selection.inc
@@ -7,10 +7,9 @@ PATHLOSS is not applicable for instruments not in the table.
 All keywords used for file selection are *required*.
 
 ========== ======================================
-Instrument Keywords                               
+Instrument Keywords
 ========== ======================================
-MIRI       INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS 
-NIRISS     INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS 
-NIRSpec    INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS 
+MIRI       INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS
+NIRISS     INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS
+NIRSpec    INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS
 ========== ======================================
-

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -39,7 +39,7 @@ def get_center(exp_type, input_model, offsets=False):
     """
     Get the center of the target in the aperture.
 
-    (0.0, 0.0) is the aperture center.  Coordinates go
+    ``(0.0, 0.0)`` is the aperture center.  Coordinates go
     from -0.5 to 0.5.
 
     Parameters
@@ -47,12 +47,12 @@ def get_center(exp_type, input_model, offsets=False):
     exp_type : str
         Keyword value
 
-    input_model : data model object
+    input_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Science data to be corrected
 
     offsets : bool
-        Only applies for MIRI LRS fixed-slit, if True the offsets
-        will be returned as well (imx, imy)
+        Only applies for MIRI LRS fixed-slit; if `True`, the offsets
+        will be returned as well in the form of ``(imx, imy)``
 
     Returns
     -------
@@ -132,7 +132,7 @@ def get_center(exp_type, input_model, offsets=False):
 
 def shutter_above_is_closed(shutter_state):
     """
-    Return True if the shutter above the target shutter is closed.
+    Check if the shutter above the target shutter is closed.
 
     Parameters
     ----------
@@ -142,7 +142,7 @@ def shutter_above_is_closed(shutter_state):
     Returns
     -------
     result : bool
-        True if the shutter above the target shutter is closed.
+        `True` if the shutter above the target shutter is closed.
     """
     ref_loc = shutter_state.find("x")
     nshutters = len(shutter_state)
@@ -154,7 +154,7 @@ def shutter_above_is_closed(shutter_state):
 
 def shutter_below_is_closed(shutter_state):
     """
-    Return True if the shutter below the target shutter is closed.
+    Check if the shutter below the target shutter is closed.
 
     Parameters
     ----------
@@ -164,7 +164,7 @@ def shutter_below_is_closed(shutter_state):
     Returns
     -------
     result : bool
-        True if the shutter below the target shutter is closed.
+        `True` if the shutter below the target shutter is closed.
     """
     ref_loc = shutter_state.find("x")
     if ref_loc == 0 or shutter_state[ref_loc - 1] == "0":
@@ -177,12 +177,14 @@ def get_aperture_from_model(input_model, match):
     """
     Determine the correct aperture in the model to use.
 
-    Based on the value of the 'match' parameter.  For MSA, match is
-    the shutter state string, for fixed slit, match is the name of the slit.
+    Based on the value of the 'match' parameter:
+
+    * For MSA, match is the shutter state string.
+    * For fixed slit, match is the name of the slit.
 
     Parameters
     ----------
-    input_model : data model object
+    input_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Science data to be corrected
 
     match : str
@@ -225,11 +227,11 @@ def calculate_pathloss_vector(pathloss_refdata, pathloss_wcs, xcenter, ycenter, 
 
     Parameters
     ----------
-    pathloss_refdata : numpy ndarray
+    pathloss_refdata : ndarray
         The input pathloss data array
 
-    pathloss_wcs : wcs
-        The pathloss datamodel's wcs attribute
+    pathloss_wcs : `~gwcs.wcs.WCS`
+        The pathloss datamodel's WCS attribute
 
     xcenter : float
         The x-center of the target (-0.5 to 0.5)
@@ -238,19 +240,19 @@ def calculate_pathloss_vector(pathloss_refdata, pathloss_wcs, xcenter, ycenter, 
         The y-center of the target (-0.5 to 0.5)
 
     calc_wave : bool
-        Calculate a wavelength vector from the ref file
+        Calculate a wavelength vector from the reference file
 
     Returns
     -------
-    wavelength : numpy ndarray
-        The 1-d wavelength array
+    wavelength : ndarray
+        The 1-D wavelength array
 
-    pathloss : numpy ndarray
-        The corresponding 1-d pathloss array
+    pathloss : ndarray
+        The corresponding 1-D pathloss array
 
     is_inside_slitlet : bool
-        Returns True if the object source position is inside the slitlet,
-        otherwise returns False
+        `True` if the object source position is inside the slitlet,
+        otherwise `False`
     """
     is_inside_slitlet = True
     if len(pathloss_refdata.shape) == 3:
@@ -326,20 +328,20 @@ def calculate_pathloss_vector(pathloss_refdata, pathloss_wcs, xcenter, ycenter, 
 
 def calculate_two_shutter_uniform_pathloss(pathloss_model):
     """
-    Calculate pathloss for uniform source, two shutter slit.
+    Calculate pathloss for uniform source, two-shutter slit.
 
-    The two shutter MOS case for uniform source calculation requires a custom
+    The two-shutter MOS case for uniform source calculation requires a custom
     routine since it uses both the 1X1 and 1X3 extensions of the pathloss reference file.
 
     Parameters
     ----------
-    pathloss_model : pathloss datamodel
+    pathloss_model : `~stdatamodels.jwst.datamodels.PathlossModel`
         The pathloss datamodel
 
     Returns
     -------
-    (wavelength, pathloss_vector) : tuple of 2 1-d numpy arrays
-        The wavelength and pathloss 1-d arrays
+    wavelength, pathloss_vector : ndarray
+        The wavelength and pathloss 1-D arrays, respectively
     """
     # This routine will run if the slit has exactly 2 shutters
     n_apertures = len(pathloss_model.apertures)
@@ -400,25 +402,25 @@ def do_correction(
     input_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         Science data to be corrected. Updated in place.
     pathloss_model : `~stdatamodels.jwst.datamodels.MirLrsPathlossModel`, \
-                     `~stdatamodels.jwst.datamodels.PathlossModel` or None, optional
+                     `~stdatamodels.jwst.datamodels.PathlossModel`, or None, optional
         Pathloss correction data
     inverse : bool, optional
         Invert the math operations used to apply the pathloss correction.
     source_type : str or None, optional
         Force processing using the specified source type.
     user_slit_loc : float, optional
-        User-provided slit location in units of arcsec, where (0,0)
+        User-provided slit location in units of arcsec, where ``(0, 0)``
         is the center and the edges are +/-0.255 arcsec.
     return_corrections : bool, optional
-        If True, a model containing the applied corrections is returned.
+        If `True`, a model containing the applied corrections is returned.
 
     Returns
     -------
-    input_model: `~stdatamodels.jwst.datamodels.JwstDataModel`
+    input_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The corrected science data with pathloss extensions added.
-    corrections: `~stdatamodels.jwst.datamodels.JwstDataModel`, optional
+    corrections : `~stdatamodels.jwst.datamodels.JwstDataModel`, optional
         A model of the correction arrays, returned if ``return_corrections``
-        is True.
+        is `True`.
     """
     if not pathloss_model:
         raise RuntimeError("A PathlossModel must be specified.")
@@ -460,25 +462,25 @@ def interpolate_onto_grid(wavelength_grid, wavelength_vector, pathloss_vector):
     Interpolate pathloss value onto grid.
 
     Get the value of pathloss by interpolating each non-NaN element of
-    wavelength_grid into pathloss_vector using the index lookup of
-    wavelength_vector.  Pixels with wavelengths outside the range of the
+    ``wavelength_grid`` into ``pathloss_vector`` using the index lookup of
+    ``wavelength_vector``.  Pixels with wavelengths outside the range of the
     reference file should have a correction of NaN.
 
     Parameters
     ----------
-    wavelength_grid : numpy ndarray (2-d)
-        The grid of wavelengths for each science data pixel
+    wavelength_grid : ndarray
+        The 2-D grid of wavelengths for each science data pixel
 
-    wavelength_vector : numpy ndarray (1-d)
-        Vector of wavelengths
+    wavelength_vector : ndarray
+        The 1-D vector of wavelengths
 
-    pathloss_vector :  numpy ndarray (1-d)
-        Corresponding vector of pathloss values
+    pathloss_vector : ndarray
+        Corresponding 1-D vector of pathloss values
 
     Returns
     -------
-    pathloss_grid : numpy array
-        Grid of pathloss corrections for each non-Nan pixel
+    pathloss_grid : ndarray
+        Grid of pathloss corrections for each non-NaN pixel
     """
     # Need to set the pathloss correction of pixels whose wavelength is outside
     # the wavelength range of the reference file to NaN.  This trick will accomplish
@@ -527,7 +529,7 @@ def interpolate_onto_grid(wavelength_grid, wavelength_vector, pathloss_vector):
 
 def is_pointsource(srctype):
     """
-    Check whether srctype is a point source.
+    Check whether input is a point source.
 
     Parameters
     ----------
@@ -537,7 +539,7 @@ def is_pointsource(srctype):
     Returns
     -------
     result : bool
-        Returns True if srctype is "POINT"
+        `True` if ``srctype`` is "POINT"
     """
     if srctype is None:
         return False
@@ -555,10 +557,10 @@ def do_correction_mos(data, pathloss, inverse=False, source_type=None):
 
     Parameters
     ----------
-    data : jwst.datamodels.JwstDataModel
+    data : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The NIRSpec MOS data to be corrected.
 
-    pathloss : jwst.datamodels.PathlossModel or None
+    pathloss : `~stdatamodels.jwst.datamodels.PathlossModel` or None
         The pathloss reference data.
 
     inverse : bool
@@ -569,7 +571,7 @@ def do_correction_mos(data, pathloss, inverse=False, source_type=None):
 
     Returns
     -------
-    corrections : jwst.datamodels.MultiSlitModel
+    corrections : `~stdatamodels.jwst.datamodels.MultiSlitModel`
         The pathloss corrections applied.
     """
     exp_type = data.meta.exposure.type
@@ -627,10 +629,10 @@ def do_correction_fixedslit(data, pathloss, inverse=False, source_type=None):
 
     Parameters
     ----------
-    data : jwst.datamodels.JwstDataModel
+    data : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The NIRSpec fixed-slit data to be corrected.
 
-    pathloss : jwst.datamodels.JwstDataModel
+    pathloss : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The pathloss reference data.
 
     inverse : bool
@@ -641,7 +643,7 @@ def do_correction_fixedslit(data, pathloss, inverse=False, source_type=None):
 
     Returns
     -------
-    corrections : jwst.datamodels.MultiSlitModel
+    corrections : `~stdatamodels.jwst.datamodels.MultiSlitModel`
         The pathloss corrections applied.
     """
     exp_type = data.meta.exposure.type
@@ -704,10 +706,10 @@ def do_correction_ifu(data, pathloss, inverse=False, source_type=None):
 
     Parameters
     ----------
-    data : jwst.datamodels.JwstDataModel
+    data : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The NIRSpec IFU data to be corrected.
 
-    pathloss : jwst.datamodels.JwstDataModel
+    pathloss : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The pathloss reference data.
 
     inverse : bool
@@ -718,7 +720,7 @@ def do_correction_ifu(data, pathloss, inverse=False, source_type=None):
 
     Returns
     -------
-    corrections : jwst.datamodels.JwstDataModel
+    corrections : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The pathloss corrections applied.
     """
     correction = _corrections_for_ifu(data, pathloss, source_type)
@@ -764,14 +766,14 @@ def do_correction_lrs(data, pathloss, user_slit_loc):
 
     Parameters
     ----------
-    data : jwst.datamodels.JwstDataModel
+    data : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The MIRI LRS fixed-slit data to be corrected.
 
-    pathloss : jwst.datamodels.JwstDataModel
+    pathloss : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The pathloss reference data.
 
     user_slit_loc : float
-        User-provided slit location in units of arcsec, where (0,0)
+        User-provided slit location in units of arcsec, where ``(0, 0)``
         is the center and the edges are +/-0.255 arcsec.
     """
     correction = _corrections_for_lrs(data, pathloss, user_slit_loc)
@@ -806,16 +808,16 @@ def do_correction_soss(data, pathloss):
     subarray aperture.  The correction depends on the pupil wheel position
     and column number (or wavelength).  The simple option is to do the
     correction by column number, then the only interpolation needed is a
-    1-d interpolation into the pupil wheel position dimension.
+    1-D interpolation into the pupil wheel position dimension.
 
     Data are modified in-place.
 
     Parameters
     ----------
-    data : jwst.datamodels.JwstDataModel
+    data : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The NIRISS SOSS data to be corrected.
 
-    pathloss : jwst.datamodels.JwstDataModel
+    pathloss : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The pathloss reference data.
     """
     # Omit correction if this is a TSO observation
@@ -898,10 +900,10 @@ def _corrections_for_mos(slit, pathloss, exp_type, source_type=None):
 
     Parameters
     ----------
-    slit : jwst.datamodels.SlitModel
+    slit : `~stdatamodels.jwst.datamodels.SlitModel`
         The slit being operated on.
 
-    pathloss : jwst.datamodels.JwstDataModel
+    pathloss : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The pathloss reference data
 
     exp_type : str
@@ -912,7 +914,7 @@ def _corrections_for_mos(slit, pathloss, exp_type, source_type=None):
 
     Returns
     -------
-    correction : jwst.datamodels.SlitModel
+    correction : `~stdatamodels.jwst.datamodels.SlitModel`
         The correction arrays
     """
     correction = None
@@ -1011,14 +1013,14 @@ def _corrections_for_mos(slit, pathloss, exp_type, source_type=None):
 
 def _corrections_for_fixedslit(slit, pathloss, exp_type, source_type):
     """
-    Calculate the correction arrays for Fixed-slit.
+    Calculate the correction arrays for fixed-slit.
 
     Parameters
     ----------
-    slit : jwst.datamodels.SlitModel
+    slit : `~stdatamodels.jwst.datamodels.SlitModel`
         The slit being operated on.
 
-    pathloss : jwst.datamodels.JwstDataModel
+    pathloss : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The pathloss reference data
 
     exp_type : str
@@ -1029,7 +1031,7 @@ def _corrections_for_fixedslit(slit, pathloss, exp_type, source_type):
 
     Returns
     -------
-    correction : jwst.datamodels.SlitModel
+    correction : `~stdatamodels.jwst.datamodels.SlitModel`
         The correction arrays
     """
     correction = None
@@ -1116,10 +1118,10 @@ def _corrections_for_ifu(data, pathloss, source_type):
 
     Parameters
     ----------
-    data : jwst.datamodels.SlitModel
+    data : `~stdatamodels.jwst.datamodels.SlitModel`
         The data being operated on.
 
-    pathloss : jwst.datamodels.JwstDataModel
+    pathloss : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The pathloss reference data
 
     source_type : str or None
@@ -1127,7 +1129,7 @@ def _corrections_for_ifu(data, pathloss, source_type):
 
     Returns
     -------
-    correction : jwst.datamodels.SlitModel
+    correction : `~stdatamodels.jwst.datamodels.SlitModel`
         The correction arrays
     """
     # IFU targets are always inside slit
@@ -1195,19 +1197,19 @@ def _corrections_for_lrs(data, pathloss, user_slit_loc):
 
     Parameters
     ----------
-    data : jwst.datamodels.JwstDataModel
+    data : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The LRS data being operated on.
 
-    pathloss : jwst.datamodels.MirLrsPathlossModel
+    pathloss : `~stdatamodels.jwst.datamodels.MirLrsPathlossModel`
         The pathloss reference data
 
     user_slit_loc : float
-        User-provided slit location in units of arcsec, where (0,0)
+        User-provided slit location in units of arcsec, where ``(0, 0)``
         is the center and the edges are +/-0.255 arcsec.
 
     Returns
     -------
-    correction : jwst.datamodels.JwstDataModel
+    correction : `~stdatamodels.jwst.datamodels.JwstDataModel`
         The correction arrays
     """
     # Get location of target

--- a/jwst/pathloss/pathloss_step.py
+++ b/jwst/pathloss/pathloss_step.py
@@ -1,3 +1,5 @@
+"""Account for signal loss in the optical path of spectroscopic modes."""
+
 import logging
 
 from stdatamodels.jwst import datamodels
@@ -40,7 +42,7 @@ class PathLossStep(Step):
         Returns
         -------
         output_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
-            The updated datamodel..
+            The updated datamodel.
         """
         # Open the input data model
         output_model = self.prepare_output(input_data)


### PR DESCRIPTION
Towards [JP-4107](https://jira.stsci.edu/browse/JP-4107)

This PR addresses `pathloss` portion of https://github.com/spacetelescope/jwst/issues/9793 . Only touch docs so should not need RT.

On main:

* https://jwst-pipeline.readthedocs.io/en/latest/jwst/pathloss/index.html

With this patch:

* https://jwst-pipeline--10517.org.readthedocs.build/en/10517/jwst/pathloss/index.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
