### PR TITLE
DOC: Complete API for wavecorr

### DIFF
--- a/docs/jwst/references_general/wavecorr_reffile.inc
+++ b/docs/jwst/references_general/wavecorr_reffile.inc
@@ -9,8 +9,8 @@ WAVECORR Reference File
 The WAVECORR reference file contains pixel offset values as a function of
 wavelength and source offset within a NIRSpec slit.
 It is used when applying the NIRSpec wavelength zero-point correction to
-fixed-slit (EXP_TYPE="NRS_FIXEDSLIT"), bright object TSO
-(EXP_TYPE="NRS_BRIGHTOBJ"), and MSA/MOS spectra (EXP_TYPE="NRS_MSASPEC").
+fixed-slit (``EXP_TYPE="NRS_FIXEDSLIT"``), bright object TSO
+(``EXP_TYPE="NRS_BRIGHTOBJ"``), and MSA/MOS spectra (``EXP_TYPE="NRS_MSASPEC"``).
 This is an optional correction that is turned on by default.
 It can be turned off by specifying ``apply_wavecorr=False`` when running the step.
 
@@ -25,11 +25,11 @@ the following keywords are *required* in WAVECORR reference files,
 because they are used as CRDS selectors
 (see :ref:`wavecorr_selectors`):
 
-=========  ==============================
+=========  ========================
 Keyword    Data Model Name
-=========  ==============================
+=========  ========================
 EXP_TYPE   model.meta.exposure.type
-=========  ==============================
+=========  ========================
 
 Reference File Format
 +++++++++++++++++++++

--- a/docs/jwst/references_general/wavecorr_selection.inc
+++ b/docs/jwst/references_general/wavecorr_selection.inc
@@ -7,8 +7,7 @@ WAVECORR is not applicable for instruments not in the table.
 Non-standard keywords used for file selection are *required*.
 
 ========== ======================================
-Instrument Keywords                               
+Instrument Keywords
 ========== ======================================
-NIRSpec    INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS 
+NIRSpec    INSTRUME, EXP_TYPE, DATE-OBS, TIME-OBS
 ========== ======================================
-

--- a/docs/jwst/wavecorr/api_ref.rst
+++ b/docs/jwst/wavecorr/api_ref.rst
@@ -1,0 +1,15 @@
+===
+API
+===
+
+Public Step API
+===============
+
+.. automodapi:: jwst.wavecorr.wavecorr_step
+   :no-inheritance-diagram:
+
+Complete Developer API
+======================
+
+.. automodapi:: jwst.wavecorr.wavecorr
+   :no-inheritance-diagram:

--- a/docs/jwst/wavecorr/arguments.rst
+++ b/docs/jwst/wavecorr/arguments.rst
@@ -1,3 +1,0 @@
-Step Arguments
-==============
-The Wavecorr step has no step-specific arguments.

--- a/docs/jwst/wavecorr/description.rst
+++ b/docs/jwst/wavecorr/description.rst
@@ -1,22 +1,22 @@
 Description
-============
+===========
 
-:Class: `jwst.wavecorr.WavecorrStep`
+:Class: `jwst.wavecorr.wavecorr_step.WavecorrStep`
 :Alias: wavecorr
 
 The wavelength correction (``wavecorr``) step in the
 :ref:`calwebb_spec2 <calwebb_spec2>` pipeline updates the wavelength
 assignments for NIRSpec fixed-slit (FS) and MOS point sources that are
-known to be off center (in the dispersion direction) in their slit.
+known to be off-center (in the dispersion direction) in their slit.
 
 Upon successful completion of the step, the status keyword "S_WAVCOR"
 in the primary header is set to "COMPLETE".  For each SCI extension, the "WAVECOR"
-keyword is set to True if the slit was wavelength corrected (it is a point
-source) or False if it was not corrected (it is not a point source).
+keyword is set to `True` if the slit was wavelength corrected (it is a point
+source) or `False` if it was not corrected (it is an extended object).
 
 NIRSpec MOS
 -----------
-For NIRSpec MOS exposures (EXP_TYPE="NRS_MSASPEC"), wavelength
+For NIRSpec MOS exposures (``EXP_TYPE="NRS_MSASPEC"``), wavelength
 assignments created during :ref:`extract_2d <extract_2d_step>` are based on
 a source that's perfectly centered in a slitlet. Most sources, however,
 are not centered in every slitlet in a real observation.
@@ -27,29 +27,32 @@ These are recorded in the "SRCXPOS" and "SRCYPOS" keywords in the SCI
 extension header of each slitlet in a FITS product.
 
 The ``wavecorr`` step loops over all slit instances in the input
