### PR TITLE
DOC: Complete API for saturation

### DIFF
--- a/docs/jwst/saturation/api_ref.rst
+++ b/docs/jwst/saturation/api_ref.rst
@@ -1,0 +1,18 @@
+===
+API
+===
+
+Public Step API
+===============
+
+.. automodapi:: jwst.saturation.saturation_step
+   :no-inheritance-diagram:
+
+Complete Developer API
+======================
+
+.. automodapi:: jwst.saturation.saturation
+   :no-inheritance-diagram:
+
+.. automodapi:: jwst.saturation.x_irs2
+   :no-inheritance-diagram:

--- a/docs/jwst/saturation/arguments.rst
+++ b/docs/jwst/saturation/arguments.rst
@@ -1,11 +1,11 @@
 Step Arguments
 ==============
-The ``saturation`` step has one optional argument:
+The ``saturation`` step has the following optional arguments.
 
 ``--n_pix_grow_sat`` (integer, default=1)
   The distance to use when growing saturation flag values to neighboring pixels,
   in order to account for charge migration (spilling). The total region size is
-  2*n_pix_grow_sat+1 pixels, centered on the primary pixel.
+  ``2*n_pix_grow_sat+1`` pixels, centered on the primary pixel.
 
 ``--use_readpatt`` (boolean, default=True)
   Use information about the readout pattern for grouped data to perform additional

--- a/docs/jwst/saturation/description.rst
+++ b/docs/jwst/saturation/description.rst
@@ -1,11 +1,11 @@
 Description
-============
+===========
 
-:Class: `jwst.saturation.SaturationStep`
+:Class: `jwst.saturation.saturation_step.SaturationStep`
 :Alias: saturation
 
 The core algorithm for this step is called from the external package ``stcal``, an STScI
-effort to unify common calibration processing algorithms for use by multiple observatories.
+effort to unify common calibration processing algorithms for use by multiple observatories; see :ref:`Saturation in stcal <stcal:saturation_module>`.
 
 Saturation Checking
 -------------------
@@ -46,8 +46,8 @@ of the following criteria must be met:
    and the superbias if available), which may occur for bright sources.
 
 #. The difference in counts between the first and second group is larger than the
-   remaining counts needed to saturate divided by the number of frames in the 
-   second group, i.e., the expected frame-averaged counts of a saturating signal 
+   remaining counts needed to saturate divided by the number of frames in the
+   second group, i.e., the expected frame-averaged counts of a saturating signal
    that occurs in the last frame of the group.
 
 #. The third group is saturated.
@@ -57,7 +57,7 @@ of the following criteria must be met:
 Charge Migration
 ----------------
 There is an effect in IR detectors that results in charge migrating (spilling)
