### PR TITLE
JP-4398: Remove references to useafter from set_telescope_pointing

### DIFF
--- a/changes/10669.set_telescope_pointing.rst
+++ b/changes/10669.set_telescope_pointing.rst
@@ -1,0 +1,1 @@
+For clarity, remove all references to an unused "useafter" date.

--- a/jwst/lib/set_telescope_pointing.py
+++ b/jwst/lib/set_telescope_pointing.py
@@ -502,8 +502,6 @@ class TransformParameters:
     #: If no telemetry can be found during the observation,
     #: the time, in seconds, beyond the observation time to search for telemetry.
     tolerance: float = 60.0
-    #: The date of observation (``stdatamodels.jwst.datamodels.JwstDataModel.meta.date``)
-    useafter: str | None = None
     #: V3 position angle at Guide Star
     # (``stdatamodels.jwst.datamodels.JwstDataModel.meta.guide_star.gs_v3_pa_science``)
     v3pa_at_gs: float | None = None
@@ -825,9 +823,6 @@ def update_wcs(
         prd = model.meta.prd_software_version
     siaf_db = SiafDb(source=siaf_path, prd=prd)
 
-    # Get model attributes
-    useafter = model.meta.observation.date
-
     # Configure transformation parameters.
     t_pars = t_pars_from_model(
         model,
@@ -837,7 +832,6 @@ def update_wcs(
         allow_default=allow_default,
         reduce_func=reduce_func,
         siaf_db=siaf_db,
-        useafter=useafter,
         **transform_kwargs,
     )
     if fgsid:
@@ -2482,7 +2476,7 @@ def calc_v3pags(t_pars: TransformParameters):
     gs_wcs = calc_estimated_gs_wcs(t_pars)
 
     # Retrieve the Ideal Y-angle for FGS1
-    fgs_siaf = t_pars.siaf_db.get_wcs(FGSId2Aper[1], useafter=t_pars.useafter)
+    fgs_siaf = t_pars.siaf_db.get_wcs(FGSId2Aper[1])
 
     # Calculate V3PAGS
     v3pags = gs_wcs.pa - fgs_siaf.v3yangle
@@ -2767,10 +2761,8 @@ def t_pars_from_model(model, **t_pars_kwargs):
     # Retrieve SIAF information
     if t_pars.siaf is None:
         siaf = None
-        useafter = None
         if t_pars.siaf_db is not None:
             aperture_name = model.meta.aperture.name.upper()
-            useafter = model.meta.observation.date
             if aperture_name != "UNKNOWN":
                 logger.info("Updating WCS for aperture %s", aperture_name)
 
@@ -2780,11 +2772,8 @@ def t_pars_from_model(model, **t_pars_kwargs):
                 to_detector = False
                 if aperture_name == "MIRIM_TAMRS":
                     to_detector = True
-                siaf = t_pars.siaf_db.get_wcs(
-                    aperture_name, to_detector=to_detector, useafter=useafter
-                )
+                siaf = t_pars.siaf_db.get_wcs(aperture_name, to_detector=to_detector)
         t_pars.siaf = siaf
-        t_pars.useafter = useafter
     logger.debug("SIAF: %s", t_pars.siaf)
 
     # Instrument details
@@ -3223,7 +3212,7 @@ def calc_wcs_guiding(
         crpix1 = crpix2 = 0
     else:
         apername = f"FGS{t_pars.detector[-1]}_FULL_OSS"
-        aperture = t_pars.siaf_db.get_aperture(apername, t_pars.useafter)
+        aperture = t_pars.siaf_db.get_aperture(apername)
         crpix1, crpix2 = gs_ideal_to_subarray(gs_position, aperture, flip=True)
 
     # Determine PC matrix

--- a/jwst/lib/siafdb.py
+++ b/jwst/lib/siafdb.py
@@ -10,7 +10,6 @@ Otherwise, use the standard interface defined by the ``pysiaf`` package
 import logging
 import os
 from collections import namedtuple
-from datetime import date
 from pathlib import Path
 
 from jwst.lib.basic_utils import LoggingContext
@@ -41,8 +40,7 @@ SIAF container.
 
 The names should correspond to the names in the ``wcsinfo`` schema.
 It is populated by the SIAF values in the PRD database based
-on APERNAME and UseAfterDate and used to populate the keywords
-in Level1bModel data models.
+on APERNAME and used to populate the keywords in Level1bModel data models.
 
 Default values are set for the SIAF.
 Values which are needed by the pipeline are set to `None`, which
@@ -110,7 +108,7 @@ class SiafDb:
         self.prd_version = None
         self.xml_path = self.get_xml_path(source, prd)
 
-    def get_aperture(self, aperture, useafter=None):
+    def get_aperture(self, aperture):
         """
         Get the ``pysiaf.Aperture`` for an aperture.
 
@@ -118,27 +116,22 @@ class SiafDb:
         ----------
         aperture : str
             The name of the aperture to retrieve.
-        useafter : str
-            The date of observation (``model.meta.date``).
 
         Returns
         -------
         aperture : pysiaf.Aperture
             The aperture specification.
         """
-        if not useafter:
-            useafter = date.today().strftime("%Y-%m-%d")
-
         instrument = INSTRUMENT_MAP[aperture[:3].lower()]
         siaf = self.pysiaf.Siaf(instrument, basepath=self.xml_path)
         aperture = siaf[aperture.upper()]
         return aperture
 
-    def get_wcs(self, aperture, to_detector=False, useafter=None):
+    def get_wcs(self, aperture, to_detector=False):
         """
         Query the SIAF database file and get WCS values.
 
-        Given an ``APERTURE_NAME`` and a ``USEAFTER`` date query the SIAF database
+        Given an ``APERTURE_NAME`` query the SIAF database
         and extract the following keywords:
         ``V2Ref``, ``V3Ref``, ``V3IdlYAngle``, ``VIdlParity``,
         ``XSciRef``, ``YSciRef``, ``XSciScale``, ``YSciScale``,
@@ -149,18 +142,15 @@ class SiafDb:
         ----------
         aperture : str
             The name of the aperture to retrieve.
-
         to_detector : bool
             Convert all the pixel parameters to be relative to the detector.
-        useafter : str
-            The date of observation (``model.meta.date``).
 
         Returns
         -------
         siaf : namedtuple
             The SIAF namedtuple with values from the PRD database.
         """
-        aperture = self.get_aperture(aperture, useafter=useafter)
+        aperture = self.get_aperture(aperture)
 
         # Build the SIAF entry. Missing required values is an error.
         # Otherwise, use defaults.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4398](https://jira.stsci.edu/browse/JP-4398)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Remove references to a "useafter" date from the set_telescope_pointing code.  

Currently, a date is retrieved from the observation date and passed through several functions, but it is not actually used in the SiafDb query.  Since UseAfterDate support is being removed from the SIAF back end, we should clean out the unnecessary references to it in our code.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
