### PR TITLE
JP-4130: Metadata improvements for SOSS and other tso3 products

### DIFF
--- a/changes/10616.extract_1d.rst
+++ b/changes/10616.extract_1d.rst
@@ -1,0 +1,1 @@
+Metadata improvements for FITS output for SOSS spectra: stop creating an empty SCI FITS extension containing only header values and stop adding an unnecessary INT_NUM value to EXTRACT1D extensions.

--- a/changes/10616.pipeline.rst
+++ b/changes/10616.pipeline.rst
@@ -1,0 +1,1 @@
+For TSO spectroscopy, blend metadata from all input exposures for the output ``x1dints`` product.

--- a/changes/10616.pipeline.rst
+++ b/changes/10616.pipeline.rst
@@ -1,1 +1,1 @@
-For TSO spectroscopy, blend metadata from all input exposures for the output ``x1dints`` product.
+For TSO spectroscopy, blend metadata from all input exposures for the output ``x1dints`` product instead of taking all metadata from the first exposure.

--- a/changes/10616.white_light.rst
+++ b/changes/10616.white_light.rst
@@ -1,0 +1,1 @@
+Add units to the flux columns in the white light table output.

--- a/jwst/clean_flicker_noise/tso_median_image.py
+++ b/jwst/clean_flicker_noise/tso_median_image.py
@@ -273,9 +273,9 @@ def make_median_image(input_model, rateints_model, soss_refmodel=None):
 
         if exp_type == "NRS_BRIGHTOBJ":
             detector = input_model.meta.instrument.detector
-            wlc_flux = whitelight_table[f"whitelight_flux_{detector}"]
+            wlc_flux = whitelight_table[f"whitelight_flux_{detector}"].value
         else:
-            wlc_flux = whitelight_table["whitelight_flux"]
+            wlc_flux = whitelight_table["whitelight_flux"].value
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)

--- a/jwst/extract_1d/soss_extract/soss_extract.py
+++ b/jwst/extract_1d/soss_extract/soss_extract.py
@@ -1597,8 +1597,14 @@ def _reconstruct_spec_from_data(spec_data):
     spec = datamodels.SpecModel(spec_table=out_table)
     spec.spectral_order = spec_data["spectral_order"]
 
-    # Int_num is used only for ATOCA spectra
+    # Int_num is used only for ATOCA spectra. It will be None for regular output spectra.
     spec.int_num = spec_data.get("int_num")
+
+    # Set units for the spectral table. Assume uncalibrated flux, wavelength in um.
+    spec.spec_table.columns["wavelength"].unit = "um"
+    spec.spec_table.columns["flux"].unit = "DN/s"
+    spec.spec_table.columns["flux_error"].unit = "DN/s"
+    spec.spec_table.columns["background"].unit = "DN/s"
 
     return spec
 

--- a/jwst/extract_1d/soss_extract/soss_extract.py
+++ b/jwst/extract_1d/soss_extract/soss_extract.py
@@ -1562,7 +1562,6 @@ def _process_one_integration(
             "background": integration.col_bkg[:table_size],
             "npixels": npixels[order][:table_size],
             "spectral_order": ORDER_STR_TO_INT[order],
-            "int_num": int_num,
         }
 
     return tracemodels, spec_list_data, atoca_list_data, tikfacs_out, wave_grid
@@ -1597,7 +1596,9 @@ def _reconstruct_spec_from_data(spec_data):
 
     spec = datamodels.SpecModel(spec_table=out_table)
     spec.spectral_order = spec_data["spectral_order"]
-    spec.int_num = spec_data["int_num"]
+
+    # Int_num is used only for ATOCA spectra
+    spec.int_num = spec_data.get("int_num")
 
     return spec
 
