### PR TITLE
JP-4370: Unset S_REGION if wcs is not sky-like

### DIFF
--- a/changes/10586.assign_wcs.rst
+++ b/changes/10586.assign_wcs.rst
@@ -1,0 +1,1 @@
+Unset the S_REGION if the output WCS is not celestial (e.g., NIRSpec lamp exposures).

--- a/changes/10586.resample_spec.rst
+++ b/changes/10586.resample_spec.rst
@@ -1,0 +1,1 @@
+Make sure no S_REGION is defined for resampled data that is not sky-like (e.g., NIRSpec lamp exposures).

--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -5,6 +5,7 @@ from gwcs.wcs import WCS
 
 from jwst.assign_wcs.miri import store_dithered_position
 from jwst.assign_wcs.util import (
+    is_sky_like,
     update_s_region_imaging,
     update_s_region_lrs,
     update_s_region_mrs,
@@ -138,6 +139,11 @@ def load_wcs(input_model, reference_files=None, nrs_slit_y_range=None, nrs_ifu_s
                 log.info(
                     f"Unable to update S_REGION for type {input_model.meta.exposure.type}: {exc}"
                 )
+
+    # For any exposure type, unset the S_REGION if the output WCS is not
+    # celestial (e.g. lamp exposures)
+    if not is_sky_like(input_model.meta.wcs.output_frame):
+        input_model.meta.wcsinfo.s_region = None
 
     # Store position of dithered pointing location in metadata for later spectral extraction
     if input_model.meta.exposure.type.lower() == "mir_lrs-fixedslit":

--- a/jwst/assign_wcs/tests/test_nirspec.py
+++ b/jwst/assign_wcs/tests/test_nirspec.py
@@ -209,8 +209,10 @@ def test_nirspec_imaging_via_step_call(exptype):
     ]
     if exptype == "NRS_LAMP":
         assert result.meta.wcs.bounding_box is None
+        assert result.meta.wcsinfo.s_region is None
     else:
         assert result.meta.wcs.bounding_box is not None
+        assert result.meta.wcsinfo.s_region is not None
 
 
 def test_nirspec_imaging_opaque():

--- a/jwst/assign_wcs/tests/test_util.py
+++ b/jwst/assign_wcs/tests/test_util.py
@@ -2,6 +2,9 @@
 Test the utility functions
 """
 
+import gwcs
+from astropy import coordinates as coord
+from astropy import units as u
 from astropy.modeling.models import Identity, Shift
 from astropy.table import QTable
 from astropy.utils.data import get_pkg_data_filename
@@ -10,6 +13,7 @@ from stdatamodels.jwst import datamodels
 from jwst.assign_wcs.util import (
     bounding_box_from_subarray,
     get_object_info,
+    is_sky_like,
     subarray_transform,
     transform_bbox_from_shape,
     wcs_bbox_from_shape,
@@ -98,3 +102,20 @@ def test_bounding_box_from_subarray():
     im.meta.subarray.xsize = 400
     im.meta.subarray.ysize = 600
     assert bounding_box_from_subarray(im) == ((-0.5, 599.5), (-0.5, 399.5))
+
+
+def test_is_sky_like():
+    frame = "test"
+    assert not is_sky_like(frame)
+
+    frame = gwcs.Frame2D()
+    assert not is_sky_like(frame)
+
+    frame = gwcs.Frame2D(unit=[u.um, u.pix])
+    assert not is_sky_like(frame)
+
+    frame = gwcs.Frame2D(unit=[u.arcsec, u.arcsec])
+    assert is_sky_like(frame)
+
+    frame = gwcs.CelestialFrame(name="icrs", axes_order=(0, 1), reference_frame=coord.ICRS())
+    assert is_sky_like(frame)

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -3,7 +3,9 @@
 import logging
 import warnings
 
+import gwcs.coordinate_frames
 import numpy as np
+from astropy import units as u
 from astropy.constants import c
 from astropy.modeling import models as astmodels
 from gwcs import WCS
@@ -38,6 +40,7 @@ __all__ = [
     "calc_rotation_matrix",
     "wrap_ra",
     "update_fits_wcsinfo",
+    "is_sky_like",
 ]
 
 
@@ -1286,3 +1289,26 @@ def get_wcs_reference_files(datamodel):
         else:
             refs[reftype] = val
     return refs
+
+
+def is_sky_like(frame):
+    """
+    Check that a frame is a sky-like frame by looking at its output units.
+
+    If output units are either ``deg`` or ``arcsec`` the frame is considered
+    a sky-like frame (as opposed to, e.g., a Cartesian frame).
+
+    Parameters
+    ----------
+    frame : `~gwcs.coordinate_frames.CoordinateFrame`
+        Coordinate frame to check.
+
+    Returns
+    -------
+    bool
+        ``True`` if the frame is sky-like, ``False`` otherwise.
+    """
+    # Make sure the frame is a coordinate frame first: if not, it's not sky-like
+    if not isinstance(frame, gwcs.coordinate_frames.CoordinateFrame):
+        return False
+    return u.Unit("deg") in frame.unit or u.Unit("arcsec") in frame.unit

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -21,7 +21,7 @@ from gwcs import coordinate_frames as cf
 from stcal.alignment.util import compute_scale, wcs_bbox_from_shape
 from stdatamodels.jwst import datamodels
 
-from jwst.assign_wcs.util import wrap_ra
+from jwst.assign_wcs.util import is_sky_like, wrap_ra
 from jwst.datamodels import ModelLibrary
 from jwst.resample import resample_utils
 from jwst.resample.resample import ResampleImage
@@ -167,7 +167,7 @@ class ResampleSpec(ResampleImage):
             # These functions internally use pixel_scale_ratio to accommodate
             # user settings.
             # Any other customizations (crpix, crval, rotation) are ignored.
-            if resample_utils.is_sky_like(input_models[0].meta.wcs.output_frame):
+            if is_sky_like(input_models[0].meta.wcs.output_frame):
                 if input_models[0].meta.instrument.name != "NIRSPEC":
                     output_wcs = self.build_interpolated_output_wcs(
                         input_models, pixel_scale_ratio=pixel_scale_ratio

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -3,13 +3,13 @@ import logging
 from stdatamodels.jwst import datamodels
 from stdatamodels.jwst.datamodels import ImageModel, MultiSlitModel
 
-from jwst.assign_wcs.util import update_s_region_spectral
+from jwst.assign_wcs.util import is_sky_like, update_s_region_spectral
 from jwst.datamodels import ModelContainer, ModelLibrary
 from jwst.exp_to_source import multislit_to_container
 from jwst.lib.pipe_utils import match_nans_and_flags
 from jwst.lib.wcs_utils import get_wavelengths
 from jwst.resample import ResampleStep, resample_spec
-from jwst.resample.resample_utils import find_miri_lrs_sregion, is_sky_like, load_custom_wcs
+from jwst.resample.resample_utils import find_miri_lrs_sregion, load_custom_wcs
 from jwst.stpipe import Step
 
 __all__ = ["ResampleSpecStep"]

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -9,7 +9,7 @@ from jwst.exp_to_source import multislit_to_container
 from jwst.lib.pipe_utils import match_nans_and_flags
 from jwst.lib.wcs_utils import get_wavelengths
 from jwst.resample import ResampleStep, resample_spec
-from jwst.resample.resample_utils import find_miri_lrs_sregion, load_custom_wcs
+from jwst.resample.resample_utils import find_miri_lrs_sregion, is_sky_like, load_custom_wcs
 from jwst.stpipe import Step
 
 __all__ = ["ResampleSpecStep"]
@@ -169,7 +169,11 @@ class ResampleSpecStep(Step):
             with drizzled_library:
                 for i, model in enumerate(drizzled_library):
                     self.update_slit_metadata(model)
-                    update_s_region_spectral(model)
+                    if not is_sky_like(model.meta.wcs.output_frame):
+                        # Output WCS is not celestial: unset the S_REGION
+                        model.meta.wcsinfo.s_region = None
+                    else:
+                        update_s_region_spectral(model)
                     result.slits.append(model)
                     drizzled_library.shelve(model, i, modify=False)
             del drizzled_library
@@ -278,7 +282,11 @@ class ResampleSpecStep(Step):
             input_wcs = input_models[0].meta.wcs
             self._transform_sourcepos(input_wcs, result)
         else:
-            update_s_region_spectral(result)
+            if not is_sky_like(result.meta.wcs.output_frame):
+                # Output WCS is not celestial: unset the S_REGION
+                result.meta.wcsinfo.s_region = None
+            else:
+                update_s_region_spectral(result)
 
         return result
 

--- a/jwst/resample/resample_utils.py
+++ b/jwst/resample/resample_utils.py
@@ -158,26 +158,6 @@ def build_mask(dqarr, bitvalue):
     return _stcal_build_mask(dqarr=dqarr, good_bits=bitvalue, flag_name_map=pixel)
 
 
-def is_sky_like(frame):
-    """
-    Check that a frame is a sky-like frame by looking at its output units.
-
-    If output units are either ``deg`` or ``arcsec`` the frame is considered
-    a sky-like frame (as opposite to, e.g., a Cartesian frame.)
-
-    Parameters
-    ----------
-    frame : gwcs.wcs.WCS
-        WCS object to check.
-
-    Returns
-    -------
-    bool
-        ``True`` if the frame is sky-like, ``False`` otherwise.
-    """
-    return u.Unit("deg") in frame.unit or u.Unit("arcsec") in frame.unit
-
-
 def load_custom_wcs(asdf_wcs_file, output_shape=None):
     """
     Load a custom output WCS from an ASDF file.

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -1779,6 +1779,9 @@ def test_nirspec_lamp_pixscale(nirspec_lamp, tmp_path):
     assert_allclose(result.slits[0].data.shape[0], nirspec_lamp.slits[0].data.shape[0], atol=5)
     assert result.slits[0].data.shape[1] == nirspec_lamp.slits[0].data.shape[1]
 
+    # no output s_region since the WCS is not sky-like
+    assert result.slits[0].meta.wcsinfo.s_region is None
+
     # test pixel scale setting: will not work without sky-based WCS
     result2 = ResampleSpecStep.call(nirspec_lamp, pixel_scale=0.5)
     assert_allclose(result2.slits[0].data, result.slits[0].data, equal_nan=True)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4370](https://jira.stsci.edu/browse/JP-4370)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
NIRSpec lamp exposures are resampled in the MSA frame, not in RA/Dec, so they should not have a celestial S_REGION assigned after assign_wcs.

This PR uses a utility that checks the output coordinate frame for the WCS to see if any of its units are sky-like (degrees or arcsec).  This utility was previously in the `resample` module; I moved it to the `assign_wcs.util` module, near the s_region utility functions used in multiple places.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
