### PR TITLE
Fixes for CFN tests after CRDS updates

### DIFF
--- a/jwst/clean_flicker_noise/tests/helpers.py
+++ b/jwst/clean_flicker_noise/tests/helpers.py
@@ -39,7 +39,7 @@ def _add_metadata(model, shape):
     model.meta.instrument.name = "MIRI"
     model.meta.instrument.detector = "MIRIMAGE"
     model.meta.instrument.filter = "F480M"
-    model.meta.observation.date = "2015-10-13"
+    model.meta.observation.date = "2025-10-13"
     model.meta.observation.time = "00:00:00"
     model.meta.exposure.type = "MIR_IMAGE"
     model.meta.exposure.group_time = 1.0

--- a/jwst/clean_flicker_noise/tests/test_clean_flicker_noise_step.py
+++ b/jwst/clean_flicker_noise/tests/test_clean_flicker_noise_step.py
@@ -192,7 +192,7 @@ def test_autoparam_failed(caplog, monkeypatch):
     monkeypatch.setattr(autoparam, "niriss_image_parameters", lambda *args: None)
 
     input_model = make_niriss_rate_model()
-    CleanFlickerNoiseStep.call(input_model, autoparam=True, override_flat="N/A")
+    CleanFlickerNoiseStep.call(input_model, autoparam=True, apply_flat_field=False)
     assert "Auto parameter setting failed" in caplog.text
     assert "Using input parameters as provided" in caplog.text
     assert "apply_flat_field: True" not in caplog.text


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Last night's scheduled regtest run (https://github.com/spacetelescope/RegressionTests/actions/runs/25843138271)
shows some failures for the clean_flicker_noise unit tests.  Looks like the failures are because there's no readnoise file defined for the synthetic data in the test, which has an invalid date of 2015.  Updating the date on the data makes those tests pass, but made one additional test fail because it picked up new parameter defaults for the step; that test (`test_autoparam_failed`) is fixed here too.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