@@ -1698,17 +1699,17 @@ def run_extract1d(
 
     # Initialize the output model.
     output_model = datamodels.TSOMultiSpecModel()
-    output_model.update(input_model)  # Copy meta data from input to output.
+    output_model.update(input_model, only="PRIMARY")  # Copy meta data from input to output.
 
     # Initialize output spectra returned by ATOCA
     # NOTE: these diagnostic spectra are formatted as a simple MultiSpecModel,
     # with integrations in separate spectral extensions.
     output_atoca = datamodels.MultiSpecModel()
-    output_atoca.update(input_model)
+    output_atoca.update(input_model, only="PRIMARY")
 
     # Initialize output references (model of the detector and box aperture weights).
     output_references = datamodels.SossExtractModel()
-    output_references.update(input_model)
+    output_references.update(input_model, only="PRIMARY")
 
     # Convert to Cube if datamodels is an ImageModel
     if isinstance(input_model, datamodels.ImageModel):

--- a/jwst/extract_1d/tests/test_extract_1d_step.py
+++ b/jwst/extract_1d/tests/test_extract_1d_step.py
@@ -220,7 +220,7 @@ def test_extract_niriss_soss_96(tmp_path, mock_niriss_soss_96):
     assert (tmp_path / "test_x1dints.fits").is_file()
 
     # Make sure the output spectrum does not have a SCI or ERR extension
-    # These sometimes get added accidentally in model metadata updates.
+    # This covers a bug where these were added accidentally in model metadata updates.
     with fits.open(str(tmp_path / "test_x1dints.fits")) as hdul:
         ext_names = [hdu.name for hdu in hdul]
         assert "EXTRACT1D" in ext_names

--- a/jwst/extract_1d/tests/test_extract_1d_step.py
+++ b/jwst/extract_1d/tests/test_extract_1d_step.py
@@ -3,6 +3,7 @@ import os
 import numpy as np
 import pytest
 import stdatamodels.jwst.datamodels as dm
+from astropy.io import fits
 
 from jwst.datamodels import ModelContainer, SourceModelContainer
 from jwst.extract_1d.extract_1d_step import Extract1dStep
@@ -154,7 +155,6 @@ def test_extract_niriss_wfss(mock_niriss_wfss_l3, simple_wcs):
     result.close()
 
 
-@pytest.mark.slow
 def test_extract_niriss_soss_256(tmp_path, mock_niriss_soss_256):
     result = Extract1dStep.call(
         mock_niriss_soss_256,
@@ -193,12 +193,14 @@ def test_extract_niriss_soss_256(tmp_path, mock_niriss_soss_256):
     result2.close()
 
 
-@pytest.mark.slow
 def test_extract_niriss_soss_96(tmp_path, mock_niriss_soss_96):
     result = Extract1dStep.call(
         mock_niriss_soss_96,
         soss_rtol=0.1,
         soss_modelname="soss_model.fits",
+        save_results=True,
+        output_file="test",
+        suffix="x1dints",
         output_dir=str(tmp_path),
     )
     assert result.meta.cal_step.extract_1d == "COMPLETE"
@@ -213,8 +215,17 @@ def test_extract_niriss_soss_96(tmp_path, mock_niriss_soss_96):
     result.close()
 
     # soss output files are saved
-    assert os.path.isfile(tmp_path / "soss_model_SossExtractModel.fits")
-    assert os.path.isfile(tmp_path / "soss_model_AtocaSpectra.fits")
+    assert (tmp_path / "soss_model_SossExtractModel.fits").is_file()
+    assert (tmp_path / "soss_model_AtocaSpectra.fits").is_file()
+    assert (tmp_path / "test_x1dints.fits").is_file()
+
+    # Make sure the output spectrum does not have a SCI or ERR extension
+    # These sometimes get added accidentally in model metadata updates.
+    with fits.open(str(tmp_path / "test_x1dints.fits")) as hdul:
+        ext_names = [hdu.name for hdu in hdul]
+        assert "EXTRACT1D" in ext_names
+        assert "SCI" not in ext_names
+        assert "ERR" not in ext_names
 
 
 def test_extract_niriss_soss_superstripe(mock_niriss_soss_superstripe):

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -986,9 +986,10 @@ class DataSet:
             match_nans_and_flags(slit)
 
         elif isinstance(self.input, datamodels.TSOMultiSpecModel):
-            # Does this block need to address SB columns as well, or will
-            # they (presumably) never be populated for SOSS?
-            # It appears flux_error is the only error column populated?
+            # This block does not address SB columns - they are never populated for SOSS.
+            # Variance columns are also not currently populated for SOSS: they are
+            # zero-filled. Conversions are applied here anyway in case variances are
+            # populated in the future.
             spec = self.input.spec[self.specnum]
             spec.spec_table.FLUX[self.integ_row] *= conversion
             spec.spec_table.FLUX_ERROR[self.integ_row] *= conversion
@@ -1000,16 +1001,21 @@ class DataSet:
             spec.spec_table.BKGD_VAR_POISSON[self.integ_row] *= conversion**2.0
             spec.spec_table.BKGD_VAR_RNOISE[self.integ_row] *= conversion**2.0
             spec.spec_table.BKGD_VAR_FLAT[self.integ_row] *= conversion**2.0
-            spec.spec_table.columns["FLUX"].unit = "MJy"
-            spec.spec_table.columns["FLUX_ERROR"].unit = "MJy"
-            spec.spec_table.columns["FLUX_VAR_POISSON"].unit = "MJy^2"
-            spec.spec_table.columns["FLUX_VAR_RNOISE"].unit = "MJy^2"
-            spec.spec_table.columns["FLUX_VAR_FLAT"].unit = "MJy^2"
-            spec.spec_table.columns["BACKGROUND"].unit = "MJy"
-            spec.spec_table.columns["BKGD_ERROR"].unit = "MJy"
-            spec.spec_table.columns["BKGD_VAR_POISSON"].unit = "MJy^2"
-            spec.spec_table.columns["BKGD_VAR_RNOISE"].unit = "MJy^2"
-            spec.spec_table.columns["BKGD_VAR_FLAT"].unit = "MJy^2"
+
+            # TODO: confirm flux unit. The photmj value may be delivered as Jy, not MJy,
+            #  for calibrating extracted SOSS spectra.
+            flux_unit = "MJy"
+            flux_squared_unit = "MJy^2"
+            spec.spec_table.columns["FLUX"].unit = flux_unit
+            spec.spec_table.columns["FLUX_ERROR"].unit = flux_unit
+            spec.spec_table.columns["FLUX_VAR_POISSON"].unit = flux_squared_unit
+            spec.spec_table.columns["FLUX_VAR_RNOISE"].unit = flux_squared_unit
+            spec.spec_table.columns["FLUX_VAR_FLAT"].unit = flux_squared_unit
+            spec.spec_table.columns["BACKGROUND"].unit = flux_unit
+            spec.spec_table.columns["BKGD_ERROR"].unit = flux_unit
+            spec.spec_table.columns["BKGD_VAR_POISSON"].unit = flux_squared_unit
+            spec.spec_table.columns["BKGD_VAR_RNOISE"].unit = flux_squared_unit
+            spec.spec_table.columns["BKGD_VAR_FLAT"].unit = flux_squared_unit
 
         else:
             conversion_squared = conversion * conversion

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -8,6 +8,7 @@ from stdatamodels.jwst import datamodels
 from jwst.adaptive_trace_model import adaptive_trace_model_step
 from jwst.extract_1d import extract_1d_step
 from jwst.lib.pipe_utils import is_tso
+from jwst.model_blender.blender import ModelBlender
 from jwst.outlier_detection import outlier_detection_step
 from jwst.photom import photom_step
 from jwst.pixel_replace import pixel_replace_step
@@ -133,7 +134,6 @@ class Tso3Pipeline(Pipeline):
 
             # Working with spectroscopic TSO data;
             # define output for x1d (level 3) products
-
             x1d_result = datamodels.TSOMultiSpecModel()
             x1d_result.update(input_models[0], only="PRIMARY")
             nint = input_models[0].meta.exposure.nints
@@ -156,6 +156,7 @@ class Tso3Pipeline(Pipeline):
             # For each exposure in the TSO...
             atm_status = []
             pr_status = []
+            blender = ModelBlender()
             for cube in input_models:
                 # model the spectral trace
                 cube = self.adaptive_trace_model.run(cube)
@@ -189,6 +190,7 @@ class Tso3Pipeline(Pipeline):
                     result = self.photom.run(result)
 
                 x1d_result.spec.extend(result.spec)
+                blender.accumulate(result)
 
             # Skip remaining processing if no spectra were extracted
             if len(x1d_result.spec) == 0:
@@ -198,6 +200,9 @@ class Tso3Pipeline(Pipeline):
                 # perform white-light photometry on all 1d extracted data
                 log.info("Performing white-light photometry")
                 phot_result_list.append(self.white_light.run(x1d_result))
+
+                # Update blended metadata
+                blender.finalize_model(x1d_result)
 
                 # Update some metadata from the association
                 x1d_result.meta.asn.pool_name = input_models.asn_table["asn_pool"]

--- a/jwst/pipeline/tests/test_calwebb_tso3.py
+++ b/jwst/pipeline/tests/test_calwebb_tso3.py
@@ -212,3 +212,35 @@ def test_tso3_single_model_input(tmp_path):
     # Input is not modified
     assert input_model.meta.cal_step.instance == model_copy.meta.cal_step.instance
     np.testing.assert_allclose(input_model.data, model_copy.data)
+
+
+def test_tso3_model_blender(tmp_path):
+    """Test metadata blending for tso3."""
+    model_1 = niriss_soss_tso()
+    model_1.meta.filename = "test_tso3_1_calints.fits"
+    model_1.meta.exposure.integration_start = 1
+    model_1.meta.exposure.integration_end = 2
+    model_1.meta.exposure.exposure_time = 20.0
+    model_2 = niriss_soss_tso()
+    model_2.meta.exposure.integration_start = 3
+    model_2.meta.exposure.integration_end = 4
+    model_2.meta.exposure.exposure_time = 20.0
+    model_2.meta.filename = "test_tso3_2_calints.fits"
+
+    # Reduce runtime for soss extraction
+    steps = {"extract_1d": {"soss_rtol": 0.1, "soss_tikfac": 2.434559775e-13}}
+    Tso3Pipeline.call(
+        [model_1, model_2], output_dir=str(tmp_path), steps=steps, output_file="test_tso3"
+    )
+
+    # Check for expected output files
+    expected = ["test_tso3_x1dints.fits", "test_tso3_whtlt.ecsv"]
+    for filename in expected:
+        assert (tmp_path / filename).exists()
+
+    # Output has blended metadata
+    with dm.open(tmp_path / "test_tso3_x1dints.fits") as result:
+        assert result.meta.filename == "test_tso3_x1dints.fits"
+        assert result.meta.exposure.integration_start == 1
+        assert result.meta.exposure.integration_end == 4
+        assert result.meta.exposure.exposure_time == 40.0

--- a/jwst/white_light/tests/test_white_light.py
+++ b/jwst/white_light/tests/test_white_light.py
@@ -160,9 +160,12 @@ def make_datamodel():
     return model
 
 
-def test_white_light(make_datamodel, monkeypatch):
+@pytest.mark.parametrize("units", ["Jy", None])
+def test_white_light(make_datamodel, monkeypatch, units):
     """Test white light step"""
-    data = make_datamodel
+    data = make_datamodel.copy()
+    for spec in data.spec:
+        spec.spec_table.columns["FLUX"].unit = units
 
     watcher = LogWatcher("1 spectra in order 1 with no mid time or duplicate mid time (20")
     monkeypatch.setattr(logging.getLogger("jwst.white_light.white_light"), "warning", watcher)
@@ -198,8 +201,11 @@ def test_white_light(make_datamodel, monkeypatch):
     expected_flux_order_1[-3] = np.nan  # the third was order 2 only
     expected_flux_order_2 = expected_flux.copy()
 
-    assert_allclose(result["whitelight_flux_order_1"], expected_flux_order_1, equal_nan=True)
-    assert_allclose(result["whitelight_flux_order_2"], expected_flux_order_2, equal_nan=True)
+    assert_allclose(result["whitelight_flux_order_1"].value, expected_flux_order_1, equal_nan=True)
+    assert_allclose(result["whitelight_flux_order_2"].value, expected_flux_order_2, equal_nan=True)
+
+    assert result["whitelight_flux_order_1"].unit == units
+    assert result["whitelight_flux_order_2"].unit == units
 
 
 def test_white_light_multi_detector(make_datamodel):

--- a/jwst/white_light/tests/test_white_light.py
+++ b/jwst/white_light/tests/test_white_light.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from astropy import units as u
 from astropy.table import Table
 from numpy.testing import assert_allclose
 from stdatamodels.jwst import datamodels
@@ -98,6 +99,9 @@ def make_datamodel():
     spec_model = datamodels.SpecModel(spec_table=otab)
     spec_model.spectral_order = 1
 
+    # Add a unit to the table to propagate
+    spec_model.spec_table.columns["FLUX"].unit = "Jy"
+
     spec_list_1 = [spec_model.copy() for _ in range(n_spec)]
 
     # change spectral order to test multiple orders in output table
@@ -160,12 +164,12 @@ def make_datamodel():
     return model
 
 
-@pytest.mark.parametrize("units", ["Jy", None])
-def test_white_light(make_datamodel, monkeypatch, units):
+@pytest.mark.parametrize("flux_unit", ["Jy", "DN/s", None])
+def test_white_light(make_datamodel, monkeypatch, flux_unit):
     """Test white light step"""
     data = make_datamodel.copy()
     for spec in data.spec:
-        spec.spec_table.columns["FLUX"].unit = units
+        spec.spec_table.columns["FLUX"].unit = flux_unit
 
     watcher = LogWatcher("1 spectra in order 1 with no mid time or duplicate mid time (20")
     monkeypatch.setattr(logging.getLogger("jwst.white_light.white_light"), "warning", watcher)
@@ -197,15 +201,17 @@ def test_white_light(make_datamodel, monkeypatch, units):
         ]
         * len(mid_times)
     )
