### PR TITLE
Read cross-slit offset for LRS slit

### DIFF
--- a/changes/10617.pathloss.rst
+++ b/changes/10617.pathloss.rst
@@ -1,0 +1,1 @@
+Added functionality for propagating cross-slit offsets to the source position used for pathloss correction.

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -124,7 +124,8 @@ def get_center(exp_type, input_model, offsets=False):
         if input_model.meta.dither.y_offset is not None:
             location = (_ref_ra, _ref_dec, ref_wave)
             scale_degrees = compute_scale(
-                input_model.meta.wcs, location, disp_axis=input_model.meta.wcsinfo.dispersion_direction
+                input_model.meta.wcs, location, 
+                disp_axis=input_model.meta.wcsinfo.dispersion_direction
             )
             scale_arcsec = scale_degrees * 3600.0
             yoffset = input_model.meta.dither.y_offset / scale_arcsec

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -119,6 +119,16 @@ def get_center(exp_type, input_model, offsets=False):
             input_model.meta.target.ra, input_model.meta.target.dec, ref_wave
         )
         log.info(f"LRS target location from RA/Dec = {xcenter, ycenter}")
+
+        # compute cross-slit dither offset
+        location = (_ref_ra, _ref_dec, ref_wave)
+        scale_degrees = util.compute_scale(
+                input_model.meta.wcs, location, disp_axis=input_model.meta.wcsinfo.dispersion_direction
+            )
+        scale_arcsec = scale_degrees * 3600.0
+        yoffset = input_model.meta.dither.y_offset / scale_arcsec
+        ycenter += yoffset
+        log.info(f"Cross-slit dither offset = {yoffset} px") 
     else:
         log.info(f"LRS target location from source_xpos, source_ypos = {xcenter, ycenter}")
 

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -123,8 +123,8 @@ def get_center(exp_type, input_model, offsets=False):
         # compute cross-slit dither offset
         location = (_ref_ra, _ref_dec, ref_wave)
         scale_degrees = util.compute_scale(
-                input_model.meta.wcs, location, disp_axis=input_model.meta.wcsinfo.dispersion_direction
-            )
+            input_model.meta.wcs, location, disp_axis=input_model.meta.wcsinfo.dispersion_direction
+        )
         scale_arcsec = scale_degrees * 3600.0
         yoffset = input_model.meta.dither.y_offset / scale_arcsec
         ycenter += yoffset

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -122,7 +122,7 @@ def get_center(exp_type, input_model, offsets=False):
 
         # compute cross-slit dither offset
         location = (_ref_ra, _ref_dec, ref_wave)
-        scale_degrees = util.compute_scale(
+        scale_degrees = compute_scale(
             input_model.meta.wcs, location, disp_axis=input_model.meta.wcsinfo.dispersion_direction
         )
         scale_arcsec = scale_degrees * 3600.0

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -124,7 +124,7 @@ def get_center(exp_type, input_model, offsets=False):
         if input_model.meta.dither.y_offset is not None:
             location = (_ref_ra, _ref_dec, ref_wave)
             scale_degrees = compute_scale(
-                input_model.meta.wcs, location, 
+                input_model.meta.wcs, location,
                 disp_axis=input_model.meta.wcsinfo.dispersion_direction
             )
             scale_arcsec = scale_degrees * 3600.0

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -128,7 +128,7 @@ def get_center(exp_type, input_model, offsets=False):
         scale_arcsec = scale_degrees * 3600.0
         yoffset = input_model.meta.dither.y_offset / scale_arcsec
         ycenter += yoffset
-        log.info(f"Cross-slit dither offset = {yoffset} px") 
+        log.info(f"Cross-slit dither offset = {yoffset} px")
     else:
         log.info(f"LRS target location from source_xpos, source_ypos = {xcenter, ycenter}")
 

--- a/jwst/pathloss/pathloss.py
+++ b/jwst/pathloss/pathloss.py
@@ -121,14 +121,15 @@ def get_center(exp_type, input_model, offsets=False):
         log.info(f"LRS target location from RA/Dec = {xcenter, ycenter}")
 
         # compute cross-slit dither offset
-        location = (_ref_ra, _ref_dec, ref_wave)
-        scale_degrees = compute_scale(
-            input_model.meta.wcs, location, disp_axis=input_model.meta.wcsinfo.dispersion_direction
-        )
-        scale_arcsec = scale_degrees * 3600.0
-        yoffset = input_model.meta.dither.y_offset / scale_arcsec
-        ycenter += yoffset
-        log.info(f"Cross-slit dither offset = {yoffset} px")
+        if input_model.meta.dither.y_offset is not None:
+            location = (_ref_ra, _ref_dec, ref_wave)
+            scale_degrees = compute_scale(
+                input_model.meta.wcs, location, disp_axis=input_model.meta.wcsinfo.dispersion_direction
+            )
+            scale_arcsec = scale_degrees * 3600.0
+            yoffset = input_model.meta.dither.y_offset / scale_arcsec
+            ycenter += yoffset
+            log.info(f"Cross-slit dither offset = {yoffset} px")
     else:
         log.info(f"LRS target location from source_xpos, source_ypos = {xcenter, ycenter}")
 


### PR DESCRIPTION
Added code to propagate cross-slit dither offsets to the ycenter. Until now, the wcs solution placed the target at the nominal pointing position at the center of the slit, regardless of whether a cross-slit dither pattern was executed. This update will be critical for utilizing the improved LRS slit pathloss correction.

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4262](https://jira.stsci.edu/browse/JP-4262)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR addresses cross-slit dithering in the LRS slit, which was previously not propagated to the pipeline-internal source position used for pathloss correction. This update directly reads on the YOFFSET information in the metadata and adds this offset to ycenter, enabling the proper pathloss correction vector to be computed for instances where there is cross-slit dithering. Note that for standard observations, which do not permit cross-slit dithering, this change will have zero effect, as YOFFSET for typical ALONG_SLIT_NOD observations is a tiny number.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
