### PR TITLE
JP-4378: Exclude dhs subarrays from tso3 asn rule

### DIFF
--- a/changes/10567.associations.rst
+++ b/changes/10567.associations.rst
@@ -1,0 +1,1 @@
+Exclude DHS subarrays from TSO3 association rule.

--- a/jwst/associations/lib/rules_level3.py
+++ b/jwst/associations/lib/rules_level3.py
@@ -879,7 +879,7 @@ class Asn_Lv3TSO(AsnMixin_Science):
         not_ifu = Constraint([Constraint_IFU()], reduce=Constraint.notany)
 
         # Exclude NIRCam TSO grism engineering modes: CLEAR pupil or module B long detector.
-        # Also excludes DHS exposures.
+        # Also excludes DHS exposures through subarray and pupil constraints.
         not_nrc_tsgrism_invalid = Constraint(
             [
                 Constraint(
@@ -903,6 +903,11 @@ class Asn_Lv3TSO(AsnMixin_Science):
                         ),
                         DMSAttrConstraint(name="module", sources=["detector"], value="nrcblong"),
                     ]
+                ),
+                DMSAttrConstraint(
+                    name="subarray",
+                    sources=["subarray"],
+                    value="sub260stripe4_dhs|sub41stripe1_dhs|sub82stripe2_dhs|sub164stripe4_dhs",
                 ),
             ],
             reduce=Constraint.notany,

--- a/jwst/regtest/associations_sdp_pools/test_associations_sdp_pools.py
+++ b/jwst/regtest/associations_sdp_pools/test_associations_sdp_pools.py
@@ -95,7 +95,7 @@ def test_std_strict(_jail, rtdata, resource_tracker, request, pool_args):
             ["-i", "o001", "o002"],
         ),  # This pair of pools test the DMS flag usage to prevent o-type ASNs when a background c-type candidate is attached to the science exposure.
         ("jw04225_20241213t150701DMS_pool", ["--DMS", "-i", "o001", "o002"]),
-        ("jw04453_o010_pool", []),  # NRC_TSGRISM / DHS pre-flight, code-to-spec
+        ("jw04453_20251228t035643_o015_pool", []),  # NRC_TSGRISM / DHS flight, sub260stripe4 only
         ("jw04462_20250318t100414_pool", []),  # NRS_FSS_VALID_LAMP_OPTICAL_PATHS
         ("jw04470_20250317t231014_pool", []),  # NIS_IMAGE science program
         (


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Addresses [JP-4378](https://jira.stsci.edu/browse/JP-4378)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR removes undesirable level 3 associations being generated for long-wavelength NIRCam DHS exposures.

The existing test pool for DHS was an engineering calibration program that didn't yet have the new subarrays available. This PR also updates the pool to use one of the later observations which was taken in the SUB260STRIPE4_DHS subarray.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
