### PR TITLE
JP-4383:  Gracefully catch MSAFileError in picture_frame step

### DIFF
--- a/changes/10635.picture_frame.rst
+++ b/changes/10635.picture_frame.rst
@@ -1,0 +1,1 @@
+Gracefully handle missing MSA metadata files in picture_frame step

--- a/changes/10635.picture_frame.rst
+++ b/changes/10635.picture_frame.rst
@@ -1,1 +1,1 @@
-Gracefully handle missing MSA metadata files in picture_frame step
+If MSA metadata files are missing and mask_science_regions is True, set the step to FAILED status and return instead of raising an exception.

--- a/jwst/picture_frame/picture_frame.py
+++ b/jwst/picture_frame/picture_frame.py
@@ -3,7 +3,7 @@ import logging
 import numpy as np
 from stdatamodels.jwst import datamodels
 
-from jwst.assign_wcs.util import NoDataOnDetectorError
+from jwst.assign_wcs.util import MSAFileError, NoDataOnDetectorError
 from jwst.clean_flicker_noise import clean_flicker_noise as cfn
 
 __all__ = ["correct_picture_frame"]
@@ -158,6 +158,12 @@ def correct_picture_frame(
             msaflagopen=False,
             input_dir=input_dir,
         )
+    except MSAFileError:
+        log.warning(
+            "MSA metadata file not found. Cannot assign WCS. Skipping corrections for this file."
+        )
+        status = "FAILED"
+        return input_model, None, None, status
 
     # Make a background mask from the draft rate file, blocking out science regions
     background_mask = cfn.create_mask(

--- a/jwst/picture_frame/tests/test_picture_frame.py
+++ b/jwst/picture_frame/tests/test_picture_frame.py
@@ -7,6 +7,7 @@ from jwst.assign_wcs.assign_wcs_step import AssignWcsStep
 from jwst.assign_wcs.util import NoDataOnDetectorError
 from jwst.clean_flicker_noise.tests.helpers import make_nirspec_fs_model, make_nrs_fs_full_ramp
 from jwst.lib.basic_utils import LoggingContext
+from jwst.msaflagopen.tests.test_msa_open import make_nirspec_mos_model
 from jwst.picture_frame import picture_frame as pf
 from jwst.picture_frame.tests.helpers import picture_frame_model
 
@@ -187,3 +188,32 @@ def test_correction_single_group(caplog):
     assert status == "SKIPPED"
     assert correction is None
     assert mask is None
+
+
+def test_correction_no_msa(caplog):
+    pctfrm_model = picture_frame_model()
+    mos_model = make_nirspec_mos_model()
+    mos_model.meta.subarray.name = "FULL"
+    mos_model.meta.instrument.msa_metadata_file = "example.fits"
+
+    # Process a MOS dataset whose MSA metadata file is not available for
+    # building WCS with mask_science_regions=True
+    cleaned, mask, correction, status = pf.correct_picture_frame(
+        mos_model.copy(),
+        pctfrm_model,
+        mask_science_regions=True,
+        save_correction=True,
+        save_mask=True,
+    )
+
+    assert "MSA metadata file not found." in caplog.text
+
+    # No correction should have been applied
+    assert np.allclose(cleaned.data, mos_model.data)
+
+    # Even though instructed to save a mask and correction they should be None
+    assert mask is None
+    assert correction is None
+
+    # Report a failure for the status of the step
+    assert status == "FAILED"


### PR DESCRIPTION
Resolves [JP-4383](https://jira.stsci.edu/browse/JP-4383)

This PR gracefully catches errors that are raised when passing a NIRSpec MOS dataset through picture_frame with the `mask_science_regions = True` option when an MSA metadata file is not available.  `mask_science_regions = True` will attempt to run assign_wcs, which for NIRSpec MOS data requires an MSA metadata file to produce WCS and will raise an MSAFileError, and causing an error in data processing if the metadata file isn't available.

## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
