### PR TITLE
JP-4390 & JP-4243: Fix outlier detection edge case and unit test

### DIFF
--- a/changes/10650.outlier_detection.rst
+++ b/changes/10650.outlier_detection.rst
@@ -1,0 +1,1 @@
+Fix a KeyError crash encountered with the combination of input parameters ``resample_data = False`` and ``weight_type = exptime``.

--- a/jwst/outlier_detection/tests/test_imaging.py
+++ b/jwst/outlier_detection/tests/test_imaging.py
@@ -188,19 +188,23 @@ def test_outlier_step_with_source_no_outliers(mirimage_three_sci, tmp_cwd, src_t
 
 
 @pytest.mark.parametrize("weight", ["exptime", "ivm"])
+@pytest.mark.parametrize("resample_data", [True, False])
 @pytest.mark.parametrize("src_type", ["gaussian", "square", "strip", "point"])
 @pytest.mark.parametrize("idx", [0, 1, 2])
-def test_outlier_step_with_outliers(mirimage_three_sci, tmp_cwd, src_type, weight, idx):
-    """Test whole step with outlier(s) added besides a uniform square source."""
+def test_outlier_step_with_outliers(
+    mirimage_three_sci, tmp_cwd, src_type, weight, idx, resample_data
+):
+    """Test whole step with outlier of various shapes added on top of a uniform square source."""
     container = ModelLibrary(list(mirimage_three_sci))
 
     atol = 2.0 * np.finfo(np.float32).eps
 
-    # Create artificial source
+    # Input data already contain a hot pixel at index 7,7 with a correspondingly higher error value.
+    # On top of that, create an artificial square source, uniform across all images
     src_sl = np.s_[5:16, 5:16]
     src = np.full((11, 11), 100 * helpers.SIGMA, dtype=np.float32)
 
-    # Create artificial CR
+    # Also create an artificial CR of variable shape, to add to one image.
     if src_type == "strip":
         sl = np.s_[9:12, 5:16]
         cr = np.full((3, 11), 100 * helpers.SIGMA, dtype=np.float32)
@@ -216,15 +220,16 @@ def test_outlier_step_with_outliers(mirimage_three_sci, tmp_cwd, src_type, weigh
         fwhm = 1.5
         cr = 100 * helpers.SIGMA * np.exp(-4.0 * np.log(2.0) * (x**2 + y**2) / fwhm**2)
 
-    cr_mask = cr > 5 * helpers.SIGMA
-
-    # put a Gaussian source in all three exposures
+    # Put the square source in all three exposures. Add the CR to one exposure.
     with container:
         for i, ccont in enumerate(container):
             ccont.data[src_sl] += src
             if i == idx:
                 ccont.data[sl] += cr
-                # ccont.err[5:16, 5:16] = np.sqrt(ccont.err[5:16, 5:16]**2 + src)
+
+                # Expected CRs: anywhere the added signal is greater than 5 sigma
+                cr_mask = cr > 5 * ccont.err[sl]
+
             container.shelve(ccont)
 
     # Save all the data into a separate array before passing into step
@@ -238,7 +243,17 @@ def test_outlier_step_with_outliers(mirimage_three_sci, tmp_cwd, src_type, weigh
             non_nan_mask_as_cube.append(np.isfinite(model.data))
             container.shelve(model, modify=False)
 
-    result = OutlierDetectionStep.call(container, in_memory=True, weight_type=weight)
+    # Call outlier detection with SNR 5.  For resampled data, set the secondary
+    # scale such that the smoothed wings of the hot pixel are still flagged as outliers,
+    # for consistency with the other tests.
+    result = OutlierDetectionStep.call(
+        container,
+        in_memory=True,
+        weight_type=weight,
+        resample_data=resample_data,
+        snr="5.0 4.0",
+        scale="1.2 0.2",
+    )
 
     with result:
         for i, corrected in enumerate(result):
@@ -247,11 +262,6 @@ def test_outlier_step_with_outliers(mirimage_three_sci, tmp_cwd, src_type, weigh
                 # Make sure CR pixels are now NaN in SCI and flagged in DQ
                 m[sl] = np.logical_not(cr_mask)
                 m2 = np.isfinite(corrected.data)
-
-                if src_type == "square":
-                    pytest.xfail(
-                        "Square CR fails with pixels in the interior of the square not flagged as outliers."
-                    )
 
                 assert np.all(m == m2)
                 assert np.all(

--- a/jwst/outlier_detection/tests/test_imaging.py
+++ b/jwst/outlier_detection/tests/test_imaging.py
@@ -194,7 +194,28 @@ def test_outlier_step_with_source_no_outliers(mirimage_three_sci, tmp_cwd, src_t
 def test_outlier_step_with_outliers(
     mirimage_three_sci, tmp_cwd, src_type, weight, idx, resample_data
 ):
-    """Test whole step with outlier of various shapes added on top of a uniform square source."""
+    """
+    Test whole step with outlier of various shapes added on top of a uniform square source.
+
+    This test is for imaging outlier detection with a complex input scene: a square
+    source present in all input images, a hot pixel present in all input images, and
+    an extended outlier present in only one image, but on top of both the source and
+    the hot pixel.
+
+    For the test with the square outlier, with default parameters, outlier_detection
+    correctly identifies the outlier except for some interior pixels near the hot pixel.
+    This is the correct behavior for outlier detection with resampling: the hot pixel
+    itself should not be flagged as an outlier because it does not exceed the sigma limit
+    (the error for that pixel is also high). The 4 pixels neighboring the hot pixel are
+    also not flagged because they don't exceed the smoothed threshold mask accounting
+    for resampling effects.
+
+    To make the test results consistent with and without resampling, this test checks
+    the sigma limit via the input error image, so that the hot pixel is not expected
+    to be flagged. Also, the input parameters for outlier detection are modified to
+    pass an input scale that lowers the threshold for the neighboring pixels, so that
+    they are flagged as outliers, even when resampling is used.
+    """
     container = ModelLibrary(list(mirimage_three_sci))
 
     atol = 2.0 * np.finfo(np.float32).eps

--- a/jwst/outlier_detection/utils.py
+++ b/jwst/outlier_detection/utils.py
@@ -17,6 +17,7 @@ from stdatamodels.jwst import datamodels
 
 from jwst.lib.pipe_utils import match_nans_and_flags
 from jwst.outlier_detection import _fileio
+from jwst.resample.resample import input_jwst_model_to_dict
 
 log = logging.getLogger(__name__)
 
@@ -126,8 +127,13 @@ def median_without_resampling(
                 drizzled_err = drizzled_model.err.copy()
             else:
                 drizzled_err = None
+
+            im_dict = input_jwst_model_to_dict(
+                drizzled_model, weight_type=weight_type, enable_var=False, compute_err=None
+            )
+
             weight = build_driz_weight(
-                drizzled_model,
+                im_dict,
                 weight_type=weight_type,
                 good_bits=good_bits,
                 flag_name_map=datamodels.dqflags.pixel,

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -810,7 +810,7 @@ def input_jwst_model_to_dict(model, weight_type, enable_var, compute_err):
         The weighting type for adding models' data.
     enable_var : bool
         Indicates whether to resample variance arrays.
-    compute_err : str
+    compute_err : str or None
         The method to compute the output model's error array.
 
     Returns


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4390](https://jira.stsci.edu/browse/JP-4390)
Resolves [JP-4243](https://jira.stsci.edu/browse/JP-4243)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Fix a crashing combination of input parameters for outlier_detection: resample_data = False and weight_type = "exptime" currently crashes with a KeyError because a utility is called with a datamodel as input when a dictionary is expected.

Also fix a currently xfailed unit test.  The test is for imaging outlier detection with a complex input scene: a square source present in all input images, a hot pixel present in all input images, and a square outlier present in only one image, but on top of both the source and the hot pixel.  

The test as originally written correctly identified the square outlier, except for some interior pixels near the hot pixel.  On investigation, I think this is the correct behavior for outlier detection with resampling.   The hot pixel itself should not be flagged as an outlier because it does not exceed the sigma limit: the error for that pixel is also high.  The 4 pixels neighboring the hot pixel are also not flagged because they don't exceed the smoothed threshold mask accounting for resampling effects.  

To remove the xfail, I revised the test to check the sigma limit via the input error image, so that the hot pixel is not expected to be flagged.  I also modified the input scale parameter to lower the threshold for the neighboring pixels, so that they are flagged.  This makes the test with resampling consistent with the results for the same test performed without resampling.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
