### PR TITLE
Match NaNs and flags for IFU in photom

### DIFF
--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -344,6 +344,9 @@ class DataSet:
 
                 area_model.close()
 
+                # Make sure output model has consistent NaN and DO_NOT_USE values
+                match_nans_and_flags(self.input)
+
     def calc_niriss(self, ftab):
         """
         Apply photometric calibration data to dataset and update conversion factor.
@@ -530,6 +533,9 @@ class DataSet:
             else:
                 self.input.meta.bunit_data = "DN/s"
                 self.input.meta.bunit_err = "DN/s"
+
+            # Make sure output model has consistent NaN and DO_NOT_USE values
+            match_nans_and_flags(self.input)
 
     def calc_nircam(self, ftab):
         """

--- a/jwst/photom/tests/test_photom.py
+++ b/jwst/photom/tests/test_photom.py
@@ -1682,6 +1682,35 @@ def test_miri_mrs_time_cor():
     np.testing.assert_allclose(ratio, compare, rtol=1e-6)
 
 
+def test_miri_mrs_match_nans():
+    """Test that NaNs and flags match in MRS output."""
+    input_model = create_input("MIRI", "MIRIFULONG", "MIR_MRS", filter_used="F1500W", band="LONG")
+
+    # add a NaN in the data that is not in err/var
+    input_model.data[10, 10] = np.nan
+
+    save_input = input_model.copy()
+    ds = photom.DataSet(input_model)
+    value = 1.436
+    pixel_area = 0.0436
+    photmjsr = 17.3
+    shape = save_input.data.shape
+    ftab = create_photom_miri_mrs(shape, value, pixel_area, photmjsr)
+    ds.calc_miri(ftab)
+
+    # input unchanged
+    assert np.isnan(save_input.data[10, 10])
+    assert ~np.isnan(save_input.err[10, 10])
+    assert ~np.isnan(save_input.var_poisson[10, 10])
+    assert (save_input.dq[10, 10] & datamodels.dqflags.pixel["DO_NOT_USE"]) == 0
+
+    # output has NaNs at the bad pixel
+    for ext in ["data", "err", "var_poisson", "var_rnoise", "var_flat"]:
+        assert np.isnan(getattr(ds.input, ext)[10, 10])
+    # DQ has do not use
+    assert (ds.input.dq[10, 10] & datamodels.dqflags.pixel["DO_NOT_USE"]) > 0
+
+
 def test_miri_lrs():
     """Test the calc_miri method of the DataSet class, LRS data."""
     input_model = create_input("MIRI", "MIRIMAGE", "MIR_LRS-FIXEDSLIT", filter_used="P750L")

--- a/jwst/photom/tests/test_photom_step.py
+++ b/jwst/photom/tests/test_photom_step.py
@@ -137,6 +137,10 @@ def test_photom_nrs_ifu():
     model.var_flat = model.get_default("var_flat")
     model = AssignWcsStep.call(model)
 
+    # Make one data pixel NaN, not matched with NaNs in the err/dq/var
+    bad_idx = (1414, 690)
+    model.data[bad_idx] = np.nan
+
     result = PhotomStep.call(model)
     assert result.meta.cal_step.photom == "COMPLETE"
 
@@ -146,7 +150,16 @@ def test_photom_nrs_ifu():
     assert not np.allclose(result.data, model.data)
     assert not np.allclose(result.err, model.err)
 
-    # inverting recovers the input
+    # NaNs and flags are matched for the bad pixel, input not modified
+    assert not np.isnan(model.err[bad_idx])
+    for ext in ["data", "err", "var_poisson", "var_rnoise", "var_flat"]:
+        assert np.isnan(getattr(result, ext)[bad_idx])
+    assert (result.dq[bad_idx] & datamodels.dqflags.pixel["DO_NOT_USE"]) > 0
+
+    # inverting recovers the input, except that the new NaN is not invertible
     inverse_result = PhotomStep.call(result, inverse=True)
     np.testing.assert_allclose(inverse_result.data, model.data)
-    np.testing.assert_allclose(inverse_result.err, model.err)
+    mask = np.full(model.err.shape, True)
+    mask[bad_idx] = False
+    np.testing.assert_allclose(inverse_result.err[mask], model.err[mask])
+    assert np.isnan(inverse_result.err[bad_idx])


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->

I noticed while testing missing variance propagation for #10590 that IFU modes are missing a `match_nans_and_flags` call in photom processing.  All other modes call the `photom_io` method, which calls `match_nans_and_flags`.

Impact to users should be minimal, if any.  I noticed it only because I turned off flat_field processing for a MIRI MRS exposure, which left a few pixels NaN in the data array and 0 in error and variance in the output cal file.  

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
