### PR TITLE
DOC: Bold no mix with literal text

### DIFF
--- a/docs/jwst/user_documentation/running_pipeline_python.rst
+++ b/docs/jwst/user_documentation/running_pipeline_python.rst
@@ -347,7 +347,11 @@ result of a pipeline. To control this behavior, and other aspects of output file
 generation like directory and file name, certain pipeline and step-level parameters
 can be set.
 
-**Output file behavior can be modified with the ``save_results``, ``output_file``, and ``output_dir`` parameters**
+**Output file behavior can be modified with the following parameters:**
+
+* ``save_results``
+* ``output_file``
+* ``output_dir``
 
 Saving Final Pipeline Results
 -----------------------------


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR addresses formatting bug I noticed in https://jwst-pipeline.readthedocs.io/en/latest/jwst/user_documentation/running_pipeline_python.html#controlling-output-file-behavior while reading the doc.

With this patch: https://jwst-pipeline--10721.org.readthedocs.build/en/10721/jwst/user_documentation/running_pipeline_python.html#controlling-output-file-behavior

No need for RT.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
