### PR TITLE
DOC: Small formatting fix for photom arguments

### DIFF
--- a/docs/jwst/photom/arguments.rst
+++ b/docs/jwst/photom/arguments.rst
@@ -1,5 +1,5 @@
-Arguments
-=========
+Step Arguments
+==============
 The ``photom`` step has the following optional arguments.
 
 ``--inverse`` (boolean, default=False)
@@ -12,5 +12,5 @@ The ``photom`` step has the following optional arguments.
   instead of using the information contained in the input data.
 
 ``--apply_time_correction`` (boolean, default=True)
-   A flag to indicate whether to apply time-dependent corrections
-   if available.
+  A flag to indicate whether to apply time-dependent corrections
+  if available.


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR is a follow-up of https://github.com/spacetelescope/jwst/pull/10530 towards https://github.com/spacetelescope/jwst/issues/9793 and #10529 

https://jwst-pipeline--10606.org.readthedocs.build/en/10606/jwst/photom/arguments.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
