### PR TITLE
Silence S_REGION logging in resample

### DIFF
--- a/jwst/assign_wcs/assign_wcs.py
+++ b/jwst/assign_wcs/assign_wcs.py
@@ -121,7 +121,7 @@ def load_wcs(input_model, reference_files=None, nrs_slit_y_range=None, nrs_ifu_s
                     f"Unable to update S_REGION for type {input_model.meta.exposure.type}: {exc}"
                 )
             else:
-                log.info(f"assign_wcs updated S_REGION to {input_model.meta.wcsinfo.s_region}")
+                log.debug(f"assign_wcs updated S_REGION to {input_model.meta.wcsinfo.s_region}")
             if input_model.meta.exposure.type.lower() == "mir_lrs-slitless":
                 input_model.wavelength = get_wavelengths(input_model)
         elif input_model.meta.exposure.type.lower() == "nrs_ifu":

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -88,7 +88,7 @@ def nrs_extract2d(input_model, slit_names=None, source_ids=None):
             orig_s_region = str(output_model.meta.wcsinfo.s_region).strip()
             util.update_s_region_nrs_slit(output_model)
             if orig_s_region != str(output_model.meta.wcsinfo.s_region).strip():
-                log.info(f"extract_2d updated S_REGION to {output_model.meta.wcsinfo.s_region}")
+                log.debug(f"extract_2d updated S_REGION to {output_model.meta.wcsinfo.s_region}")
     else:
         output_model = datamodels.MultiSlitModel()
         output_model.update(input_model)
@@ -122,7 +122,7 @@ def nrs_extract2d(input_model, slit_names=None, source_ids=None):
             if "world" in input_model.meta.wcs.available_frames:
                 util.update_s_region_nrs_slit(new_model)
                 if orig_s_region != str(new_model.meta.wcsinfo.s_region).strip():
-                    log.info(f"Updated S_REGION to {new_model.meta.wcsinfo.s_region}")
+                    log.debug(f"Updated S_REGION to {new_model.meta.wcsinfo.s_region}")
 
             # Copy BUNIT values to output slit
             new_model.meta.bunit_data = input_model.meta.bunit_data

--- a/jwst/pipeline/calwebb_spec3.py
+++ b/jwst/pipeline/calwebb_spec3.py
@@ -461,5 +461,5 @@ class Spec3Pipeline(Pipeline):
         except ValueError as e:
             log.warning(f"Could not combine S_REGIONs: {e}. Output S_REGION will not be set.")
             return
-        log.info(f"Setting S_REGION for combined footprint to: {sregion}")
+        log.debug(f"Setting S_REGION for combined footprint to: {sregion}")
         wfss_model.spec[0].s_region = sregion

--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -502,7 +502,7 @@ class ResampleImage(Resample):
             # only for an imaging WCS:
             self.update_fits_wcsinfo(self.output_jwst_model)
             output_sregion = self.combine_input_sregions()
-            log.info(f"Assigning output S_REGION: {output_sregion}")
+            log.debug(f"Assigning output S_REGION: {output_sregion}")
             self.output_jwst_model.meta.wcsinfo.s_region = output_sregion
 
         self.output_jwst_model.meta.cal_step.resample = "COMPLETE"

--- a/jwst/resample/resample_spec_step.py
+++ b/jwst/resample/resample_spec_step.py
@@ -275,7 +275,7 @@ class ResampleSpecStep(Step):
             s_region_model1 = input_models[0].meta.wcsinfo.s_region
             s_region = find_miri_lrs_sregion(s_region_model1, result.meta.wcs)
             result.meta.wcsinfo.s_region = s_region
-            log.info(f"Updating S_REGION: {s_region}.")
+            log.debug(f"Updating S_REGION: {s_region}.")
 
             # Transform source_xpos and source_ypos to resampled image frame, since they
             # are defined in full-frame coordinates for MIRI LRS Fixed Slit


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses superfluous, debug-level logging in resample.  Typically, this looks like:


