### PR TITLE
JP-4379: Document and test MIRI LRS FS TSO mode

### DIFF
--- a/docs/jwst/outlier_detection/main.rst
+++ b/docs/jwst/outlier_detection/main.rst
@@ -17,7 +17,9 @@ being processed.  This step supports:
    - See :ref:`outlier-detection-imaging` for algorithm details
 * **Slit-like Spectroscopic modes**: 'MIR_LRS-FIXEDSLIT', 'NRS_FIXEDSLIT', 'NRS_MSASPEC'
    - See :ref:`outlier-detection-spec` for algorithm details
-* **Time-Series-Observation (TSO) modes**: 'MIR_LRS-SLITLESS', 'NRC_TSGRISM', 'NIS_SOSS', 'NRS_BRIGHTOBJ', 'NRC_TSIMAGE', as well as TSOs obtained with the MIRI imager ('MIR_IMAGE' with TSOVISIT=True).
+* **Time-Series-Observation (TSO) modes**: 'MIR_LRS-SLITLESS', 'NRC_TSGRISM', 'NIS_SOSS', 'NRS_BRIGHTOBJ',
+     'NRC_TSIMAGE', as well as TSOs obtained with the MIRI imager or in fixed slit mode
+     ('MIR_IMAGE' or 'MIR_LRS-FIXEDSLIT' with TSOVISIT=True).
    - See :ref:`outlier-detection-tso` for algorithm details
 * **IFU Spectroscopic modes**: 'MIR_MRS', 'NRS_IFU'
    - See :ref:`outlier-detection-ifu` for algorithm details

--- a/docs/jwst/outlier_detection/main.rst
+++ b/docs/jwst/outlier_detection/main.rst
@@ -13,17 +13,22 @@ The ``outlier_detection`` step supports multiple
 algorithms and determines the appropriate algorithm for the type of observation
 being processed.  This step supports:
 
-* **Image modes**: 'FGS_IMAGE', 'MIR_IMAGE', 'NRC_IMAGE', 'NIS_IMAGE'
+* **Image modes**:
+   - Exposure types: 'FGS_IMAGE', 'MIR_IMAGE', 'NRC_IMAGE', 'NIS_IMAGE'
    - See :ref:`outlier-detection-imaging` for algorithm details
-* **Slit-like Spectroscopic modes**: 'MIR_LRS-FIXEDSLIT', 'NRS_FIXEDSLIT', 'NRS_MSASPEC'
+* **Slit-like Spectroscopic modes**:
+   - Exposure types: 'MIR_LRS-FIXEDSLIT', 'NRS_FIXEDSLIT', 'NRS_MSASPEC'
    - See :ref:`outlier-detection-spec` for algorithm details
-* **Time-Series-Observation (TSO) modes**: 'MIR_LRS-SLITLESS', 'NRC_TSGRISM', 'NIS_SOSS', 'NRS_BRIGHTOBJ',
-     'NRC_TSIMAGE', as well as TSOs obtained with the MIRI imager or in fixed slit mode
+* **Time-Series-Observation (TSO) modes**:
+   - Exposure types: 'MIR_LRS-SLITLESS', 'NRC_TSGRISM', 'NIS_SOSS', 'NRS_BRIGHTOBJ',
+     and 'NRC_TSIMAGE', as well as TSOs obtained with the MIRI imager or in fixed slit mode
      ('MIR_IMAGE' or 'MIR_LRS-FIXEDSLIT' with TSOVISIT=True).
    - See :ref:`outlier-detection-tso` for algorithm details
-* **IFU Spectroscopic modes**: 'MIR_MRS', 'NRS_IFU'
+* **IFU Spectroscopic modes**:
+   - Exposure types: 'MIR_MRS', 'NRS_IFU'
    - See :ref:`outlier-detection-ifu` for algorithm details
-* **Coronagraphic Image modes**: 'MIR_LYOT', 'MIR_4QPM', 'NRC_CORON'
+* **Coronagraphic Image modes**:
+   - Exposure types: 'MIR_LYOT', 'MIR_4QPM', 'NRC_CORON'
    - See :ref:`outlier-detection-coron` for algorithm details
 
 This step uses the following logic to apply the appropriate algorithm to the

--- a/docs/jwst/pipeline/main.rst
+++ b/docs/jwst/pipeline/main.rst
@@ -115,11 +115,13 @@ mode are marked as "N/A" in the TSOVISIT column.
 +---------------------+----------+----------------------------------------------+-----------------------------------------+----------------------------------------+
 | | MIR_CORONCAL      | N/A      | :ref:`calwebb_detector1 <calwebb_detector1>` | :ref:`calwebb_image2 <calwebb_image2>`  | N/A                                    |
 +---------------------+----------+----------------------------------------------+-----------------------------------------+----------------------------------------+