+    if flux_unit is not None:
+        expected_flux = expected_flux << u.Unit(flux_unit)
     expected_flux_order_1 = expected_flux.copy()
     expected_flux_order_1[-3] = np.nan  # the third was order 2 only
     expected_flux_order_2 = expected_flux.copy()
 
-    assert_allclose(result["whitelight_flux_order_1"].value, expected_flux_order_1, equal_nan=True)
-    assert_allclose(result["whitelight_flux_order_2"].value, expected_flux_order_2, equal_nan=True)
+    assert_allclose(result["whitelight_flux_order_1"], expected_flux_order_1, equal_nan=True)
+    assert_allclose(result["whitelight_flux_order_2"], expected_flux_order_2, equal_nan=True)
 
-    assert result["whitelight_flux_order_1"].unit == units
-    assert result["whitelight_flux_order_2"].unit == units
+    assert result["whitelight_flux_order_1"].unit == flux_unit
+    assert result["whitelight_flux_order_2"].unit == flux_unit
 
 
 def test_white_light_multi_detector(make_datamodel):

--- a/jwst/white_light/tests/test_white_light.py
+++ b/jwst/white_light/tests/test_white_light.py
@@ -24,7 +24,7 @@ TIME_KEYS = [
 ]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def make_datamodel():
     """Make data for white light tests"""
     n_spec = 5
