### PR TITLE
JP-4376: Consistent resampling for LRS slitless

### DIFF
--- a/changes/10670.pipeline.rst
+++ b/changes/10670.pipeline.rst
@@ -1,0 +1,1 @@
+Explicitly avoid the ``resample_spec`` step for MIRI-LRS_SLITLESS data in the spec3 pipeline, to match handling in the spec2 pipeline.

--- a/changes/10670.resample.rst
+++ b/changes/10670.resample.rst
@@ -1,0 +1,1 @@
+Flip MIRI-LRS_SLITLESS images along the wavelength axis, so that the resampled image matches the orientation in the input image.

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -248,7 +248,9 @@ class Spec3Pipeline(Pipeline):
                         resample_complete = result[0].meta.cal_step.cube_build
                     except AttributeError:
                         pass
-                else:
+                elif exptype != "MIR_LRS-SLITLESS":
+                    # LRS slitless data is never resampled, matching spec2 handling
+                    # for non-TSO slitless data.
                     result = self.resample_spec.run(result)
                     try:
                         resample_complete = result.meta.cal_step.resample

--- a/jwst/pipeline/tests/test_calwebb_spec3.py
+++ b/jwst/pipeline/tests/test_calwebb_spec3.py
@@ -12,7 +12,7 @@ from stcal.alignment.util import compute_s_region_keyword, sregion_to_footprint
 import jwst
 from jwst.datamodels.container import ModelContainer
 from jwst.datamodels.utils.wfss_multispec import make_wfss_multiexposure
-from jwst.extract_1d.tests.helpers import mock_nirspec_fs_one_slit_func
+from jwst.extract_1d.tests.helpers import mock_miri_lrs_fs_func, mock_nirspec_fs_one_slit_func
 from jwst.pipeline import Spec3Pipeline
 from jwst.stpipe import Step
 
@@ -211,3 +211,22 @@ def test_spec3_nrs_fs(tmp_cwd):
     # make sure input model was not modified
     assert input_model.meta.cal_step.instance == model_copy.meta.cal_step.instance
     np.testing.assert_allclose(input_model.data, model_copy.data)
+
+
+def test_spec3_miri_lrs_slitless(tmp_cwd):
+    # Mock a slitless non-TSO observation by modifying a LRS fixed slit fixture
+    input_model = mock_miri_lrs_fs_func()
+    input_model.meta.exposure.type = "MIR_LRS-SLITLESS"
+
+    input_model.meta.filename = "test_spec3_cal.fits"
+    steps = {"outlier_detection": {"skip": True}}
+    Spec3Pipeline.call([input_model], steps=steps, save_results=True)
+
+    # check for expected output
+    x1d_file = "test_spec3_x1d.fits"
+    assert Path(x1d_file).exists()
+
+    # make sure resample_spec was not called, nor skipped:
+    # it is explicitly avoided for this mode
+    with dm.open(x1d_file) as output_model:
+        assert output_model.meta.cal_step.resample is None

--- a/jwst/resample/resample_spec.py
+++ b/jwst/resample/resample_spec.py
@@ -720,10 +720,10 @@ class ResampleSpec(ResampleImage):
         all_wave = np.sort(all_wave, axis=None)
         # Tabular interpolation model, pixels -> lambda
         wavelength_array = np.unique(all_wave)
-        # Check if the data is MIRI LRS FIXED Slit. If it is then
+        # Check if the data is MIRI LRS. If it is, then
         # the wavelength array needs to be flipped so that the resampled
         # dispersion direction matches the dispersion direction on the detector.
-        if input_models[0].meta.exposure.type == "MIR_LRS-FIXEDSLIT":
+        if input_models[0].meta.exposure.type.startswith("MIR_LRS"):
             wavelength_array = np.flip(wavelength_array, axis=None)
 
         step = 1


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4376](https://jira.stsci.edu/browse/JP-4376)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Explicitly avoid resampling for MIRI LRS slitless non-TSO data in spec3, to match handling in spec2.

Also, for standalone resampling support, add a flip on the wavelength axis for MIRI LRS slitless data, matching the handling for LRS fixed slit.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