-| | MIR_IMAGE         | False    | :ref:`calwebb_detector1 <calwebb_detector1>` | :ref:`calwebb_image2 <calwebb_image2>`  | :ref:`calwebb_image3 <calwebb_image3>` |
+| | MIR_IMAGE         | True     | :ref:`calwebb_detector1 <calwebb_detector1>` | :ref:`calwebb_image2 <calwebb_image2>`  | :ref:`calwebb_tso3 <calwebb_tso3>`     |
 +                     +----------+----------------------------------------------+-----------------------------------------+----------------------------------------+
-|                     | True     | :ref:`calwebb_detector1 <calwebb_detector1>` | :ref:`calwebb_image2 <calwebb_image2>`  | :ref:`calwebb_tso3 <calwebb_tso3>`     |
+|                     | False    | :ref:`calwebb_detector1 <calwebb_detector1>` | :ref:`calwebb_image2 <calwebb_image2>`  | :ref:`calwebb_image3 <calwebb_image3>` |
 +---------------------+----------+----------------------------------------------+-----------------------------------------+----------------------------------------+
-| | MIR_LRS-FIXEDSLIT | N/A      | :ref:`calwebb_detector1 <calwebb_detector1>` | :ref:`calwebb_spec2 <calwebb_spec2>`    | :ref:`calwebb_spec3 <calwebb_spec3>`   |
+| | MIR_LRS-FIXEDSLIT | True     | :ref:`calwebb_detector1 <calwebb_detector1>` | :ref:`calwebb_spec2 <calwebb_spec2>`    | :ref:`calwebb_tso3 <calwebb_tso3>`     |
++                     +----------+----------------------------------------------+-----------------------------------------+----------------------------------------+
+|                     | False    | :ref:`calwebb_detector1 <calwebb_detector1>` | :ref:`calwebb_spec2 <calwebb_spec2>`    | :ref:`calwebb_spec3 <calwebb_spec3>`   |
 +---------------------+----------+----------------------------------------------+-----------------------------------------+----------------------------------------+
 | | MIR_LRS-SLITLESS  | True     | :ref:`calwebb_detector1 <calwebb_detector1>` | :ref:`calwebb_spec2 <calwebb_spec2>`    | :ref:`calwebb_tso3 <calwebb_tso3>`     |
 +                     +----------+----------------------------------------------+-----------------------------------------+----------------------------------------+

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -14,9 +14,7 @@ from jwst.stpipe.utilities import query_step_status, record_step_status
 # Categorize all supported modes
 IMAGE_MODES = ["NRC_IMAGE", "MIR_IMAGE", "NRS_IMAGE", "NIS_IMAGE", "FGS_IMAGE"]
 SLIT_SPEC_MODES = ["NRC_WFSS", "MIR_LRS-FIXEDSLIT", "NRS_FIXEDSLIT", "NRS_MSASPEC", "NIS_WFSS"]
-TSO_SPEC_MODES = ["NIS_SOSS", "MIR_LRS-SLITLESS", "NRC_TSGRISM", "NRS_BRIGHTOBJ"]
 IFU_SPEC_MODES = ["NRS_IFU", "MIR_MRS"]
-TSO_IMAGE_MODES = ["NRC_TSIMAGE"]  # missing MIR_IMAGE with TSOVIST=True, not really addable
 CORON_IMAGE_MODES = ["NRC_CORON", "MIR_LYOT", "MIR_4QPM"]
 
 __all__ = ["OutlierDetectionStep"]

--- a/jwst/regtest/associations_sdp_pools/test_associations_sdp_pools.py
+++ b/jwst/regtest/associations_sdp_pools/test_associations_sdp_pools.py
@@ -102,6 +102,7 @@ def test_std_strict(_jail, rtdata, resource_tracker, request, pool_args):
             "jw05554_20250528t204800_c1012_pool",
             ["--DMS", "-i", "o009", "o010", "c1012"],
         ),  # This pool checks background behavior with paired MIRI MRS/Imaging exposures
+        ("jw06219_20251211t073827_pool", []),  # MIR_LRS-FIXEDSLIT TSO
     ],
     ids=parfunc,
 )

