### PR TITLE
DOC: Formatting fix for source_catalog arguments

### DIFF
--- a/docs/jwst/source_catalog/arguments.rst
+++ b/docs/jwst/source_catalog/arguments.rst
@@ -1,115 +1,125 @@
-Arguments
-=========
+Step Arguments
+==============
 
-The ``source_catalog`` step uses the following user-settable arguments:
+The ``source_catalog`` step has the following optional arguments.
 
 **General parameters:**
 
-* ``--suffix``: A string value giving the file name suffix to use for
-  the output catalog file. (Default='cat')
+``--suffix`` (str, default='cat')
+  File name suffix to use for the output catalog file.
 
 **Aperture photometry parameters:**
 
-* ``--aperture_ee1``: An integer value of the smallest aperture
-  encircled energy value. (Default=30)
+``--aperture_ee1`` (int, default=30)
+  Value of the smallest aperture encircled energy.
 
-* ``--aperture_ee2``: An integer value of the middle aperture encircled
-  energy value. (Default=50)
+``--aperture_ee2`` (int, default=50)
+  Value of the middle aperture encircled energy.
 
-* ``--aperture_ee3``: An integer value of the largest aperture encircled
-  energy value. (Default=70)
+``--aperture_ee3`` (int, default=70)
+  Value of the largest aperture encircled energy.
 
-* ``--ci1_star_threshold``: A floating-point value of the threshold
-  compared to the concentration index calculated from aperture_ee1
-  and aperture_ee2 that is used to determine whether a source is a
-  star. Sources must meet the criteria of both ci1_star_threshold and
-  ci2_star_threshold to be considered a star. (Default=2.0)
+``--ci1_star_threshold`` (float, default=2.0)
+  The threshold
+  compared to the concentration index calculated from ``aperture_ee1``
+  and ``aperture_ee2`` that is used to determine whether a source is a
+  star. Sources must meet the criteria of both ``ci1_star_threshold`` and
+  ``ci2_star_threshold`` to be considered a star.
 
-* ``--ci2_star_threshold``: A floating-point value of the threshold
-  compared to the concentration index calculated from aperture_ee2
-  and aperture_ee3 that is used to determine whether a source is a
-  star. Sources must meet the criteria of both ci1_star_threshold and
-  ci2_star_threshold to be considered a star. (Default=1.8)
-
+``--ci2_star_threshold`` (float, default=1.8)
+  The threshold
+  compared to the concentration index calculated from ``aperture_ee2``
+  and ``aperture_ee3`` that is used to determine whether a source is a
+  star. Sources must meet the criteria of both ``ci1_star_threshold`` and
+  ``ci2_star_threshold`` to be considered a star.
 
 **General source finding parameters:**
 
-* ``starfinder``: A `str` indicating the source detection algorithm to use.
-  Allowed values: ``'iraf'``, ``'dao'``, ``'segmentation'``. (Default= ``'segmentation'``)
+``--starfinder`` (str, default='segmentation')
+  The source detection algorithm to use.
+  Allowed values: ``'iraf'``, ``'dao'``, ``'segmentation'``.
 
-* ``snr_threshold``: A `float` value indicating SNR threshold above the
-  background. Required for all star finders. (Default=3.0)
+``--snr_threshold`` (float, default=3.0)
+  SNR threshold above the
+  background. Required for all star finders.
 
-* ``bkg_boxsize``: A positive `int` indicating the background mesh box size
-  in pixels. (Default=1000)
+``--bkg_boxsize`` (int, default=1000)
+  A positive value indicating the background mesh box size
+  in pixels.
 
-* ``kernel_fwhm``: A `float` value indicating the Gaussian kernel FWHM in
-  pixels. (Default=2.0)
-
+``--kernel_fwhm`` (float, default=2.0)
+  The Gaussian kernel FWHM in pixels.
 
 **Additional source finding parameters for "segmentation":**
 
-* ``npixels``: An `int` value indicating the minimum number of
-  connected pixels that comprises a segment (Default=25)
+``--npixels`` (int, default=25)
+  The minimum number of connected pixels that comprises a segment.
 
-* ``connectivity``: An `int` value indicating the connectivity defining the
-  neighborhood of a pixel. Options are ``4``, i.e., connected pixels touch along edges,
-  or ``8``, i.e, connected pixels touch along edges or corners (Default=8)
+``--connectivity`` (int, default=8)
+  The connectivity defining the neighborhood of a pixel.
+  Options are ``4``, i.e., connected pixels touch along edges,
+  or ``8``, i.e, connected pixels touch along edges or corners.
 