> 2026-07-06 09:18:36,993 - stcal.resample.resample - INFO - Resampling science and variance data
> 2026-07-06 09:18:38,901 - stcal.resample.resample - INFO - Resampling science and variance data
> 2026-07-06 09:18:40,753 - stcal.resample.resample - INFO - Resampling science and variance data
> 2026-07-06 09:18:41,496 - jwst.resample.resample - INFO - Assigning output S_REGION: POLYGON ICRS  226.052153661 62.842148642 226.079146470 62.829288159 226.079177879 62.829301647 226.079267042 62.829259139 226.079359933 62.829299030 226.079392752 62.829283383 226.079596476 62.829370869 226.079598573 62.829369869 226.107690821 62.841425791 226.081029060 62.854491279 226.080996443 62.854477218 226.080908591 62.854520242 226.080815363 62.854480052 226.080782776 62.854496011 226.080703252 62.854461729 226.080623892 62.854500594 226.080604609 62.854492281 226.080516789 62.854535289 226.080423453 62.854495052 226.080403354 62.854504895 226.051980470 62.842243937 226.052167797 62.842154744  POLYGON ICRS  226.081029876 62.828539186 226.107357849 62.815784546 226.107390061 62.815798270 226.107478311 62.815755490 226.107571801 62.815795321 226.107603997 62.815779714 226.107808428 62.815866811 226.107809789 62.815866151 226.135672959 62.827729464 226.109589913 62.840648517 226.109556760 62.840634339 226.109469543 62.840677511 226.109375822 62.840637432 226.109343759 62.840653303 226.109263544 62.840619000 226.109184937 62.840657910 226.109165203 62.840649471 226.109077970 62.840692650 226.108984173 62.840652538 226.108964525 62.840662264 226.080856835 62.828634507 226.081042529 62.828544604  POLYGON ICRS  226.082648260 62.855350391 226.109294221 62.842270519 226.109327358 62.842284432 226.109414842 62.842241461 226.109509242 62.842281096 226.109540622 62.842265683 226.109746568 62.842352152 226.138269793 62.854320113 226.111883506 62.867645714 226.111849242 62.867631184 226.111763000 62.867674710 226.111668528 62.867634648 226.111637108 62.867650505 226.111555705 62.867615985 226.111478174 62.867655114 226.111457349 62.867646283 226.111371010 62.867689857 226.111276625 62.867649831 226.111257525 62.867659471 226.082475114 62.855445713 226.082659605 62.855355209  POLYGON ICRS  226.111003525 62.841356019 226.137250810 62.828499365 226.137283772 62.828513182 226.137371319 62.828470272 226.137465718 62.828509842 226.137497074 62.828494473 226.165702636 62.840309982 226.165908803 62.840396318 226.139829788 62.853456673 226.139795977 62.853442360 226.139709382 62.853485699 226.139615019 62.853445753 226.139583523 62.853461516 226.139502469 62.853427203 226.139424652 62.853466149 226.139404325 62.853457544 226.139317626 62.853500935 226.139223258 62.853460986 226.139204132 62.853470558 226.110830528 62.841451366 226.111015197 62.841360967  POLYGON ICRS  226.131040056 62.874863615 226.158100508 62.861854707 226.158132444 62.861868282 226.158221199 62.861825587 226.158314725 62.861865342 226.158347088 62.861849774 226.158551919 62.861936842 226.158553413 62.861936123 226.186888767 62.873972800 226.160370053 62.887087504 226.160336660 62.887073472 226.160249494 62.887116552 226.160154963 62.887076829 226.160123486 62.887092386 226.160042634 62.887058411 226.159964479 62.887097037 226.159944589 62.887088679 226.159857228 62.887131855 226.159762638 62.887092106 226.159743665 62.887101483 226.130866986 62.874958978 226.131053611 62.874869319  POLYGON ICRS  226.159740226 62.860968157 226.186357908 62.848166115 226.186389603 62.848179737 226.186478487 62.848136960 226.186571499 62.848176936 226.186604351 62.848161125 226.186808054 62.848248673 226.186810646 62.848247426 226.214667028 62.860211985 226.188493193 62.873082761 226.188460326 62.873068795 226.188372735 62.873111840 226.188278829 62.873071937 226.188246758 62.873087697 226.188166621 62.873053644 226.188087814 62.873092372 226.188068414 62.873084128 226.187980700 62.873127233 226.187886659 62.873087272 226.187867128 62.873096870 226.159567306 62.861063546 226.159753772 62.860973920  POLYGON ICRS  226.161965187 62.887931616 226.188278892 62.874737734 226.188313336 62.874751872 226.188399629 62.874708576 226.188495401 62.874747886 226.188525589 62.874732740 226.217203298 62.886496101 226.217201663 62.886496945 226.217410002 62.886582348 226.191912744 62.899733594 226.191545948 62.899910763 226.191523020 62.899901404 226.191438239 62.899945105 226.191341741 62.899905714 226.191312154 62.899920965 226.191228456 62.899886799 226.191153099 62.899925642 226.191130963 62.899916606 226.191045790 62.899960508 226.190949516 62.899921208 226.190932176 62.899930146 226.161792163 62.888027006 226.161974738 62.887935520  POLYGON ICRS  226.190261796 62.873935439 226.216341681 62.861031068 226.216375207 62.861045000 226.216462308 62.861001875 226.216557289 62.861041344 226.216588243 62.861026018 226.244466336 62.872603352 226.244966917 62.872818266 226.219264396 62.885822707 226.219229773 62.885808399 226.219143903 62.885851818 226.219048296 62.885812307 226.219017851 62.885827701 226.218935479 62.885793659 226.218858858 62.885832402 226.218837876 62.885823731 226.218751687 62.885867311 226.218656133 62.885827821 226.218638065 62.885836957 226.190088922 62.874030853 226.190272728 62.873939963
> 2026-07-06 09:18:43,289 - jwst.resample.resample - INFO - 8 exposures to drizzle together
> 2026-07-06 09:18:44,712 - stcal.resample.resample - INFO - Resampling science and variance data
> 2026-07-06 09:18:46,708 - stcal.resample.resample - INFO - Resampling science and variance data
> 2026-07-06 09:18:48,585 - stcal.resample.resample - INFO - Resampling science and variance data
> 

All those floats for the S_REGION should be DEBUG level.  It is not useful info for the user, nor can it even be parsed by the user.

This PR changes these log messages from INFO to DEBUG.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