--- a/jwst/regtest/test_miri_lrs_slit_tso.py
+++ b/jwst/regtest/test_miri_lrs_slit_tso.py
@@ -1,0 +1,105 @@
+import pytest
+
+from jwst.regtest.st_fitsdiff import STFITSDiff as FITSDiff
+from jwst.stpipe import Step
+
+# Mark all tests in this module
+pytestmark = [pytest.mark.bigdata]
+
+SPEC2_BASENAME = "jw06219001001_04103_00001-seg001_mirimage"
+ASN_ID = "o001"
+TSO3_BASENAME = "jw06219-o001_t001_miri_p750l"
+
+
+@pytest.fixture(scope="module")
+def run_spec2_pipeline(rtdata_module, resource_tracker):
+    """Run the calwebb_spec2 pipeline on a MIRI LRS FS TSO exposure."""
+    rtdata = rtdata_module
+    rtdata.get_data(f"miri/lrs/{SPEC2_BASENAME}_rateints.fits")
+
+    args = [
+        "calwebb_spec2",
+        rtdata.input,
+        "--steps.assign_wcs.save_results=true",
+        "--steps.srctype.save_results=true",
+        "--steps.flat_field.save_results=true",
+    ]
+    with resource_tracker.track():
+        Step.from_cmdline(args)
+
+
+@pytest.fixture(scope="module")
+def run_tso3_pipeline(run_spec2_pipeline, rtdata_module, resource_tracker):
+    """Run the calwebb_tso3 pipeline on the output of run_spec2_pipeline."""
+    rtdata = rtdata_module
+
+    # Run spec2 for an extra input file
+    second_file = SPEC2_BASENAME.replace("seg001", "seg002")
+    rtdata.get_data(f"miri/lrs/{second_file}_rateints.fits")
+    args = ["calwebb_spec2", rtdata.input]
+    Step.from_cmdline(args)
+
+    # Get the ASN for tso3
+    rtdata.get_data("miri/lrs/jw06219-o001_20251211t073827_tso3_00001_asn_small.json")
+
+    # Run tso3
+    args = ["calwebb_tso3", rtdata.input]
+    with resource_tracker.track():
+        Step.from_cmdline(args)
+
+
+def test_log_tracked_resources_spec2(log_tracked_resources, run_spec2_pipeline):
+    log_tracked_resources()
+
+
+def test_log_tracked_resources_tso3(log_tracked_resources, run_tso3_pipeline):
+    log_tracked_resources()
+
+
+@pytest.mark.parametrize("suffix", ["assign_wcs", "srctype", "flat_field", "calints", "x1dints"])
+def test_miri_lrs_slit_tso_spec2(
+    run_spec2_pipeline, rtdata_module, fitsdiff_default_kwargs, suffix
+):
+    """Compare the output of a MIRI LRS FS TSO spec2 pipeline run."""
+    rtdata = rtdata_module
+
+    output_filename = f"{SPEC2_BASENAME}_{suffix}.fits"
+    rtdata.output = output_filename
+    rtdata.get_truth(f"truth/test_miri_lrs_slit_tso/{output_filename}")
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+def test_miri_lrs_slit_tso3_crfints(run_tso3_pipeline, rtdata_module, fitsdiff_default_kwargs):
+    """Compare one of the crfints outputs from tso3 for MIRI LRS FS TSO."""
+    rtdata = rtdata_module
+    output_filename = f"{SPEC2_BASENAME}_{ASN_ID}_crfints.fits"
+    rtdata.output = output_filename
+    rtdata.get_truth(f"truth/test_miri_lrs_slit_tso/{output_filename}")
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+def test_miri_lrs_slit_tso3_x1dints(run_tso3_pipeline, rtdata_module, fitsdiff_default_kwargs):
+    """Compare the x1dints output from tso3 for MIRI LRS FS TSO."""
+    rtdata = rtdata_module
+
+    output_filename = f"{TSO3_BASENAME}_x1dints.fits"
+    rtdata.output = output_filename
+    rtdata.get_truth(f"truth/test_miri_lrs_slit_tso/{output_filename}")
+
+    diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
+    assert diff.identical, diff.report()
+
+
+def test_miri_lrs_slit_tso3_whtlt(run_tso3_pipeline, rtdata_module, diff_astropy_tables):
+    """Compare the whtlt output from tso3 for MIRI LRS FS TSO."""
+    rtdata = rtdata_module
+
+    output_filename = f"{TSO3_BASENAME}_whtlt.ecsv"
+    rtdata.output = output_filename
+    rtdata.get_truth(f"truth/test_miri_lrs_slit_tso/{output_filename}")
+
+    assert diff_astropy_tables(rtdata.output, rtdata.truth)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4379](https://jira.stsci.edu/browse/JP-4379)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Minor documentation updates and new regtests for new TSO mode in MIRI LRS fixed slit exposures.

Associations and pipeline processing already seems to work out of the box for this mode, so all that is needed is to update some documentation, remove a couple unused constants that are no longer relevant, and add some regression tests.

Test observation is PID 6219 obs 1.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
