### PR TITLE
JP-4401: Add fallback intstart value for tso_photometry

### DIFF
--- a/changes/10689.tso_photometry.rst
+++ b/changes/10689.tso_photometry.rst
@@ -1,0 +1,1 @@
+Use an integration start value of 1 if the keyword is not populated.

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -1,10 +1,8 @@
 import logging
-import warnings
 
 import numpy as np
 from astropy.io.fits import FITS_rec
 from astropy.table import vstack
-from astropy.utils.metadata.exceptions import MergeConflictWarning
 from stdatamodels.jwst import datamodels
 
 from jwst.adaptive_trace_model import adaptive_trace_model_step
@@ -230,8 +228,7 @@ class Tso3Pipeline(Pipeline):
             log.warning("Could not create a photometric catalog; all results are null")
         else:
             # Otherwise, save results to a photometry catalog file
-            with warnings.catch_warnings(category=MergeConflictWarning):
-                phot_results = vstack(phot_result_list)
+            phot_results = vstack(phot_result_list)
             phot_results.meta["number_of_integrations"] = len(phot_results)
             phot_tab_name = self.make_output_path(suffix=phot_tab_suffix, ext="ecsv")
             log.info(f"Writing Level 3 photometry catalog {phot_tab_name}")

--- a/jwst/pipeline/calwebb_tso3.py
+++ b/jwst/pipeline/calwebb_tso3.py
@@ -1,8 +1,10 @@
 import logging
+import warnings
 
 import numpy as np
 from astropy.io.fits import FITS_rec
 from astropy.table import vstack
+from astropy.utils.metadata.exceptions import MergeConflictWarning
 from stdatamodels.jwst import datamodels
 
 from jwst.adaptive_trace_model import adaptive_trace_model_step
@@ -228,7 +230,8 @@ class Tso3Pipeline(Pipeline):
             log.warning("Could not create a photometric catalog; all results are null")
         else:
             # Otherwise, save results to a photometry catalog file
-            phot_results = vstack(phot_result_list)
+            with warnings.catch_warnings(category=MergeConflictWarning):
+                phot_results = vstack(phot_result_list)
             phot_results.meta["number_of_integrations"] = len(phot_results)
             phot_tab_name = self.make_output_path(suffix=phot_tab_suffix, ext="ecsv")
             log.info(f"Writing Level 3 photometry catalog {phot_tab_name}")

--- a/jwst/regtest/test_nircam_tsimg.py
+++ b/jwst/regtest/test_nircam_tsimg.py
@@ -37,6 +37,8 @@ def run_pipelines(rtdata_module, resource_tracker):
 def run_tsgrism_sw_img_pipeline(rtdata_module, resource_tracker):
     rtdata = rtdata_module
 
+    rtdata.get_data("nircam/tsimg/jw01442003001_02104_00001_nrca1_calints.fits")
+    rtdata.get_data("nircam/tsimg/jw01442003001_02104_00001_nrca3_calints.fits")
     rtdata.get_data("nircam/tsimg/jw01442-o003_tso3_00002_asn.json")
     args = ["calwebb_tso3", rtdata.input]
     with resource_tracker.track():

--- a/jwst/regtest/test_nircam_tsimg.py
+++ b/jwst/regtest/test_nircam_tsimg.py
@@ -1,7 +1,4 @@
-import warnings
-
 import pytest
-from astropy.utils.metadata.exceptions import MergeConflictWarning
 
 from jwst.lib.set_telescope_pointing import add_wcs
 from jwst.regtest.st_fitsdiff import STFITSDiff as FITSDiff
@@ -42,9 +39,8 @@ def run_tsgrism_sw_img_pipeline(rtdata_module, resource_tracker):
 
     rtdata.get_asn("nircam/tsimg/jw01442-o003_tso3_00002_asn.json")
     args = ["calwebb_tso3", rtdata.input]
-    with warnings.catch_warnings(category=MergeConflictWarning):
-        with resource_tracker.track():
-            Step.from_cmdline(args)
+    with resource_tracker.track():
+        Step.from_cmdline(args)
 
     return rtdata
 

--- a/jwst/regtest/test_nircam_tsimg.py
+++ b/jwst/regtest/test_nircam_tsimg.py
@@ -37,9 +37,7 @@ def run_pipelines(rtdata_module, resource_tracker):
 def run_tsgrism_sw_img_pipeline(rtdata_module, resource_tracker):
     rtdata = rtdata_module
 