@@ -99,9 +99,6 @@ def make_datamodel():
     spec_model = datamodels.SpecModel(spec_table=otab)
     spec_model.spectral_order = 1
 
-    # Add a unit to the table to propagate
-    spec_model.spec_table.columns["FLUX"].unit = "Jy"
-
     spec_list_1 = [spec_model.copy() for _ in range(n_spec)]
 
     # change spectral order to test multiple orders in output table
@@ -167,7 +164,7 @@ def make_datamodel():
 @pytest.mark.parametrize("flux_unit", ["Jy", "DN/s", None])
 def test_white_light(make_datamodel, monkeypatch, flux_unit):
     """Test white light step"""
-    data = make_datamodel.copy()
+    data = make_datamodel
     for spec in data.spec:
         spec.spec_table.columns["FLUX"].unit = flux_unit
 
@@ -217,7 +214,7 @@ def test_white_light(make_datamodel, monkeypatch, flux_unit):
 def test_white_light_multi_detector(make_datamodel):
     """Test white light step on data with multiple detectors."""
     # Set the detectors in the two spec tables to different values
-    data = make_datamodel.copy()
+    data = make_datamodel
     data.spec[0].detector = "NRS1"
     data.spec[1].detector = "NRS2"
 
@@ -267,7 +264,7 @@ def test_white_light_multi_detector(make_datamodel):
 def test_white_light_duplicate_times(monkeypatch, make_datamodel):
     """Test white light step on data with duplicate time stamps."""
     # Set all times to the same value for order 1
