### PR TITLE
fix test that left datamodel open

### DIFF
--- a/jwst/wfss_contam/tests/test_wfss_contam_step.py
+++ b/jwst/wfss_contam/tests/test_wfss_contam_step.py
@@ -113,24 +113,24 @@ def test_wfss_contam_skip_bad_order(multislitmodel, tmp_cwd_module):
 
 def test_output_is_not_input(multislitmodel, tmp_cwd_module):
     """Check that input is not modified by the step."""
-    datamodel = dm.open(multislitmodel)
-    input_copy = datamodel.copy()
+    with dm.open(multislitmodel) as datamodel:
+        input_copy = datamodel.copy()
 
-    result = WfssContamStep.call(datamodel)
-    assert isinstance(result, dm.MultiSlitModel)
-    assert result.meta.cal_step.wfss_contam == "COMPLETE"
+        result = WfssContamStep.call(datamodel)
+        assert isinstance(result, dm.MultiSlitModel)
+        assert result.meta.cal_step.wfss_contam == "COMPLETE"
 
-    # input is not modified
-    assert result is not datamodel
-    assert datamodel.meta.cal_step.wfss_contam is None
-    any_modified = False
-    for i in range(len(datamodel.slits)):
-        # Input data is not modified
-        np.testing.assert_allclose(datamodel.slits[i].data, input_copy.slits[i].data)
+        # input is not modified
+        assert result is not datamodel
+        assert datamodel.meta.cal_step.wfss_contam is None
+        any_modified = False
+        for i in range(len(datamodel.slits)):
+            # Input data is not modified
+            np.testing.assert_allclose(datamodel.slits[i].data, input_copy.slits[i].data)
 
-        # Output data may have been modified
-        if not np.allclose(result.slits[i].data, datamodel.slits[i].data):
-            any_modified = True
+            # Output data may have been modified
+            if not np.allclose(result.slits[i].data, datamodel.slits[i].data):
+                any_modified = True
 
     # There was at least one slit updated in the output and not modified in the input
     assert any_modified


### PR DESCRIPTION
the py314-xdist job here randomly failed:
https://github.com/spacetelescope/jwst/actions/runs/26958916352/job/79543721789?pr=10581
due in-part to an unclosed file in a test. This PR closes the file to hopefully avoid the random failure.

~py311-xdist failure is unrelated. Looks to be a crds parallel file downloading without file locking issue: https://github.com/spacetelescope/crds/issues/930~ reran the test and got lucky!

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