-    rtdata.get_data("nircam/tsimg/jw01442003001_02104_00001_nrca1_calints.fits")
-    rtdata.get_data("nircam/tsimg/jw01442003001_02104_00001_nrca3_calints.fits")
-    rtdata.get_data("nircam/tsimg/jw01442-o003_tso3_00002_asn.json")
+    rtdata.get_asn("nircam/tsimg/jw01442-o003_tso3_00002_asn.json")
     args = ["calwebb_tso3", rtdata.input]
     with resource_tracker.track():
         Step.from_cmdline(args)

--- a/jwst/regtest/test_nircam_tsimg.py
+++ b/jwst/regtest/test_nircam_tsimg.py
@@ -33,6 +33,22 @@ def run_pipelines(rtdata_module, resource_tracker):
     return rtdata
 
 
+@pytest.fixture(scope="module")
+def run_tsgrism_sw_img_pipeline(rtdata_module, resource_tracker):
+    rtdata = rtdata_module
+
+    rtdata.get_data("nircam/tsimg/jw01442-o003_tso3_00002_asn.json")
+    args = ["calwebb_tso3", rtdata.input]
+    with resource_tracker.track():
+        Step.from_cmdline(args)
+
+    return rtdata
+
+
+def test_log_tracked_resources_tsgrism_img(log_tracked_resources, run_tsgrism_sw_img_pipeline):
+    log_tracked_resources()
+
+
 def test_log_tracked_resources_tsimg(log_tracked_resources, run_pipelines):
     log_tracked_resources()
 
@@ -82,3 +98,14 @@ def test_nircam_setpointing_tsimg(rtdata, fitsdiff_default_kwargs):
     fitsdiff_default_kwargs["rtol"] = 1e-6
     diff = FITSDiff(rtdata.output, rtdata.truth, **fitsdiff_default_kwargs)
     assert diff.identical, diff.report()
+
+
+def test_nircam_tsgrism_swimage_stage3_phot(run_tsgrism_sw_img_pipeline, diff_astropy_tables):
+    rtdata = run_tsgrism_sw_img_pipeline
+    rtdata.input = "nircam/tsimg/jw01442-o003_tso3_00002_asn.json"
+    rtdata.output = "jw01442-o003_t001_nircam_clear-wlp4-subgrism256_phot.ecsv"
+    rtdata.get_truth(
+        "truth/test_nircam_tsimg_stage23/jw01442-o003_t001_nircam_clear-wlp4-subgrism256_phot.ecsv"
+    )
+
+    assert diff_astropy_tables(rtdata.output, rtdata.truth)

--- a/jwst/regtest/test_nircam_tsimg.py
+++ b/jwst/regtest/test_nircam_tsimg.py
@@ -1,4 +1,7 @@
+import warnings
+
 import pytest
+from astropy.utils.metadata.exceptions import MergeConflictWarning
 
 from jwst.lib.set_telescope_pointing import add_wcs
 from jwst.regtest.st_fitsdiff import STFITSDiff as FITSDiff
@@ -39,8 +42,9 @@ def run_tsgrism_sw_img_pipeline(rtdata_module, resource_tracker):
 
     rtdata.get_asn("nircam/tsimg/jw01442-o003_tso3_00002_asn.json")
     args = ["calwebb_tso3", rtdata.input]
-    with resource_tracker.track():
-        Step.from_cmdline(args)
+    with warnings.catch_warnings(category=MergeConflictWarning):
+        with resource_tracker.track():
+            Step.from_cmdline(args)
 
     return rtdata
 

--- a/jwst/tso_photometry/tso_photometry.py
+++ b/jwst/tso_photometry/tso_photometry.py
@@ -280,7 +280,11 @@ def _get_int_times(datamodel):
     num_integ = 1
     if len(shape) > 2:
         num_integ = shape[0]
-    int_start = datamodel.meta.exposure.integration_start
+    int_start = (
+        datamodel.meta.exposure.integration_start
+        if datamodel.meta.exposure.integration_start is not None
+        else 1
+    )
 
     # Columns of integration numbers & times of integration from the
     # INT_TIMES table.


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4401](https://jira.stsci.edu/browse/JP-4401)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR addresses errors seen by Ops while processing TSO imaging products related to NRC_TSGRISM data - the images are not segmented, meaning SDP does not populate a value for integration_start. This leads to a type collision while trying to subtract a value from None.

RTs: https://github.com/spacetelescope/RegressionTests/actions/runs/28960415425

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [x] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