-    data = make_datamodel.copy()
+    data = make_datamodel
     for key in TIME_KEYS:
         data.spec[0].spec_table[key][:] = data.spec[0].spec_table[key][0]
 
@@ -369,7 +366,7 @@ def test_get_reference_wavelength_range(make_datamodel):
 
 def test_get_reference_wavelength_range_other_exptype(make_datamodel):
     """Test that non-SOSS exposure types return None."""
-    model = make_datamodel.copy()
+    model = make_datamodel
     model.meta.exposure.type = "NRC_TSIMAGE"
     wr = WhiteLightStep()._get_reference_wavelength_range(model)
     assert wr is None
@@ -377,7 +374,7 @@ def test_get_reference_wavelength_range_other_exptype(make_datamodel):
 
 def test_get_reference_wavelength_range_no_file(make_datamodel, monkeypatch, log_watcher):
     """Test that missing wavelength range reference files are handled."""
-    model = make_datamodel.copy()
+    model = make_datamodel
     monkeypatch.setattr(WhiteLightStep, "get_reference_file", lambda *args: "N/A")
 
     watcher = log_watcher(

--- a/jwst/white_light/white_light.py
+++ b/jwst/white_light/white_light.py
@@ -4,6 +4,7 @@ import logging
 from collections import OrderedDict
 
 import numpy as np
+from astropy import units as u
 from astropy.table import QTable
 
 log = logging.getLogger(__name__)
@@ -43,10 +44,14 @@ def white_light(input_model, waverange_table=None, min_wave=None, max_wave=None)
     mid_times = []
     mid_tdbs = []
     flux_sums = []
-
+    flux_units = None
     # Loop over the spectra in the input model and find mid times and fluxes
     for spec in input_model.spec:
         n_spec = len(spec.spec_table)
+
+        # Take flux units from the first spectrum.
+        if flux_units is None:
+            flux_units = spec.spec_table.columns["FLUX"].unit
 
         # Figure out the spectral order for this spectrum
         spectral_order = getattr(spec, "spectral_order", None)
@@ -164,7 +169,10 @@ def white_light(input_model, waverange_table=None, min_wave=None, max_wave=None)
             if len(sporders) > 1:
                 # add the spectral order to the column name if there are more than 1
                 colname += f"_order_{order}"
-            tbl[f"{colname}{detector_name}"] = fluxes
+            if flux_units is not None:
+                tbl[f"{colname}{detector_name}"] = fluxes << u.Unit(flux_units)
+            else:
+                tbl[f"{colname}{detector_name}"] = fluxes
 
     return tbl
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4130](https://jira.stsci.edu/browse/JP-4130)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Clean up some metadata values for SOSS spectra:
- don't create an empty SCI extension for SOSS spectra
- don't add meaningless int_num to regular SOSS spectra

Also improve metadata for all tso3 products:
- blend metadata in tso3 to combine exposure values and set cal_step status in output
- add units to extracted spectra and whitelight product

Also included here is a placeholder for reconsidering the flux units for SOSS spectra.  They are currently hard-coded to MJy, which matches expectations for the commissioning-era photom file.  More recent files have been delivered with PHOTMJ in Jy/(DN/s).  We'll defer handling this inconsistency for the next build; for now, I'm just marking the issue with a `TODO` comment.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [x] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
