### PR TITLE
Fix small model.update bug in wfss_contam optional products

### DIFF
--- a/changes/10611.wfss_contam.rst
+++ b/changes/10611.wfss_contam.rst
@@ -1,0 +1,1 @@
+Remove empty ERR extensions from _contam and _simul_slits files

--- a/jwst/wfss_contam/tests/test_wfss_contam_step.py
+++ b/jwst/wfss_contam/tests/test_wfss_contam_step.py
@@ -47,6 +47,7 @@ def multislitmodel(
 
     fname = "multislit_model.fits"
     model.save(fname)
+    model.close()
     return fname
 
 
@@ -70,6 +71,7 @@ def test_wfss_contam_step(multislitmodel, tmp_cwd_module):
     assert (tmp_cwd_module / "multislit_model_simul.fits").exists()
     assert (tmp_cwd_module / "multislit_model_simul_slits.fits").exists()
     assert (tmp_cwd_module / "multislit_model_contam.fits").exists()
+    result.close()
 
 
 def test_wfss_contam_step_defaults(multislitmodel, tmp_cwd_module):
@@ -79,6 +81,7 @@ def test_wfss_contam_step_defaults(multislitmodel, tmp_cwd_module):
     result = WfssContamStep.call(multislitmodel)
     assert isinstance(result, dm.MultiSlitModel)
     assert result.meta.cal_step.wfss_contam == "COMPLETE"
+    result.close()
 
 
 def test_wfss_contam_skip_maglimit(multislitmodel, tmp_cwd_module):
@@ -94,6 +97,7 @@ def test_wfss_contam_skip_maglimit(multislitmodel, tmp_cwd_module):
     )
     assert isinstance(result, dm.MultiSlitModel)
     assert result.meta.cal_step.wfss_contam == "SKIPPED"
+    result.close()
 
 
 def test_wfss_contam_skip_bad_order(multislitmodel, tmp_cwd_module):
@@ -109,6 +113,7 @@ def test_wfss_contam_skip_bad_order(multislitmodel, tmp_cwd_module):
     )
     assert isinstance(result, dm.MultiSlitModel)
     assert result.meta.cal_step.wfss_contam == "SKIPPED"
+    result.close()
 
 
 def test_output_is_not_input(multislitmodel, tmp_cwd_module):
@@ -141,3 +146,4 @@ def test_wfss_contam_step_with_polyfit(multislitmodel, tmp_cwd_module):
     result = WfssContamStep.call(multislitmodel, orders=[1], polyfit_degree=2, n_iterations=2)
     assert isinstance(result, dm.MultiSlitModel)
     assert result.meta.cal_step.wfss_contam == "COMPLETE"
+    result.close()

--- a/jwst/wfss_contam/wfss_contam.py
+++ b/jwst/wfss_contam/wfss_contam.py
@@ -797,11 +797,11 @@ def contam_corr(
         if this_simul is not None:
             # turn it into a SlitModel so we can use model.update
             this_simul = datamodels.SlitModel(this_simul.instance)
-            this_simul.update(this_obs)
+            this_simul.update(this_obs, only="SCI")
             simul_slits.slits.append(this_simul)
 
         contam_slit = datamodels.SlitModel()
-        contam_slit.update(this_obs)
+        contam_slit.update(this_obs, only="SCI")
         contam_slit.data = contam_cut
         contam_model.slits.append(contam_slit)
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Relates to [JP-4316](https://jira.stsci.edu/browse/JP-4316)

<!-- describe the changes comprising this PR here -->
This PR addresses a bug introduced by https://github.com/spacetelescope/jwst/pull/10509 where the optional `_contam.fits` and `_simul_slits.fits` files had empty ERR extensions in each of the slits.  This was caused by calls to `model.update()` carrying over the `bunit_err` keyword, which lives in the ERR extension.  This PR gives the offending `update` calls the `only="SCI"` option which fixes the problem.

This PR also adds some explicit `model.close()` calls in an attempt to fix intermittent file I/O errors in CI during `test_wfss_contam_step.py`.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
