### PR TITLE
API: Remove deprecated save_bsub

### DIFF
--- a/changes/10680.breaking.rst
+++ b/changes/10680.breaking.rst
@@ -1,0 +1,1 @@
+Removed deprecated ``save_bsub`` from ``calwebb_image2`` and ``calwebb_spec2``; use the background step's ``save_results`` parameter instead.

--- a/changes/10680.pipeline.rst
+++ b/changes/10680.pipeline.rst
@@ -1,0 +1,1 @@
+Removed deprecated ``save_bsub`` from ``calwebb_image2`` and ``calwebb_spec2``; use the background step's ``save_results`` parameter instead.

--- a/docs/jwst/pipeline/calwebb_image2.rst
+++ b/docs/jwst/pipeline/calwebb_image2.rst
@@ -38,16 +38,6 @@ table below.
 .. [1] Resampling is only performed for exposure types "MIR_IMAGE", "NRC_IMAGE", and
    "NIS_IMAGE".
 
-Arguments
----------
-
-The ``calwebb_image2`` pipeline has one optional argument, which is deprecated::
-
-  --save_bsub  boolean  default=False
-
-This parameter will be removed in a future version. To toggle saving of background-subtracted
-data, use the background step's ``save_results`` parameter instead.
-
 Inputs
 ------
 

--- a/docs/jwst/pipeline/calwebb_spec2.rst
+++ b/docs/jwst/pipeline/calwebb_spec2.rst
@@ -269,14 +269,9 @@ abbreviations used in the table are as follows:
 In the :ref:`resample_spec <resample_spec_step>` and :ref:`cube_build <cube_build_step>` steps, the spectra are
 transformed to a space of (wavelength, offset along the slit) without applying a tangent plane projection.
 
-Arguments
----------
-The ``calwebb_spec2`` pipeline has three optional arguments.
-
-``--save_bsub`` (boolean, default=False)
-  This parameter is deprecated and will be removed in a future release.
-  To save background-subtracted data ("_bsub" or "_bsubints"), use the background step's
-  ``--save_results`` parameter instead.
+Pipeline Arguments
+------------------
+The ``calwebb_spec2`` pipeline has the following optional arguments.
 
 ``--fail_on_exception`` (boolean, default=False)
   If set to ``True``, the pipeline will stop processing and raise an exception

--- a/jwst/pipeline/calwebb_image2.py
+++ b/jwst/pipeline/calwebb_image2.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import logging
-import warnings
 from collections import defaultdict
 from pathlib import Path
 
@@ -31,10 +30,6 @@ class Image2Pipeline(Pipeline):
 
     class_alias = "calwebb_image2"
 