-from a pixel that has "hard" saturation (i.e. where the pixel no longer accumulates
+from a pixel that has "hard" saturation (i.e., where the pixel no longer accumulates
 charge) into neighboring pixels. This results in non-linearities in the accumulating
 signal ramp in the neighboring pixels and hence the ramp data following the onset
 of saturation is not usable.
@@ -66,7 +66,7 @@ The ``saturation`` step accounts for charge migration by flagging - as saturated
 all pixels neighboring a pixel that goes above the saturation threshold. This is
 accomplished by first flagging all pixels that cross their saturation thresholds
 and then making a second pass through the data to flag neighbors within a specified
-region. The region of neighboring pixels is specified as a 2N+1 pixel wide box that
+region. The region of neighboring pixels is specified as a ``2N+1`` pixel wide box that
 is centered on the saturating pixel and N is set by the step parameter
 ``n_pix_grow_sat``. The default value is 1, resulting in a 3x3 box of neighboring
 pixels that will be flagged.
@@ -78,8 +78,8 @@ handling in this step, due to the extra reference pixel values that are interlea
 within the science data. The saturation reference file data does not contain
 extra entries for these pixels. The step-by-step process is as follows:
 
-#. Retrieve and load data from the appropriate "SATURATION" and "SUPERBIAS" 
-   reference files from CRDS
+#. Retrieve and load data from the appropriate :ref:`SATURATION <saturation_reffile>`
+   and :ref:`SUPERBIAS <superbias_reffile>` reference files from CRDS
 
 #. If the input science exposure used the NIRSpec IRS2 readout pattern:
 
@@ -100,10 +100,10 @@ extra entries for these pixels. The step-by-step process is as follows:
    "GROUPDQ" array if the pixel value is greater than or equal to the saturation
    threshold from the reference file
 
-#. If the "use_readpatt" keyword is set, trimmed versions of the data, 
-   saturation threshold, and superbias arrays (i.e., excluding interleaved 
+#. If the "use_readpatt" keyword is set, trimmed versions of the data,
+   saturation threshold, and superbias arrays (i.e., excluding interleaved
    reference pixels), will be used to identify the special case of pixels that
-   saturate in the middle of the second group for readout patterns that have 
+   saturate in the middle of the second group for readout patterns that have
    frame-averaged groups.
 
 NIRCam Frame 0

--- a/docs/jwst/saturation/index.rst
+++ b/docs/jwst/saturation/index.rst
@@ -10,5 +10,4 @@ Saturation Detection
    description.rst
    arguments.rst
    reference_files.rst
-
-.. automodapi:: jwst.saturation
+   api_ref.rst

--- a/docs/jwst/saturation/reference_files.rst
+++ b/docs/jwst/saturation/reference_files.rst
@@ -1,9 +1,9 @@
 Reference Files
 ===============
-The ``saturation`` step uses a SATURATION reference file.
+The ``saturation`` step uses a :ref:`saturation_reffile`.
 
 The ``saturation`` step also optionally uses a :ref:`SUPERBIAS <superbias_reffile>`
-reference file for identifying pixels that saturate in the second group of data 
+reference file for identifying pixels that saturate in the second group of data
 with frame-averaged groups.
 
 .. include:: ../references_general/saturation_reffile.inc

--- a/jwst/saturation/saturation.py
+++ b/jwst/saturation/saturation.py
@@ -25,28 +25,28 @@ def flag_saturation(output_model, ref_model, n_pix_grow_sat, use_readpatt, bias_
 
     Parameters
     ----------
-    output_model : `~jwst.datamodels.RampModel`
-        The input science data to be corrected
+    output_model : `~stdatamodels.jwst.datamodels.RampModel`
+        The input science data to be corrected.
 
-    ref_model : `~jwst.datamodels.SaturationModel`
-        Saturation reference file data model
+    ref_model : `~stdatamodels.jwst.datamodels.SaturationModel`
+        Saturation reference file data model.
 
     n_pix_grow_sat : int
         Number of layers of pixels adjacent to a saturated pixel to also flag
-        as saturated (i.e '1' will flag the surrounding 8 pixels) to account for
+        as saturated (i.e., '1' will flag the surrounding 8 pixels) to account for
         charge spilling.
 
     use_readpatt : bool
-        Use grouped read pattern information to assist with flagging
+        Use grouped read pattern information to assist with flagging.
 
-    bias_model : `~jwst.datamodels.SuperBiasModel` or None, optional
+    bias_model : `~stdatamodels.jwst.datamodels.SuperBiasModel` or None, optional
         Superbias reference file data model.
 
     Returns
     -------
-    output_model : `~jwst.datamodels.RampModel`
+    output_model : `~stdatamodels.jwst.datamodels.RampModel`
         Data model with saturation, A/D floor, and do not use flags set in
-        the GROUPDQ array
+        the GROUPDQ array.
     """
     ngroups = output_model.meta.exposure.ngroups
     nframes = output_model.meta.exposure.nframes
@@ -137,26 +137,26 @@ def irs2_flag_saturation(output_model, ref_model, n_pix_grow_sat, use_readpatt, 
 
     Parameters
     ----------
-    output_model : `~jwst.datamodels.RampModel`
+    output_model : `~stdatamodels.jwst.datamodels.RampModel`
         The input science data to be corrected
 
-    ref_model : `~jwst.datamodels.SaturationModel`
+    ref_model : `~stdatamodels.jwst.datamodels.SaturationModel`
         Saturation reference file data model
 
     n_pix_grow_sat : int
         Number of layers of pixels adjacent to a saturated pixel to also flag
-        as saturated (i.e '1' will flag the surrounding 8 pixels) to account for
+        as saturated (i.e., '1' will flag the surrounding 8 pixels) to account for
         charge spilling.
 
     use_readpatt : bool
         Use grouped read pattern information to assist with flagging
 
-    bias_model : `~jwst.datamodels.SuperBiasModel` or None, optional
+    bias_model : `~stdatamodels.jwst.datamodels.SuperBiasModel` or None, optional
         Superbias reference file data model.
 
     Returns
     -------
-    output_model : `~jwst.datamodels.RampModel`
+    output_model : `~stdatamodels.jwst.datamodels.RampModel`
         Data model with saturation, A/D floor, and do not use flags set in
         the GROUPDQ array
     """
@@ -325,7 +325,7 @@ def adjacency_sat(flag_temp, saturated, n_pix_grow_sat):
 
     n_pix_grow_sat : int
         Number of layers of pixels adjacent to a saturated pixel to also flag
-        as saturated (i.e '1' will flag the surrounding 8 pixels) to account for
+        as saturated (i.e., '1' will flag the surrounding 8 pixels) to account for
         charge spilling.
 
     Returns

--- a/jwst/saturation/saturation_step.py
+++ b/jwst/saturation/saturation_step.py
@@ -1,3 +1,5 @@
+"""Set saturation flags for pixels."""
+
 import logging
 
 from stdatamodels.jwst import datamodels
@@ -30,7 +32,7 @@ class SaturationStep(Step):
         Parameters
         ----------
         step_input : `~stdatamodels.jwst.datamodels.RampModel` or str
-            Input datamodel or string name of the fits file.
+            Input datamodel or FITS filename.
 
         Returns
         -------

--- a/jwst/saturation/x_irs2.py
+++ b/jwst/saturation/x_irs2.py
@@ -4,26 +4,25 @@ import numpy as np
 
 from jwst.lib import pipe_utils
 
-""" This is the interface:
-    mask = make_mask(input_model)
-        Create a mask for extracting normal pixels; used by from_irs2 and
-        to_irs2.
-        n and r can be specified as keyword arguments to override the
-        default values.  This option is primarily useful if `input_model`
-        is a numpy.ndarray rather than a jwst.datamodels object.
-    shape = normal_shape(input_model, n=n, r=r)
-        The shape of the data array when excluding interleaved reference
-        pixels.
-        n and r can be specified as keyword arguments.
-    normal_data = from_irs2(irs2_data, mask, detector)
-        Extract the normal pixels from data in IRS2 format.
-    to_irs2(irs2_data, normal_data, mask, detector)
-        Insert an array of normal pixels back into data in IRS2 format.
+# This is the interface:
+#     mask = make_mask(input_model)
+#         Create a mask for extracting normal pixels; used by from_irs2 and
+#         to_irs2.
+#         n and r can be specified as keyword arguments to override the
+#         default values.  This option is primarily useful if `input_model`
+#         is a numpy.ndarray rather than a jwst.datamodels object.
+#     shape = normal_shape(input_model, n=n, r=r)
+#         The shape of the data array when excluding interleaved reference
+#         pixels.
+#         n and r can be specified as keyword arguments.
+#     normal_data = from_irs2(irs2_data, mask, detector)
+#         Extract the normal pixels from data in IRS2 format.
+#     to_irs2(irs2_data, normal_data, mask, detector)
+#         Insert an array of normal pixels back into data in IRS2 format.
 
-    Note that `input_model` may be either a jwst.datamodels object or a
-    numpy.ndarray (though in the latter case the parameters will be
-    assigned default values, unless specified explicitly).
-"""
+#     Note that `input_model` may be either a jwst.datamodels object or a
+#     numpy.ndarray (though in the latter case the parameters will be
+#     assigned default values, unless specified explicitly).
 
 
 ReadoutParam = namedtuple("ReadoutParam", ["refout", "n", "r"])
@@ -37,7 +36,7 @@ def _get_irs2_parameters(input_model, n=None, r=None):
 
     Parameters
     ----------
-    input_model : DataModel or numpy.ndarray
+    input_model : `~stdatamodels.jwst.datamodels.JwstDataModel` or ndarray
         Model from which we retrieve the width of the reference
         output and the values of NRS_NORM and NRS_REF. If the input_model
         is a ndarray the parameters will be assigned default values.
@@ -54,6 +53,7 @@ def _get_irs2_parameters(input_model, n=None, r=None):
     -------
     param : ReadoutParam object
         ReadoutParam objects contains the following information:
+
         param.refout: int
             The length (in the last image axis) of the reference output
             section.  The reference output is assumed to be on the left
@@ -93,7 +93,7 @@ def normal_shape(input_model, n=None, r=None, detector=None):
 
     Parameters
     ----------
-    input_model : DataModel
+    input_model : `~stdatamodels.jwst.datamodels.JwstDataModel`
         This is used to get the shape of the input data.
 
     n : int or None
@@ -106,12 +106,12 @@ def normal_shape(input_model, n=None, r=None, detector=None):
 
     detector : str
        Detector of data. Valid values are None, NRS1, or NRS2. Other detector
-       values will result in a run time error.
+       values will result in a RuntimeError.
 
     Returns
     -------
-    data_shape : 2 D array
-        The shape of the data array when excluding interleaved reference
+    data_shape : ndarray
+        The shape of the 2-D data array when excluding interleaved reference
         pixels.
     """
     if isinstance(input_model, np.ndarray):
@@ -150,7 +150,7 @@ def make_mask(input_model, n=None, r=None):
 
     Parameters
     ----------
-    input_model : the model for the input data, or a numpy.ndarray
+    input_model : `~stdatamodels.jwst.datamodels.JwstDataModel` or ndarray
         This is used for getting the IRS2 parameters and the length of
         the X image axis.
 
@@ -164,8 +164,8 @@ def make_mask(input_model, n=None, r=None):
 
     Returns
     -------
-    irs2_mask : 1-D bool array
-        Boolean index mask with length equal to the last axis of
+    irs2_mask : ndarray
+        Boolean index mask (1-D) with length equal to the last axis of
         the data shape.
     """
     param = _get_irs2_parameters(input_model, n=n, r=r)
@@ -223,23 +223,23 @@ def from_irs2(irs2_data, irs2_mask, detector=None):
         Data in IRS2 format.  This can be a slice in the Y direction, but
         it should include the entire X (last) axis.
 
-    irs2_mask : 1-D array, bool
-        Boolean mask to extract the "normal" pixels.  This is a 1-D array
+    irs2_mask : ndarray
+        Boolean mask (1-D) to extract the "normal" pixels.  This is a 1-D array
         with length equal to the size of the next-to-last axis (for data
-        in DMS orientation) of `irs2_data`.
+        in DMS orientation) of ``irs2_data``.
 
     detector : str or None
-        For IRS2 data in DMS orientation, `detector` should be either
+        For IRS2 data in DMS orientation, this should be either
         "NRS1" or "NRS2"; NIRSpec is currently the only instrument
         supported in this module.  The mask will be applied to the rows,
         and for "NRS2" the mask will first be reversed.
-        For IRS2 data in detector orientation, `detector` should be None
+        For IRS2 data in detector orientation, this should be None
         (the default), and the mask will be applied to the columns.
 
     Returns
     -------
     norm_data : ndarray
-       The normal pixel data (i.e. without embedded reference pixels).
+       The normal pixel data (i.e., without embedded reference pixels).
     """
     if detector is None:
         # Select columns.
@@ -267,21 +267,21 @@ def to_irs2(irs2_data, norm_data, irs2_mask, detector=None):
         Data in IRS2 format.  This will be modified in-place.
 
     norm_data : ndarray
-        The normal data, for example previously extracted from irs2_data
+        The normal data, for example previously extracted from ``irs2_data``
         but then modified in some way.  This will be copied back into
-        irs2_data in the correct locations, as specified by `irs2_mask`.
+        ``irs2_data`` in the correct locations, as specified by ``irs2_mask``.
 
-    irs2_mask : 1-D array, bool
-        Boolean mask identifying the locations of the "normal" pixels
+    irs2_mask : ndarray
+        Boolean mask (1-D) identifying the locations of the "normal" pixels
         within irs2_data.  The length is equal to the size of the
-        next-to-last axis (for data in DMS orientation) of `irs2_data`.
+        next-to-last axis (for data in DMS orientation) of ``irs2_data``.
 
     detector : str or None
-        For IRS2 data in DMS orientation, `detector` should be either
+        For IRS2 data in DMS orientation, this should be either
         "NRS1" or "NRS2"; NIRSpec is currently the only instrument
         supported in this module.  The mask will be applied to the rows,
         and for "NRS2" the mask will first be reversed.
-        For IRS2 data in detector orientation, `detector` should be None
+        For IRS2 data in detector orientation, this should be None
         (the default), and the mask will be applied to the columns.
     """
     if detector is None:


### PR DESCRIPTION
Towards [JP-4107](https://jira.stsci.edu/browse/JP-4107)

This PR addresses `saturation` portion of https://github.com/spacetelescope/jwst/issues/9793 . Only touch docs so should not need RT.

On main:

* https://jwst-pipeline.readthedocs.io/en/latest/jwst/saturation/description.html

With this patch:

* https://jwst-pipeline--10660.org.readthedocs.build/en/10660/jwst/saturation/index.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