-* ``nlevels``: An `int` value indicating the number of multi-thresholding
-  levels for deblending (Default=32)
+``--nlevels`` (int, default=32)
+  The number of multi-thresholding levels for deblending.
 
-* ``contrast``: A `float` value indicating the fraction of total source flux
-  an object must have to be deblended (Default=0.001)
+``--contrast`` (float, default=0.001)
+  The fraction of total source flux an object must have to be deblended.
 
-* ``multithresh_mode``: A `str` indicating the multi-thresholding mode.
+``--multithresh_mode`` (str, default='exponential')
+  The multi-thresholding mode.
   Allowed values: ``'exponential'``, ``'linear'``, ``'sinh'``.
-  (Default= ``'exponential'``)
 
-* ``localbkg_width``: An `int` value indicating the width of rectangular
+``--localbkg_width`` (int, default=0)
+  The width of rectangular
   annulus used to compute local background around each source. If set to 0,
-  then local background will not be subtracted. (Default=0)
+  then local background will not be subtracted.
 
-* ``apermask_method``: A `str` indicating the method used to handle
+``--apermask_method`` (str, default='correct')
+  The method used to handle
   neighboring sources when performing aperture photometry.
-  Allowed values: ``'correct'``, ``'mask'``, ``'none'``. (Default= ``'correct'``)
+  Allowed values: ``'correct'``, ``'mask'``, ``'none'``.
 
-* ``kron_params``: A tuple of `float` values indicating the
-  parameters defining Kron aperture. If None,
-  the parameters ``(2.5, 1.4, 0.0)`` are used. (Default=None)
+``--kron_params`` (tuple of float, default=None)
+  The parameters defining Kron aperture. If None,
+  the parameters ``(2.5, 1.4, 0.0)`` are used.
 
-* ``deblend``: A `bool` indicating whether to deblend sources. (Default=False)
-
+``--deblend`` (bool, default=False)
+  Indicator for whether to deblend sources.
 
 **Additional source finding parameters for "dao" and "iraf":**
 
-* ``minsep_fwhm``: A `float` value indicating the minimum separation between
-  detected objects in units of number of FWHMs. (Default=0.0)
+``--minsep_fwhm`` (float, default=0.0)
+  The minimum separation between
+  detected objects in units of number of FWHMs.
 
-* ``sigma_radius``: A `float` value indicating the truncation radius of the
-  Gaussian kernel in units of number of FWHMs. (Default=1.5)
+``--sigma_radius`` (float, default=1.5)
+  The truncation radius of the
+  Gaussian kernel in units of number of FWHMs.
 
-* ``sharplo``: A `float` value indicating The lower bound on sharpness
-  for object detection. (Default=0.5)
+``--sharplo`` (float, default=0.5)
+  The lower bound on sharpness for object detection.
 
-* ``sharphi``: A `float` value indicating the upper bound on sharpness
-  for object detection. (Default=2.0)
+``--sharphi`` (float, default=2.0)
+  The upper bound on sharpness for object detection.
 
-* ``roundlo``: A `float` value indicating the lower bound on roundness
-  for object detection. (Default=0.0)
+``--roundlo`` (float, default=0.0)
+  The lower bound on roundness for object detection.
 
-* ``roundhi``: A `float` value indicating the upper bound on roundness
-  for object detection. (Default=0.2)
+``--roundhi`` (float, default=0.2)
+  The upper bound on roundness for object detection.
 
-* ``brightest``: A positive `int` value indicating the number of brightest
-  objects to keep. If None, keep all objects above the threshold. (Default=200)
+``--brightest`` (int, default=200)
+  A positive value indicating the number of brightest
+  objects to keep. If None, keep all objects above the threshold.
 
-* ``peakmax``: A `float` value used to filter out objects with pixel values
-  >= ``peakmax``. (Default=None)
+``--peakmax`` (float, default=None)
+  A value used to filter out objects with pixel values
+  ``>= peakmax``.
 
 .. warning::
   Different source finding algorithms have different values for the
-  ``sharplo``, ``sharphi``, ``roundlo`` and ``roundhi`` parameters. These
+  ``sharplo``, ``sharphi``, ``roundlo``, and ``roundhi`` parameters. These
   parameters should be adjusted to match the algorithm selected by the
   ``starfinder`` parameter. See documentation for
   `~photutils.detection.IRAFStarFinder`


### PR DESCRIPTION
This PR is a follow-up of https://github.com/spacetelescope/jwst/pull/10149 towards https://github.com/spacetelescope/jwst/issues/9793 and https://github.com/spacetelescope/jwst/issues/10529

https://jwst-pipeline--10614.org.readthedocs.build/en/10614/jwst/source_catalog/arguments.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
