### PR TITLE
DOC: Formatting fix for jump arguments

### DIFF
--- a/docs/jwst/jump/arguments.rst
+++ b/docs/jwst/jump/arguments.rst
@@ -1,14 +1,15 @@
 .. _jump_arguments:
 
-Arguments
-=========
+Step Arguments
+==============
 
 The ``jump`` step has many optional arguments that can be set by the user.
 The details for each are listed below.
 
 **Parameters for Baseline Cosmic Ray Jump Detection**
 
-* ``--rejection_threshold``: A floating-point value that sets the sigma
+``--rejection_threshold``
+  A floating-point value that sets the sigma
   threshold for jump detection. In the code, sigma is determined using the read noise from the
   read noise reference file and the Poisson noise (based on the median difference between
   samples and the gain reference file). Note that any noise source beyond these two that
@@ -17,15 +18,18 @@ The details for each are listed below.
   rejection threshold will yield 6200 false positives for every million pixels, if the noise
   model is correct.
 
-* ``--three_group_rejection_threshold``: Cosmic ray sigma rejection threshold for ramps
+``--three_group_rejection_threshold``
+  Cosmic ray sigma rejection threshold for ramps
   having 3 groups. This is a floating-point value with default value of 6.0, and minimum
   of 0.0.
 
-* ``--four_group_rejection_threshold``: Cosmic ray sigma rejection threshold for ramps
+``--four_group_rejection_threshold``
+  Cosmic ray sigma rejection threshold for ramps
   having 4 groups. This is a floating-point value with default value of 5.0, and minimum
   of 0.0.
 
-* ``--maximum_cores``: The number of available cores that will be
+``--maximum_cores``
+  The number of available cores that will be
   used for multi-processing in this step. The default value is '1', which does not use
   multi-processing. The other options are either an integer, 'quarter', 'half', or 'all'.
   Note that these fractions refer to the total available cores and on most CPUs these include
@@ -36,18 +40,21 @@ The details for each are listed below.
   to compute snowballs and/or showers is significant, the reduction in processing time for
   the jump step when using multiprocessing may not be as significant as expected.
 
-* ``--flag_4_neighbors``: If set to True (default is True) it will cause the four perpendicular
+``--flag_4_neighbors``
+  If set to True (default is True) it will cause the four perpendicular
   neighbors of all detected jumps to also be flagged as a jump. This is needed because of
   the inter-pixel capacitance (IPC), which causes a small jump in the neighbors. The small jump
   might be below the rejection threshold, but will affect the slope determination of
   the pixel. The step will take about 40% longer to run when this is set to True.
 
-* ``--max_jump_to_flag_neighbors``: A floating point value in units of sigma that limits
+``--max_jump_to_flag_neighbors``
+  A floating point value in units of sigma that limits
   the flagging of neighbors. Any jump above this cutoff will not have its neighbors flagged.
   The concept is that the jumps in neighbors will be above the rejection threshold and thus
   be flagged as primary jumps. The default value is 200.
 
-* ``--min_jump_to_flag_neighbors``: A floating point value in units of sigma that limits
+``--min_jump_to_flag_neighbors``
+  A floating point value in units of sigma that limits
   the flagging of neighbors of marginal detections. Any primary jump below this value will
   not have its neighbors flagged. The goal is to prevent flagging jumps that would be too
   small to significantly affect the slope determination.  The default value is 10.
@@ -57,66 +64,103 @@ The details for each are listed below.
 After a jump of at least ``after_jump_flag_dn1`` DN, groups up to ``after_jump_flag_time1``
 seconds will also be flagged as jumps. That pair of arguments is defined as:
 
-* ``--after_jump_flag_dn1``: A floating point value in units of DN
-* ``--after_jump_flag_time1``: A floating point value in units of seconds
+``--after_jump_flag_dn1``
+  A floating point value in units of DN
+
+``--after_jump_flag_time1``
+  A floating point value in units of seconds
 
 A second threshold and time can also be set: after a jump of at least ``after_jump_flag_dn2`` DN,
 groups up to ``after_jump_flag_time2`` seconds will also be flagged as jumps. That pair of arguments
 is defined as:
 
-* ``--after_jump_flag_dn2``: A floating point value in units of DN
-* ``--after_jump_flag_time2``: A floating point value in units of seconds
+``--after_jump_flag_dn2``
+  A floating point value in units of DN
+
+``--after_jump_flag_time2``
+  A floating point value in units of seconds
 
 **Parameters that affect Near-IR Snowball Flagging**
 
-* ``--expand_large_events``:  A boolean parameter that controls whether the jump step will expand the number of pixels that are flagged around large cosmic ray events. These are know as "snowballs" in the near-infrared detectors and "showers" for the MIRI detectors. In general, this should be set to `True`.
+``--expand_large_events``
+  A boolean parameter that controls whether the jump step will expand
+  the number of pixels that are flagged around large cosmic ray events.
+  These are know as "snowballs" in the near-infrared detectors and "showers"
+  for the MIRI detectors. In general, this should be set to `True`.
 
-* ``--min_jump_area``: The minimum number of contiguous pixels needed to trigger the expanded flagging of large cosmic rays events.
+``--min_jump_area``
+  The minimum number of contiguous pixels needed to trigger the expanded flagging of large cosmic rays events.
 
