### PR TITLE
Rename tests to avoid okify collision

### DIFF
--- a/jwst/regtest/test_nirspec_brightobj.py
+++ b/jwst/regtest/test_nirspec_brightobj.py
@@ -163,7 +163,7 @@ def test_tso3_whtlt(run_tso3_pipeline, diff_astropy_tables):
     assert diff_astropy_tables(rtdata.output, rtdata.truth)
 
 
-def test_flat_field_step_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
+def test_flat_field_step_user_supplied_flat_nrs_bots(rtdata, fitsdiff_default_kwargs):
     """Test providing a user-supplied flat field to the FlatFieldStep"""
     basename = "jw02420001001_04101_00001-first100_nrs1"
     output_file = f"{basename}_flat_from_user_file.fits"

--- a/jwst/regtest/test_nirspec_image2.py
+++ b/jwst/regtest/test_nirspec_image2.py
@@ -23,7 +23,7 @@ def test_nirspec_image2(rtdata, fitsdiff_default_kwargs):
 
 
 @pytest.mark.bigdata
-def test_flat_field_step_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
+def test_flat_field_step_user_supplied_flat_nrs_image(rtdata, fitsdiff_default_kwargs):
     """Test providing a user-supplied flat field to the FlatFieldStep"""
     basename = "jw03290001001_03101_00001_nrs2"
     output_file = f"{basename}_flat_from_user_file.fits"

--- a/jwst/regtest/test_nirspec_mos_spec2_steps.py
+++ b/jwst/regtest/test_nirspec_mos_spec2_steps.py
@@ -10,7 +10,7 @@ from jwst.regtest.st_fitsdiff import STFITSDiff as FITSDiff
 
 
 @pytest.mark.bigdata
-def test_flat_field_step_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
+def test_flat_field_step_user_supplied_flat_nrs_mos(rtdata, fitsdiff_default_kwargs):
     """Test providing a user-supplied flat field to the FlatFieldStep"""
     basename = "jw01345066001_05101_00001_nrs1"
     output_file = f"{basename}_flat_from_user_file.fits"

--- a/jwst/regtest/test_nirspec_steps_spec2.py
+++ b/jwst/regtest/test_nirspec_steps_spec2.py
@@ -35,7 +35,7 @@ def test_nirspec_ifu_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
 
 
 @pytest.mark.bigdata
-def test_flat_field_step_user_supplied_flat(rtdata, fitsdiff_default_kwargs):
+def test_flat_field_step_user_supplied_flat_nrs_ifu(rtdata, fitsdiff_default_kwargs):
     """Test providing a user-supplied flat field to the FlatFieldStep"""
     basename = "jw01251004001_03107_00001_nrs1"
     output_file = f"{basename}_flat_from_user_file.fits"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Follow up to #10544 to fix a few tests that are hard to okify

Several tests that work from intermediate files and have the same test name generate an output okify.json file with the same filename when they fail.  If they fail at the same time, only one of them will be okified when the `okify_regtests` script runs, due to a quirk in the way the script works.

This PR renames the tests to make sure the okify output is unique.  There should only be one remaining regtest failure that could not be okified from the last run (https://github.com/spacetelescope/RegressionTests/actions/runs/25867746948) after #10544 was merged and okified, but this should hopefully prevent the same thing coming up the future.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