-    spec = """
-        save_bsub = boolean(default=False) # Deprecated; use the background step's save_results parameter instead.
-    """  # noqa: E501
-
     # Define alias to steps
     step_defs = {
         "bkg_subtract": background_step.BackgroundStep,
@@ -62,15 +57,6 @@ class Image2Pipeline(Pipeline):
             The calibrated data models.
         """
         log.info("Starting calwebb_image2 ...")
-
-        if self.save_bsub:
-            deprecation_message = (
-                "The --save_bsub parameter is deprecated and will be removed in a future release. "
-                "To toggle saving background-subtracted data, use the background step's "
-                "--save_results parameter instead."
-            )
-            warnings.warn(deprecation_message, DeprecationWarning, stacklevel=2)
-            log.warning(deprecation_message)
 
         # Retrieve the input(s)
         asn = LoadAsLevel2Asn.load(input_data, basename=self.output_file)
@@ -157,10 +143,6 @@ class Image2Pipeline(Pipeline):
             self.bkg_subtract.suffix = "bsub"
             if isinstance(input_data, datamodels.CubeModel):
                 self.bkg_subtract.suffix = "bsubints"
-
-            # Backwards compatibility
-            if self.save_bsub:
-                self.bkg_subtract.save_results = True
 
             # Call the background subtraction step
             input_data = self.bkg_subtract.run(input_data, members_by_type["background"])

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -1,6 +1,5 @@
 import logging
 import traceback
-import warnings
 from collections import defaultdict
 from pathlib import Path
 
@@ -71,7 +70,6 @@ class Spec2Pipeline(Pipeline):
     class_alias = "calwebb_spec2"
 
     spec = """
-        save_bsub = boolean(default=False) # Deprecated; use the background step's save_results parameter instead.
         fail_on_exception = boolean(default=True) # Fail if any product fails.
         save_wfss_esec = boolean(default=False)   # Save WFSS e-/sec image
     """  # noqa: E501
@@ -121,15 +119,6 @@ class Spec2Pipeline(Pipeline):
             The calibrated data models.
         """
         log.info("Starting calwebb_spec2 ...")
-
-        if self.save_bsub:
-            deprecation_message = (
-                "The --save_bsub parameter is deprecated and will be removed in a future release. "
-                "To toggle saving background-subtracted data, use the background step's "
-                "--save_results parameter instead."
-            )
-            warnings.warn(deprecation_message, DeprecationWarning, stacklevel=2)
-            log.warning(deprecation_message)
 
         # Setup step parameters required by the pipeline.
         self.resample_spec.save_results = self.save_results
@@ -497,10 +486,6 @@ class Spec2Pipeline(Pipeline):
                 self.bkg_subtract.suffix = "bsub"
                 if multi_int:
                     self.bkg_subtract.suffix = "bsubints"
-
-                # Backwards compatibility
-                if self.save_bsub:
-                    self.bkg_subtract.save_results = True
             else:
                 log.debug(
                     "Science data does not allow direct background subtraction. "

--- a/jwst/pipeline/tests/test_calwebb_image2.py
+++ b/jwst/pipeline/tests/test_calwebb_image2.py
@@ -9,7 +9,6 @@ from stdatamodels.jwst import datamodels
 from jwst.pipeline import Image2Pipeline
 from jwst.pipeline.tests.helpers import make_nircam_rate_model
 from jwst.stpipe import Step
-from jwst.tests.helpers import _help_pytest_warns
 
 INPUT_FILE = "test_rate.fits"
 INPUT_FILE_2 = "test2_rate.fits"
@@ -113,26 +112,6 @@ def test_output_file_norename_asn(run_image2_pipeline_asn):
     assert (
         "Multiple products in input association. Output file name will be ignored." in log_content
     )
-
-
-def test_bsub_deprecated(make_rate_file):
-    """
-    Ensure that the deprecated save_bsub parameter raises a
-    DeprecationWarning when set to True.
-    """
-    args = [
-        "calwebb_image2",
-        INPUT_FILE,
-        "--save_bsub=true",
-        "--steps.flat_field.skip=true",
-        "--steps.photom.skip=true",
-        "--steps.resample.skip=true",
-    ]
-    with (
-        _help_pytest_warns(),
-        pytest.warns(DeprecationWarning, match="The --save_bsub parameter is deprecated"),
-    ):
-        Step.from_cmdline(args)
 
 
 def test_image2_nircam_model(make_rate_file):

--- a/jwst/pipeline/tests/test_calwebb_spec2.py
+++ b/jwst/pipeline/tests/test_calwebb_spec2.py
@@ -14,7 +14,6 @@ from jwst.targ_centroid.tests.helpers import (
     make_slit_data,
     make_ta_association,
 )
-from jwst.tests.helpers import _help_pytest_warns
 
 INPUT_FILE = "test_rate.fits"
 INPUT_FILE_2 = "test2_rate.fits"
@@ -143,32 +142,6 @@ def test_filenotfounderror_raised(capsys):
     # Verify the failure is printed to stderr
     captured = capsys.readouterr()
     assert "FileNotFoundError" in captured.err
-
-
-def test_bsub_deprecated(make_test_rate_file):
-    """
-    Ensure that the deprecated save_bsub parameter raises a
-    DeprecationWarning when set to True.
-    """
-    args = [
-        "calwebb_spec2",
-        INPUT_FILE,
-        "--save_bsub=true",
-        "--steps.badpix_selfcal.skip=true",
-        "--steps.msa_flagging.skip=true",
-        "--steps.clean_flicker_noise.skip=true",
-        "--steps.flat_field.skip=true",
-        "--steps.pathloss.skip=true",
-        "--steps.photom.skip=true",
-        "--steps.pixel_replace.skip=true",
-        "--steps.extract_1d.skip=true",
-    ]
-
-    with (
-        _help_pytest_warns(),
-        pytest.warns(DeprecationWarning, match="The --save_bsub parameter is deprecated"),
-    ):
-        Step.from_cmdline(args)
 
 
 @pytest.mark.parametrize("use_asn", [True, False])


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
Closes #9814 . Was deprecated in #9805 .

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md)) https://github.com/spacetelescope/RegressionTests/actions/runs/28823114886
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