-science product and updates the WCS models of slits that contain a point 
-source to include a wavelength correction. The point source determination is 
+science product and updates the WCS models of slits that contain a point
+source to include a wavelength correction. The point source determination is
 based on the value of the "SRCTYPE" keyword populated for each slit by the
 :ref:`srctype <srctype_step>` step. The computation of the correction is
 based on the "SRCXPOS" value. A value of 0.0 indicates a perfectly centered
 source, and ranges from -0.5 to +0.5 for sources at the extreme edges
 of a slit. The computation uses calibration data from the ``WAVECORR``
-reference file, which contains pixel shifts as a function of source position 
-and wavelength, and can be converted to wavelength shifts with the dispersion. 
-For each slit, the ``wavecorr`` step uses the average wavelengths and 
-dispersions in a slit (averaged across the cross-dispersion direction) to 
-calculate corresponding corrected wavelengths.  It then uses the average 
-wavelengths and their corrections to generate a transform that interpolates 
-between "center of slit" wavelengths and corrected wavelengths.  This 
+reference file, which contains pixel shifts as a function of source position
+and wavelength, and can be converted to wavelength shifts with the dispersion.
+For each slit, the ``wavecorr`` step uses the average wavelengths and
+dispersions in a slit (averaged across the cross-dispersion direction) to
+calculate corresponding corrected wavelengths.  It then uses the average
+wavelengths and their corrections to generate a transform that interpolates
+between "center of slit" wavelengths and corrected wavelengths.  This
 transformation is added to the slit WCS after the ``slit_frame`` and
 produces a new wavelength corrected slit frame, ``wavecorr_frame``.
 
 NIRSpec Fixed Slit (FS)
 -----------------------
