### PR TITLE
Fix orientation wrap to (-90, 90] deg

### DIFF
--- a/changes/10710.source_catalog.rst
+++ b/changes/10710.source_catalog.rst
@@ -1,0 +1,1 @@
+Always return orientation and sky_orientation values in the range (-90, 90] deg.

--- a/jwst/source_catalog/source_catalog.py
+++ b/jwst/source_catalog/source_catalog.py
@@ -245,7 +245,16 @@ class JWSTSourceCatalog:
         }
 
         for column in self.segment_colnames:
-            # define the property name
+            # Compute 'orientation' with the `orientation` property,
+            # which always wraps the angle to the (-90, 90] deg
+            # convention. This avoids shadowing the `orientation`
+            # property with the raw segmentation-catalog value, which
+            # may be in a different range depending on the photutils
+            # version used to generate the catalog.
+            if column == "orientation":
+                continue
+
+            # Define the property name
             prop_name = rename_map.get(column, column)
             if prop_name in self.segm_cat.colnames:
                 value = self.segm_cat[prop_name]
@@ -372,6 +381,40 @@ class JWSTSourceCatalog:
         """
         return self.isophotal_abmag_err
 
+    @staticmethod
+    def _to_symmetric_orientation(theta):
+        """
+        Convert an orientation angle to the (-90, 90] deg convention.
+
+        Parameters
+        ----------
+        theta : `~astropy.units.Quantity`
+            The input orientation angle.
+
+        Returns
+        -------
+        `~astropy.units.Quantity`
+            The orientation angle in the range (-90, 90] degrees.
+        """
+        theta_deg = theta.to_value(u.deg)
+        return (90.0 - np.mod(90.0 - theta_deg, 180.0)) * u.deg
+
+    @lazyproperty
+    def orientation(self):
+        """
+        Return the orientation of the source major axis.
+
+        Returns
+        -------
+        `~astropy.units.Quantity`
+            The position angle of the source major axis. The angle
+            increases in the counter-clockwise direction and is
+            in the range (-90, 90] degrees.
+        """
+        if "orientation" not in self.segm_cat.colnames:
+            return np.nan
+        return self._to_symmetric_orientation(self.segm_cat["orientation"])
+
     @lazyproperty
     def sky_orientation(self):
         """
@@ -388,7 +431,8 @@ class JWSTSourceCatalog:
         )
         _, _, angle = pixel_scale_angle_at_skycoord(skycoord, self.wcs)
 
-        return ((180.0 * u.deg) - angle + self.orientation) % (360 * u.deg)
+        result = (180.0 * u.deg) - angle + self.orientation
+        return self._to_symmetric_orientation(result)
 
     def _make_aperture_colnames(self, name):
         """

--- a/jwst/source_catalog/tests/test_source_catalog.py
+++ b/jwst/source_catalog/tests/test_source_catalog.py
@@ -8,7 +8,7 @@ from astropy.modeling import models
 from astropy.table import QTable
 from numpy.testing import assert_allclose
 
-from jwst.source_catalog import SourceCatalogStep
+from jwst.source_catalog import SourceCatalogStep, source_catalog_step
 from jwst.source_catalog.tests.helpers import (
     make_nircam_model,
     make_nircam_model_without_apcorr,
@@ -68,10 +68,45 @@ def test_source_catalog(nircam_model, npixels, nsources):
         if isinstance(ellipticity, u.Quantity):
             ellipticity = ellipticity.value
         assert np.isclose(ellipticity, 0.627, atol=0.001)
-        assert np.isclose(cat["orientation"][1].value, -72.783, atol=0.001) or np.isclose(
-            cat["orientation"][1].value, 287.217, atol=0.001
-        )
+        assert np.isclose(cat["orientation"][1].value, -72.783, atol=0.001)
         assert np.isclose(cat["sky_orientation"][1].value, 77.217, atol=0.001)
+
+
+@pytest.mark.parametrize("offset", [180.0, 360.0])
+def test_orientation_range(nircam_model, monkeypatch, offset):
+    """
+    Regression test that ``orientation`` is always in the (-90, 90] deg range.
+
+    The output ``orientation`` and ``sky_orientation`` must be wrapped to
+    the (-90, 90] deg convention regardless of the angle convention used by
+    the installed photutils version (e.g., an older version that returned
+    ``orientation`` in the [0, 360) range).
+    """
+    real_make_catalog = source_catalog_step.make_tweakreg_catalog
+
+    def shifted_make_catalog(*args, **kwargs):
+        catalog, segment_img = real_make_catalog(*args, **kwargs)
+        # simulate a photutils version that returns orientation using a
+        # different convention (e.g., [0, 360) instead of (-90, 90])
+        catalog["orientation"] = catalog["orientation"] + (offset * u.deg)
+        return catalog, segment_img
+
+    monkeypatch.setattr(source_catalog_step, "make_tweakreg_catalog", shifted_make_catalog)
+
+    step = SourceCatalogStep(
+        snr_threshold=0.5,
+        npixels=5,
+        bkg_boxsize=50,
+        kernel_fwhm=2.0,
+        save_results=False,
+    )
+    cat = step.run(nircam_model)
+
+    for colname in ("orientation", "sky_orientation"):
+        values = cat[colname].to_value(u.deg)
+        finite = values[np.isfinite(values)]
+        assert finite.size > 0
+        assert np.all((finite > -90.0) & (finite <= 90.0))
 
 
 def test_source_catalog_no_sources(nircam_model, monkeypatch):


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->

`photutils` reverted its orientation definition from [0, 360) back to (-90, 90] (https://github.com/astropy/photutils/pull/2317). This updates `source_catalog` to always normalize `orientation` and `sky_orientation` to (-90, 90] regardless of which `photutils` version produced the underlying segmentation catalog.  Note that this only changes how the angles are *represented* (wrapped into (-90, 90]).  The underlying orientation values themselves have the same physical meaning.  All local test pass, but regression tests may need to be okified.  Sorry for the noise!

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [x] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