-* ``--min_sat_area``:  The minimum number of saturated pixels required to meet ``sat_required_snowball``.
+``--min_sat_area``
+  The minimum number of saturated pixels required to meet ``sat_required_snowball``.
 
-* ``--expand_factor``: A multiplicative factor applied to the enclosing ellipse for snowballs. This larger area will have all pixels flagged as having a jump.
+``--expand_factor``
+  A multiplicative factor applied to the enclosing ellipse for snowballs.
+  This larger area will have all pixels flagged as having a jump.
 
-* ``--sat_required_snowball``: A boolean value that if `True` requires that there are saturated pixels within the enclosed jump circle.
+``--sat_required_snowball``
+  A boolean value that if `True` requires that there are saturated pixels within the enclosed jump circle.
 
-* ``--min_sat_radius_extend``: The minimum radius of the saturated core of a snowball required to for the radius of the saturated core to be extended.
+``--min_sat_radius_extend``
+  The minimum radius of the saturated core of a snowball required for the radius of the saturated core to be extended.
 
-* ``--sat_expand``: Number of pixels to add to the radius of the saturated core of snowballs
+``--sat_expand``
+  Number of pixels to add to the radius of the saturated core of snowballs
 
-* ``--edge_size``: The distance from the edge of the detector where saturated cores are not required for snowball detection
+``--edge_size``
+  The distance from the edge of the detector where saturated cores are not required for snowball detection
 
-* ``--mask_snowball_core_next_int``: Turns on/off the flagging of saturated cores of snowballs in the next integration
+``--mask_snowball_core_next_int``
+  Turns on/off the flagging of saturated cores of snowballs in the next integration
 
-* ``--snowball_time_masked_next_int``: Controls the total time that the saturated cores of snowballs are flagged in the next integration.
+``--snowball_time_masked_next_int``
+  Controls the total time that the saturated cores of snowballs are flagged in the next integration.
 
 **Parameters that affect MIRI Shower Flagging**
 
-* ``--find_showers``: Turn on the detection of showers for the MIRI detectors
+``--find_showers``
+  Turn on the detection of showers for the MIRI detectors
 
-* ``--extend_snr_threshold``: The SNR minimum for the detection of faint extended showers in MIRI
+``--extend_snr_threshold``
+  The SNR minimum for the detection of faint extended showers in MIRI
 
-* ``--extend_min_area``: The required minimum area of extended emission after convolution for the detection of showers in MIRI
+``--extend_min_area``
+  The required minimum area of extended emission after convolution for the detection of showers in MIRI
 
-* ``--extend_inner_radius``: The inner radius of the `~astropy.convolution.Ring2DKernel` that is used for the detection of extended emission in showers
+``--extend_inner_radius``
+  The inner radius of the `~astropy.convolution.Ring2DKernel` that is used
+  for the detection of extended emission in showers
 
-* ``--extend_outer_radius``: The outer radius of the `~astropy.convolution.Ring2DKernel` that is used for the detection of extended emission in showers
+``--extend_outer_radius``
+  The outer radius of the `~astropy.convolution.Ring2DKernel` that is used
+  for the detection of extended emission in showers
 
-* ``--extend_ellipse_expand_ratio``: Multiplicative factor to expand the radius of the ellipse fit to the detected extended emission in MIRI showers
+``--extend_ellipse_expand_ratio``
+  Multiplicative factor to expand the radius of the ellipse fit
+  to the detected extended emission in MIRI showers
 
-* ``--time_masked_after_shower``: Number of seconds to flag groups as jump after a detected extended emission in MIRI showers
+``--time_masked_after_shower``
+  Number of seconds to flag groups as jump after a detected extended emission in MIRI showers
 
-* ``--min_diffs_single_pass``: The minimum number of differences to switch to flagging all outliers at once
+``--min_diffs_single_pass``
+  The minimum number of differences to switch to flagging all outliers at once
 
-* ``--max_shower_amplitude``: The maximum allowable amplitude for MIRI showers in DN/s
+``--max_shower_amplitude``
+  The maximum allowable amplitude for MIRI showers in DN/s
 
 **Parameter that affects both Snowball and Shower flagging**
 
-* ``--max_extended_radius``: The maximum extension of the jump and saturation that will be flagged for showers or snowballs
+``--max_extended_radius``
+  The maximum extension of the jump and saturation that will be flagged for showers or snowballs
 
 **Parameters that affect Sigma Clipping**
 
-* ``--minimum_groups``: The minimum number of groups to run the jump step with sigma clipping
+``--minimum_groups``
+  The minimum number of groups to run the jump step with sigma clipping
 
-* ``--minimum_sigclip_groups``: The minimum number of groups to switch the jump detection to use sigma clipping
+``--minimum_sigclip_groups``
+  The minimum number of groups to switch the jump detection to use sigma clipping
 
-* ``--only_use_ints``: If `True` the sigma clipping is applied only for a given group across all integrations. If not, all groups from all integrations are used for the sigma clipping.
+``--only_use_ints``
+  If `True` the sigma clipping is applied only for a given group across all integrations.
+  If not, all groups from all integrations are used for the sigma clipping.


### PR DESCRIPTION
This PR is a follow-up of https://github.com/spacetelescope/jwst/pull/10238 towards https://github.com/spacetelescope/jwst/issues/9793 and https://github.com/spacetelescope/jwst/issues/10529

https://jwst-pipeline--10610.org.readthedocs.build/en/10610/jwst/jump/arguments.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