-
-The source position within the primary slit is estimated based on the 
-target coordinates and aperture reference point during the 
-:ref:`extract_2d <extract_2d_step>` step. This estimated position (in the 
+The source position within the primary slit is estimated based on the
+target coordinates and aperture reference point during the
+:ref:`extract_2d <extract_2d_step>` step. This estimated position (in the
 dispersion direction) is used in the same manner as described above
 for MOS slitlets to update the slit WCS and compute corrected wavelengths
 for the primary slit only.
+
+Step Arguments
+--------------
+The ``wavecorr`` step has no step-specific arguments.

--- a/docs/jwst/wavecorr/index.rst
+++ b/docs/jwst/wavecorr/index.rst
@@ -8,7 +8,5 @@ Wavelength Correction
    :maxdepth: 2
 
    description.rst
-   arguments.rst
    reference_files.rst
-
-.. automodapi:: jwst.wavecorr
+   api_ref.rst

--- a/jwst/wavecorr/wavecorr.py
+++ b/jwst/wavecorr/wavecorr.py
@@ -25,14 +25,16 @@ def do_correction(input_model, wavecorr_file):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.ImageModel` or `~jwst.datamodels.CubeModel`
-        Input data model.  Updated in place.
+    input_model : `~stdatamodels.jwst.datamodels.ImageModel` or \
+                  `~stdatamodels.jwst.datamodels.CubeModel`
+        Input data model. It is updated in place.
     wavecorr_file : str
         Wavecorr reference file name.
 
     Returns
     -------
-    output_model : `~jwst.datamodels.ImageModel` or `~jwst.datamodels.CubeModel`
+    output_model : `~stdatamodels.jwst.datamodels.ImageModel` or \
+                   `~stdatamodels.jwst.datamodels.CubeModel`
         Corrected data model.
     """
     wavecorr_supported_modes = ["NRS_FIXEDSLIT", "NRS_MSASPEC", "NRS_BRIGHTOBJ", "NRS_AUTOFLAT"]
@@ -77,7 +79,8 @@ def apply_zero_point_correction(slit, reffile):
 
     Parameters
     ----------
-    slit : `~jwst.datamodels.SlitModel`, `~jwst.datamodels.CubeModel`
+    slit : `~stdatamodels.jwst.datamodels.SlitModel` or \
+           `~stdatamodels.jwst.datamodels.CubeModel`
         Slit data to be corrected.
     reffile : str
         The ``wavecorr`` reference file.
@@ -138,9 +141,9 @@ def calculate_wavelength_correction_transform(
     Parameters
     ----------
     lam : ndarray
-        Wavelength array [in m].
+        Wavelength array in meters.
     dispersion : ndarray
-        The pixel dispersion [in m].
+        The pixel dispersion in meters.
     freference : str
         ``wavecorr`` reference file name.
     source_xpos : float
@@ -150,7 +153,7 @@ def calculate_wavelength_correction_transform(
 
     Returns
     -------
-    model : `~astropy.modeling.tabular.Tabular1D`or None
+    model : `~astropy.modeling.tabular.Tabular1D` or None
         A model which takes wavelength inputs and returns zero-point
         corrected wavelengths.  Returns None if an invertible model
         cannot be generated.
@@ -209,7 +212,7 @@ def compute_dispersion(wcs, xpix=None, ypix=None):
     """
     Compute the pixel dispersion.
 
-    If `xpix` or `ypix` is not provided, the dispersion is computed on a grid
+    If ``xpix`` or ``ypix`` is not provided, the dispersion is computed on a grid
     based on ``wcs.bounding_box``.
 
     Parameters
@@ -224,7 +227,7 @@ def compute_dispersion(wcs, xpix=None, ypix=None):
     Returns
     -------
     dispersion : ndarray
-        The pixel dispersion [in m].
+        The pixel dispersion in meters.
     """
     if xpix is None or ypix is None:
         xpix, ypix = wcstools.grid_from_bounding_box(wcs.bounding_box, step=(1, 1))
@@ -239,7 +242,7 @@ def compute_wavelength(wcs, xpix=None, ypix=None):
     """
     Compute the pixel wavelength.
 
-    If `xpix` or `ypix` is not provided, the dispersion is computed on a grid
+    If ``xpix`` or ``ypix`` is not provided, the dispersion is computed on a grid
     based on ``wcs.bounding_box``.
 
     Parameters
@@ -254,7 +257,7 @@ def compute_wavelength(wcs, xpix=None, ypix=None):
     Returns
     -------
     wavelength : ndarray
-        The wavelength [in microns].
+        The wavelength in microns.
     """
     if xpix is None or ypix is None:
         xpix, ypix = wcstools.grid_from_bounding_box(wcs.bounding_box, step=(1, 1))
@@ -275,7 +278,7 @@ def _is_point_source(slit):
     Returns
     -------
     bool
-        True if point source; False otherwise.
+        `True` if point source; `False` otherwise.
     """
     result = False
 

--- a/jwst/wavecorr/wavecorr_step.py
+++ b/jwst/wavecorr/wavecorr_step.py
@@ -1,3 +1,5 @@
+"""Apply wavelength corrections to off-center NIRSpec point sources."""
+
 import logging
 
 from stdatamodels.jwst import datamodels
@@ -28,14 +30,14 @@ class WavecorrStep(Step):
         and FS data.
 
         The algorithm uses a reference file which is a look-up table of
-        wavelength_correction as a function of slit_x_position and wavelength.
-        The x direction is the one parallel to dispersion/wavelength for
+        wavelength correction as a function of slit's x-position and wavelength.
+        The x-direction is the one parallel to dispersion/wavelength for
         both MOS and FS slits.
 
-        The slit_x_position is read from the ``source_xpos`` attribute in the input
-        slit metadata.  For MOS data, the x position is read from the msa_metadata_file
-        in the assign_wcs step.  For FS data, the x position is calculated from
-        the dither ``x_offset`` value in the extract_2d step.
+        The slit's x-position is read from the ``source_xpos`` attribute in the input
+        slit metadata.  For MOS data, the x-position is read from the ``msa_metadata_file``
+        in the ``assign_wcs`` step.  For FS data, the x-position is calculated from
+        the dither ``x_offset`` value in the ``extract_2d`` step.
 
         The wavelength value used to look up the wavelength correction at each dispersion
         element is an average of the wavelength values in the cross-dispersion direction
@@ -49,7 +51,7 @@ class WavecorrStep(Step):
 
         Returns
         -------
-        output_model : `~stdatamodels.jwst.datamodels.MultiSlitModel`, or \
+        output_model : `~stdatamodels.jwst.datamodels.MultiSlitModel` or \
                        `~stdatamodels.jwst.datamodels.SlitModel`
             The corrected datamodel.
         """


### PR DESCRIPTION
Towards [JP-4107](https://jira.stsci.edu/browse/JP-4107)

This PR addresses `wavecorr` portion of https://github.com/spacetelescope/jwst/issues/9793 . Only touch docs so should not need RT.

On main:

* https://jwst-pipeline.readthedocs.io/en/latest/jwst/wavecorr/index.html

With this patch:

* https://jwst-pipeline--10701.org.readthedocs.build/en/10701/jwst/wavecorr/index.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
