### PR TITLE
Handle empty and null source names the same way in exp_to_source

### DIFF
--- a/changes/10588.exp_to_source.rst
+++ b/changes/10588.exp_to_source.rst
@@ -1,0 +1,1 @@
+Check for an empty string in the slit ``source_name`` attribute, to fix an edge case bug in reducing fixed slit regions from NRS_MSASPEC exposures.

--- a/jwst/exp_to_source/exp_to_source.py
+++ b/jwst/exp_to_source/exp_to_source.py
@@ -36,7 +36,7 @@ def exp_to_source(inputs):
         log.info(f"Reorganizing data from exposure {exposure.meta.filename}")
 
         for slit in exposure.slits:
-            if slit.source_name is None:
+            if slit.source_name is None or str(slit.source_name).strip() == "":
                 # All MultiSlit data other than NIRSpec MOS get sorted by
                 # source_id (source_name is not populated)
                 key = slit.source_id

--- a/jwst/exp_to_source/tests/test_exp_to_source.py
+++ b/jwst/exp_to_source/tests/test_exp_to_source.py
@@ -113,3 +113,29 @@ def test_slit_exptype(mock_input):
         model.close()
     for model in outputs.values():
         model.close()
+
+
+def test_empty_source_name(mock_input):
+    """Test for source name handling."""
+
+    container = ModelContainer(mock_input)
+
+    # Set an empty source name in each slit
+    for model in container:
+        for slit in model.slits:
+            slit.source_name = ""
+
+    # Make the source-based containers
+    outputs = multislit_to_container(container)
+
+    # Check that output is still sorted by source id, not the empty source name
+    assert len(container) == 3
+    assert len(outputs) == 5
+    assert list(outputs.keys()) == [str(n) for n in range(1, 6)]
+
+    # Closeout
+    container.close()
+    for model in mock_input:
+        model.close()
+    for model in outputs.values():
+        model.close()


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->


<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Fix for an issue reported by a helpdesk user, reducing a NRS_MSASPEC observation as if it were a NRS_FIXEDSLIT exposure.  Since the input data still had OPMODE="MSASPEC", `extract_2d` set the `slit.source_name` to an empty string instead of None.  Then, `exp_to_source` treated the empty string as a valid source name, and sorted all fixed slits into the same source container.  This made spec3 reduce all the slits together as a single source, resampling them all into the same s2d product.

The workaround for the user is to set OPMODE = "FIXEDSLIT", along with EXP_TYPE = "NRS_FIXEDSLIT", so that source_name is set to None for the extracted slits.  The fix here should make that workaround unnecessary, by handling an empty source name the same as a null one.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
