### PR TITLE
DOC: Formatting fix for charge_migration argument

### DIFF
--- a/docs/jwst/charge_migration/arguments.rst
+++ b/docs/jwst/charge_migration/arguments.rst
@@ -1,7 +1,8 @@
-Arguments
-=========
+Step Arguments
+==============
 
-The ``charge migration`` step has one optional argument that can be set by the user:
+The ``charge_migration`` step has one optional argument:
 
-* ``--signal_threshold``: A floating-point value in units of ADU for the science value above which
+``--signal_threshold`` (float, default=25000)
+  A value in units of ADU for the science value above which
   a group's DQ will be flagged as CHARGELOSS and DO_NOT_USE.


### PR DESCRIPTION
This PR is a follow-up of https://github.com/spacetelescope/jwst/pull/10263 towards https://github.com/spacetelescope/jwst/issues/9793 and https://github.com/spacetelescope/jwst/issues/10529

https://jwst-pipeline--10609.org.readthedocs.build/en/10609/jwst/charge_migration/arguments.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
