### PR TITLE
DOC: Complete API for extract_2d

### DIFF
--- a/docs/jwst/extract_2d/api_ref.rst
+++ b/docs/jwst/extract_2d/api_ref.rst
@@ -1,0 +1,21 @@
+===
+API
+===
+
+Public Step API
+===============
+
+.. automodapi:: jwst.extract_2d.extract_2d_step
+   :no-inheritance-diagram:
+
+Complete Developer API
+======================
+
+.. automodapi:: jwst.extract_2d.extract_2d
+   :no-inheritance-diagram:
+
+.. automodapi:: jwst.extract_2d.grisms
+   :no-inheritance-diagram:
+
+.. automodapi:: jwst.extract_2d.nirspec
+   :no-inheritance-diagram:

--- a/docs/jwst/extract_2d/arguments.rst
+++ b/docs/jwst/extract_2d/arguments.rst
@@ -1,60 +1,64 @@
 Step Arguments
 ==============
+The ``extract_2d`` step has the following optional arguments.
 
-The ``extract_2d`` step has the following optional arguments:
+The following arguments apply to **all modes** unless otherwise specified:
 
-``--slit_names`` (list of strings or integers)
+``--slit_names`` (list of strings or integers, default=None)
   Names of specific slits to extract.
-  If None, all known slits for the instrument mode to be extracted.
-  Applies to all modes.
+  If None (default), all known slits for the instrument mode to be extracted.
 
-``--source_ids`` (list of strings or integers)
+``--source_ids`` (list of strings or integers, default=None)
   Source IDs of specific slits to extract.
-  If None, all known slits for the instrument to be extracted.
+  If None (default), all known slits for the instrument to be extracted.
   For WFSS data, the selected source IDs correspond to the ``label`` column of the source catalog.
   ``slit_names`` and ``source_ids`` can be used at the same time, and duplicates will be filtered out.
   If either argument is specified, but no valid slits are identified, an error will be
-  raised and the step will exit.  Applies to all modes.
+  raised and the step will exit.
 
-``--tsgrism_extract_height`` (int)
-  The cross-dispersion extraction size, in units of pixels. Only applies to TSO mode.
+The following arguments apply to **TSO and WFSS modes** only:
 
-``--source_ra`` (list of floats)
+``--extract_orders`` (list, default=None)
+  The list of spectral orders to extract. If not explicitly specified, the default
+  is taken from the :ref:`bg_wlrange_reffile`.
+
+The following arguments apply to **TSO mode** only:
+
+``--tsgrism_extract_height`` (integer, default=None)
+  The cross-dispersion extraction size, in units of pixels.
+
+The following arguments apply to **WFSS mode** only:
+
+``--source_ra`` (list of floats, default=None)
   The RA coordinates (in decimal degrees) of specific sources to extract from
   the source catalog. Must match the length of ``source_dec``.
   ``source_ids`` can be used at the same time as ``source_ra`` and ``source_dec``;
-  duplicates will be filtered out. Only applies to WFSS mode.
+  duplicates will be filtered out.
 
-``--source_dec`` (list of floats)
+``--source_dec`` (list of floats, default=None)
   The Dec coordinates (in decimal degrees) of specific sources to extract from
   the source catalog. Must match the length of ``source_ra``.
   ``source_ids`` can be used at the same time as ``source_ra`` and ``source_dec``;
-  duplicates will be filtered out. Only applies to WFSS mode.
+  duplicates will be filtered out.
 
-``--source_max_sep`` (float)
+``--source_max_sep`` (float, default=2)
   The maximum separation in arcseconds within which ``source_ra`` and ``source_dec``
   will be matched to sources in the catalog. If no source is found within this radius, a warning
-  will be emitted and no source will be extracted corresponding to that ra, dec pair.
-  Only applies to WFSS mode.
+  will be emitted and no source will be extracted corresponding to that RA, Dec pair.
 
-``--wfss_extract_half_height`` (int)
+``--grism_objects`` (list, default=None)
+  A list of `~stdatamodels.jwst.transforms.GrismObject` that override
+  the default extraction boxes.
+
+``--wfss_extract_half_height`` (int, default=5)
   The cross-dispersion half size of the extraction region, in pixels, applied to
-  point sources. Only applies to WFSS mode.
+  point sources.
 
-``--wfss_mmag_extract`` (float)
+``--wfss_mmag_extract`` (float, default=None)
   The minimum (faintest) magnitude object to extract, based on
   the value of ``isophotal_abmag`` in the source catalog.
-  If None, sources of any magnitude will be extracted.
-  Only applies to WFSS mode.
+  If None (default), sources of any magnitude will be extracted.
 
-``--wfss_nbright`` (int)
+``--wfss_nbright`` (int, default=1000)
   The number of brightest source catalog objects to extract.
-  Can be used in conjunction with ``wfss_mmag_extract``. Only applies to WFSS mode.
-
-``--extract_orders`` (list)
-  The list of spectral orders to extract. If not explicitly specified, the default
-  is taken from the ``wavelengthrange`` reference file. Applies to both WFSS and TSO modes.
-
-``--grism_objects`` (list)
-  A list of `~stdatamodels.jwst.transforms.GrismObject` that override
-  the default extraction boxes. Only applies to WFSS mode.
+  Can be used in conjunction with ``wfss_mmag_extract``.

--- a/docs/jwst/extract_2d/arguments.rst
+++ b/docs/jwst/extract_2d/arguments.rst
@@ -6,11 +6,11 @@ The following arguments apply to **all modes** unless otherwise specified:
 
 ``--slit_names`` (list of strings or integers, default=None)
   Names of specific slits to extract.
-  If None (default), all known slits for the instrument mode to be extracted.
+  If None (default), all known slits for the instrument mode will be extracted.
 
 ``--source_ids`` (list of strings or integers, default=None)
   Source IDs of specific slits to extract.
-  If None (default), all known slits for the instrument to be extracted.
+  If None (default), all known slits for the instrument will be extracted.
   For WFSS data, the selected source IDs correspond to the ``label`` column of the source catalog.
   ``slit_names`` and ``source_ids`` can be used at the same time, and duplicates will be filtered out.
   If either argument is specified, but no valid slits are identified, an error will be
@@ -27,7 +27,7 @@ The following arguments apply to **TSO mode** only:
 ``--tsgrism_extract_height`` (integer, default=None)
   The cross-dispersion extraction size, in units of pixels.
 
-The following arguments apply to **WFSS mode** only:
+The following arguments apply to **WFSS modes** only:
 
 ``--source_ra`` (list of floats, default=None)
   The RA coordinates (in decimal degrees) of specific sources to extract from
@@ -41,7 +41,7 @@ The following arguments apply to **WFSS mode** only:
   ``source_ids`` can be used at the same time as ``source_ra`` and ``source_dec``;
   duplicates will be filtered out.
 
-``--source_max_sep`` (float, default=2)
+``--source_max_sep`` (float, default=2.0)
   The maximum separation in arcseconds within which ``source_ra`` and ``source_dec``
   will be matched to sources in the catalog. If no source is found within this radius, a warning
   will be emitted and no source will be extracted corresponding to that RA, Dec pair.

--- a/docs/jwst/extract_2d/index.rst
+++ b/docs/jwst/extract_2d/index.rst
@@ -10,5 +10,4 @@ Extract 2D Spectra
    main.rst
    arguments.rst
    reference_files.rst
-   
-.. automodapi:: jwst.extract_2d
+   api_ref.rst

--- a/docs/jwst/extract_2d/main.rst
+++ b/docs/jwst/extract_2d/main.rst
@@ -1,7 +1,7 @@
 Description
 ===========
 
-:Class: `jwst.extract_2d.Extract2dStep`
+:Class: `jwst.extract_2d.extract_2d_step.Extract2dStep`
 :Alias: extract_2d
 
 Overview
@@ -17,11 +17,11 @@ and saved as separate tuples of extensions in the output FITS file.
 Assumptions
 -----------
 This step uses the ``bounding_box`` attribute of the WCS stored in the data model,
-which is populated by the ``assign_wcs`` step. Hence the ``assign_wcs`` step
+which is populated by the :ref:`assign_wcs <assign_wcs_step>` step; hence that step
 must be applied to the science exposure before running this step.
 
 For NIRCam, MIRI, and NIRISS WFSS modes, no ``bounding_box`` is attached to the data
-model by the ``assign_wcs`` step.
+model by the :ref:`assign_wcs <assign_wcs_step>` step.
 This is to keep the WCS flexible enough to be used with any
 source catalog or similar list of objects that may be associated with the dispersed image.
 Instead, there
@@ -35,12 +35,18 @@ bounding box. This list is used to make the 2D cutouts from the dispersed image.
 NIRCam TSGRISM exposures do not use a source catalog, so the step instead relies on the
 assumption that the source of interest is located at the aperture reference point
 and centers the extraction there.
-More details are given below.
+More details are given in :ref:`extract2d_tsgrism_non_dhs` and :ref:`extract2d_tsgrism_dhs`.
 
 Algorithm
 ---------
-This step is currently applied only to NIRSpec Fixed-Slit, NIRSpec MOS, NIRSpec TSO
-(BrightObj), NIRCam and NIRISS WFSS, and NIRCam TSGRISM observations.
+This step is currently applied only to:
+
+* :ref:`extract2d_nirspec_fs_mos`
+* NIRSpec TSO (BrightObj)
+* :ref:`extract2d_nircam_miri_niriss_wfss`
+* :ref:`extract2d_tsgrism_non_dhs` and :ref:`extract2d_tsgrism_dhs`
+
+.. _extract2d_nirspec_fs_mos:
 
 NIRSpec Fixed Slit and MOS
 ++++++++++++++++++++++++++
@@ -51,7 +57,7 @@ specifying the slit name with the ``slit_name`` argument. In the case of a NIRSp
 fixed-slit exposure the allowed slit names are: "S1600A1", "S200A1", "S200A2", "S200B1"
 and "S400A1". For NIRSpec MOS exposures, the slit name is the slitlet number from the
 MSA metadata file, corresponding to the value of the "SLTNAME" keyword in FITS products,
-and it has to be provided as a string, e.g. slit_name='60'.
+and it has to be provided as a string, e.g., ``slit_name='60'``.
 
 To find out what slits are available for extraction::
 
@@ -60,10 +66,11 @@ To find out what slits are available for extraction::
 
 The corner locations of the regions to be extracted are determined from the
 ``bounding_box`` contained in the exposure's WCS, which defines the range of valid inputs
-along each axis. The input coordinates are in the image frame, i.e. subarray shifts
+along each axis. The input coordinates are in the image frame, i.e., subarray shifts
 are accounted for.
 
-The output `~stdatamodels.jwst.datamodels.MultiSlitModel` data model will have the meta data associated with each
+The output `~stdatamodels.jwst.datamodels.MultiSlitModel`
+will have the metadata associated with each
 slit region populated with the name and region characteristic for the slits,
 corresponding to the FITS keywords "SLTNAME", "SLTSTRT1", "SLTSIZE1",
 "SLTSTRT2", and "SLTSIZE2."  Keyword "DISPAXIS" (dispersion direction)
@@ -72,7 +79,7 @@ will be copied from the input file to each of the output cutout images.
 The "SRCXPOS" and "SRCYPOS" keywords in the SCI extension header of each slitlet
 are also populated with estimates of the source
 x (dispersion) and y (cross-dispersion) location within the slitlet.
-For MOS data, these values are taken from the :ref:`MSA metadata file<msa_metadata>`.
+For MOS data, these values are taken from the :ref:`MSA metadata file <msa_metadata>`.
 Fixed slit data do not have an *a priori* estimate of the source
 location within a given slit, so the estimated source location is
 computed by the ``extract_2d`` step. It uses the target coordinates in
@@ -85,10 +92,11 @@ are set to 0.0 (the center of the slit).\ :sup:`1`
 
 :sup:`1`\ Note that fixed slits that are planned as part of a combined
 MOS and FS observation do have *a priori* estimates of their source
-locations, via the :ref:`MSA metadata file<msa_metadata>`. When available,
+locations, via the :ref:`MSA metadata file <msa_metadata>`. When available,
 these source locations are directly used, instead of recomputing the source
 position from the WCS information.
 
+.. _extract2d_nircam_miri_niriss_wfss:
 
 NIRCam, MIRI, and NIRISS WFSS
 +++++++++++++++++++++++++++++
@@ -100,11 +108,12 @@ step uses the source catalog that is specified in the input model's meta informa
 list of objects to be extracted.
 Otherwise, a user can submit a list of `~stdatamodels.jwst.transforms.GrismObject` that contains information
 about the objects that they want extracted.
-The `~stdatamodels.jwst.transforms.GrismObject` list can be created automatically by using the method in
-``jwst.assign_wcs.utils.create_grism_bbox``. This method also uses the name of the source
+The `~stdatamodels.jwst.transforms.GrismObject` list can be created automatically by using
+:func:`~jwst.assign_wcs.util.create_grism_bbox`. This method also uses the name of the source
 catalog saved in the input model's meta information. If it's better to construct a list
-of `~stdatamodels.jwst.transforms.GrismObject` outside of these, the `~stdatamodels.jwst.transforms.GrismObject` itself can be imported from
-``jwst.transforms.models``.
+of `~stdatamodels.jwst.transforms.GrismObject` outside of these, the
+`~stdatamodels.jwst.transforms.GrismObject` itself can be imported from
+`stdatamodels.jwst.transforms`.
 
 The dispersion direction will be documented by copying keyword "DISPAXIS"
 (1 = horizontal, 2 = vertical) from the input file to the output cutout.
@@ -116,7 +125,7 @@ The rejection or retention of objects proceeds as follows:
 1. As each object is read from the source catalog, they are immediately rejected if
    their ``isophotal_abmag > wfss_mmag_extract``, meaning that only objects brighter than
    ``wfss_mmag_extract`` will be retained. The default ``wfss_mmag_extract`` value of
-   ``None`` retains all objects.
+   `None` retains all objects.
 
 2. If the computed footprint (bounding box) of the spectral trace of an object lies
    completely outside the field of view of the grism image, it is rejected.
@@ -127,7 +136,7 @@ The rejection or retention of objects proceeds as follows:
 
 4. The ``source_ids`` list, which at this stage represents the unique combination of
    input catalog IDs and the sources from RA/Dec selection, is applied.
-   If ``source_ids``, ``source_ra`` and ``source_dec`` are all ``None``,
+   If ``source_ids``, ``source_ra`` and ``source_dec`` are all `None`,
    all objects are retained.
 
 5. The list of objects retained after the above filtering steps have been applied is
@@ -145,28 +154,29 @@ extracted, in order to better explain the various steps.
 First, the input file (or data model) must already have a WCS object assigned to it by running
 the :ref:`assign_wcs <assign_wcs_step>` step. The default values
 for the wavelength range of each spectral order to be extracted are also required;
-they are stored in the ``wavelengthrange`` reference file, which can be retrieved from CRDS.
+they are stored in the :ref:`bg_wlrange_reffile`, which can be retrieved from CRDS.
 
-Load the grism image, which is assumed to have already been processed through ``assign_wcs``,
-into an `~stdatamodels.jwst.datamodels.ImageModel` data model
+Load the grism image, which is assumed to have already been
+processed through :ref:`assign_wcs <assign_wcs_step>`,
+into an `~stdatamodels.jwst.datamodels.ImageModel`
 (used for all 2-D "images", regardless of whether
 they actually contain imaging data or dispersed spectra)::
 
     from stdatamodels.jwst.datamodels import ImageModel
     input_model = ImageModel("jw12345001001_03101_00001_nis_assign_wcs.fits")
 
-Load the ``extract_2d`` step and retrieve the ``wavelengthrange`` reference file
+Load the ``extract_2d`` step and retrieve the :ref:`bg_wlrange_reffile`
 specific for this mode:
 
 .. doctest-skip::
 
-  >>> from jwst.extract_2d import Extract2dStep
-  >>> step = Extract2dStep()
-  >>> refs = {}
-  >>> reftype = 'wavelengthrange'
-  >>> refs[reftype] = step.get_reference_file(input_model, reftype)
-  >>> print(refs)
-  {'wavelengthrange': '/crds/jwst/references/jwst_niriss_wavelengthrange_0002.asdf'}
+    >>> from jwst.extract_2d import Extract2dStep
+    >>> step = Extract2dStep()
+    >>> refs = {}
+    >>> reftype = 'wavelengthrange'
+    >>> refs[reftype] = step.get_reference_file(input_model, reftype)
+    >>> print(refs)
+    {'wavelengthrange': '/crds/jwst/references/jwst_niriss_wavelengthrange_0002.asdf'}
 
 Create a list of grism objects for a specified spectral order with a limited
 minimum magnitude and a specified half-height of the extraction box in the
@@ -175,35 +185,36 @@ Note that the half-height parameter only applies to point sources.
 
 .. doctest-skip::
 
-  >>> from jwst.assign_wcs.util import create_grism_bbox
-  >>> grism_objects = create_grism_bbox(input_model, refs, mmag_extract=17,
-  ... extract_orders=[1], wfss_extract_half_height=10)
-  >>> print(len(grism_objects))
-  6
-  >>> print(grism_objects[0])
-  id: 432
-  order_bounding {1: ((array(1113), array(1471)), (array(1389), array(1609)))}
-  sky_centroid: <SkyCoord (ICRS): (ra, dec) in deg
-      (3.59204081, -30.40553435)>
-  sky_bbox_ll: <SkyCoord (ICRS): (ra, dec) in deg
-      (3.59375611, -30.40286617)>
-  sky_bbox_lr: <SkyCoord (ICRS): (ra, dec) in deg
-      (3.59520565, -30.40665425)>
-  sky_bbox_ur: <SkyCoord (ICRS): (ra, dec) in deg
-      (3.58950974, -30.4082754)>
-  sky_bbox_ul:<SkyCoord (ICRS): (ra, dec) in deg
-      (3.5880604, -30.40448726)>
-  xcentroid: 1503.6541213285695
-  ycentroid: 1298.2882813663837
-  partial_order: {1: False}
-  waverange: {1: (0.97, 1.32)}
-  is_extended: True
-  isophotal_abmag: 16.185488680084294
+    >>> from jwst.assign_wcs.util import create_grism_bbox
+    >>> grism_objects = create_grism_bbox(
+    ...     input_model, refs, mmag_extract=17,
+    ...     extract_orders=[1], wfss_extract_half_height=10)
+    >>> print(len(grism_objects))
+    6
+    >>> print(grism_objects[0])
+    id: 432
+    order_bounding {1: ((array(1113), array(1471)), (array(1389), array(1609)))}
+    sky_centroid: <SkyCoord (ICRS): (ra, dec) in deg
+        (3.59204081, -30.40553435)>
+    sky_bbox_ll: <SkyCoord (ICRS): (ra, dec) in deg
+        (3.59375611, -30.40286617)>
+    sky_bbox_lr: <SkyCoord (ICRS): (ra, dec) in deg
+        (3.59520565, -30.40665425)>
+    sky_bbox_ur: <SkyCoord (ICRS): (ra, dec) in deg
+        (3.58950974, -30.4082754)>
+    sky_bbox_ul:<SkyCoord (ICRS): (ra, dec) in deg
+        (3.5880604, -30.40448726)>
+    xcentroid: 1503.6541213285695
+    ycentroid: 1298.2882813663837
+    partial_order: {1: False}
+    waverange: {1: (0.97, 1.32)}
+    is_extended: True
+    isophotal_abmag: 16.185488680084294
 
 Create a list of grism objects for a specified spectral order and wavelength range.
-In this case we don't use the default wavelength range limits from the ``wavelengthrange``
-reference file, but instead designate custom limits via the ``wavelength_range`` parameter
-passed to the ``create_grism_bbox`` function, which is a dictionary of the form
+In this case we don't use the default wavelength range limits from the
+:ref:`bg_wlrange_reffile`, but instead designate custom limits via the ``wavelength_range`` parameter
+passed to the :func:`~jwst.assign_wcs.util.create_grism_bbox` function, which is a dictionary of the form
 ``{spectral_order: (wave_min, wave_max)}``.
 Use the source ID, ``sid``, to identify the object(s) to be modified.
 The computed extraction limits are stored in the ``order_bounding`` attribute,
@@ -211,56 +222,56 @@ which is ordered ``(y, x)``.
 
 .. doctest-skip::
 
-  >>> from jwst.assign_wcs.util import create_grism_bbox
-  >>> grism_objects = create_grism_bbox(input_model, mmag_extract=18,
-  ... wavelength_range={1: (3.01, 4.26)})
-  >>> print([obj.sid for obj in grism_objects])
-  [12, 26, 31, 37, 104]
-  >>> print(grism_objects[-1])
-  id: 104
-  order_bounding {1: ((array(1165), array(1566)), (array(1458), array(1577)))}
-  sky_centroid: <SkyCoord (ICRS): (ra, dec) in deg
-      (3.57958792, -30.40926139)>
-  sky_bbox_ll: <SkyCoord (ICRS): (ra, dec) in deg
-      (3.58060118, -30.40800999)>
-  sky_bbox_lr: <SkyCoord (ICRS): (ra, dec) in deg
-      (3.58136873, -30.41001654)>
-  sky_bbox_ur: <SkyCoord (ICRS): (ra, dec) in deg
-      (3.57866098, -30.4107869)>
-  sky_bbox_ul:<SkyCoord (ICRS): (ra, dec) in deg
-      (3.57789348, -30.40878033)>
-  xcentroid: 1513.4964315117466
-  ycentroid: 1920.6251490007467
-  partial_order: {1: False}
-  waverange: {1: (3.01, 4.26)}
-  is_extended: True
-  isophotal_abmag: 17.88278103874113
-  >>> grism_object[-1].order_bounding[1] = ((1200, 1500), (1480, 1520))
-  >>> print(grism_object[-1].order_bounding
-  {1: ((1200, 1500), (1480,1520))}
+    >>> from jwst.assign_wcs.util import create_grism_bbox
+    >>> grism_objects = create_grism_bbox(
+    ...     input_model, mmag_extract=18,
+    ...     wavelength_range={1: (3.01, 4.26)})
+    >>> print([obj.sid for obj in grism_objects])
+    [12, 26, 31, 37, 104]
+    >>> print(grism_objects[-1])
+    id: 104
+    order_bounding {1: ((array(1165), array(1566)), (array(1458), array(1577)))}
+    sky_centroid: <SkyCoord (ICRS): (ra, dec) in deg
+        (3.57958792, -30.40926139)>
+    sky_bbox_ll: <SkyCoord (ICRS): (ra, dec) in deg
+        (3.58060118, -30.40800999)>
+    sky_bbox_lr: <SkyCoord (ICRS): (ra, dec) in deg
+        (3.58136873, -30.41001654)>
+    sky_bbox_ur: <SkyCoord (ICRS): (ra, dec) in deg
+        (3.57866098, -30.4107869)>
+    sky_bbox_ul:<SkyCoord (ICRS): (ra, dec) in deg
+        (3.57789348, -30.40878033)>
+    xcentroid: 1513.4964315117466
+    ycentroid: 1920.6251490007467
+    partial_order: {1: False}
+    waverange: {1: (3.01, 4.26)}
+    is_extended: True
+    isophotal_abmag: 17.88278103874113
+    >>> grism_object[-1].order_bounding[1] = ((1200, 1500), (1480, 1520))
+    >>> print(grism_object[-1].order_bounding
+    {1: ((1200, 1500), (1480,1520))}
 
 The ``grism_objects`` list created in the above examples can now be used
 as input to the ``extract_2d`` step in order to extract the particular objects
-defined in that list:
+defined in that list::
 
-.. doctest-skip::
+    result = step.call(input_model, grism_objects=grism_objects)
 
-  >>> result = step.call(input_model, grism_objects=grism_objects)
-
-``result`` is a `~stdatamodels.jwst.datamodels.MultiSlitModel` data model,
+``result`` is a `~stdatamodels.jwst.datamodels.MultiSlitModel`,
 containing one `~stdatamodels.jwst.datamodels.SlitModel`
-instance for each extracted object, which includes meta data that identify
+instance for each extracted object, which includes metadata that identify
 each object and the actual extracted data arrays, e.g.:
 
 .. doctest-skip::
 
-  >>> print(len(result.slits))
-  8
-  >>> result.slits[0].source_id
-  104
-  >>> result.slits[0].data
-  array([[..., ..., ...]])
+    >>> print(len(result.slits))
+    8
+    >>> result.slits[0].source_id
+    104
+    >>> result.slits[0].data
+    array([[..., ..., ...]])
 
+.. _extract2d_tsgrism_non_dhs:
 
 NIRCam non-DHS TSGRISM
 ++++++++++++++++++++++
@@ -274,7 +285,7 @@ extension header of the input image. These values are used to set the source loc
 for all computations involving the extent of the spectral trace and pixel wavelength
 assignments.
 
-In rare cases, it may be desirable to shift the source location in the X-direction, e.g.
+In rare cases, it may be desirable to shift the source location in the X-direction, e.g.,
 for a custom noise suppression scheme. This is achieved in the APT by specifying an
 offset special requirement, and shows up in the header keyword "XOFFSET". The
 ``extract_2d`` step accounts for this offset by simply shifting the wavelength array by
@@ -292,13 +303,15 @@ For non-DHS TSGRISM, ``extract_2d`` always produces a cutout that is 64 pixels i
 or subarray.
 This cutout height is equal to the height of the smallest available subarray (2048 x 64).
 This is to allow area within the cutout for sampling the background in later steps,
-such as ``extract_1d``. The slit height is a parameter that a user can set
+such as :ref:`extract_1d <extract_1d_step>`. The slit height is a parameter that a user can set
 (during reprocessing) to tailor their results, but the entire extent of the image in
 the dispersion direction (along the image x-axis) is always included in the cutout.
 
 The dispersion direction is horizontal for this mode, and it will be
 documented by copying the keyword "DISPAXIS" (with value 1) from the input file
 to the output cutout.
+
+.. _extract2d_tsgrism_dhs:
 
 NIRCam DHS TSGRISM
 ++++++++++++++++++
@@ -307,8 +320,9 @@ Similarly to non-DHS TSGRISM, for DHS modes the source location is determined fr
 aperture reference point, and those values are used to set the source location
 for all computations involving the extent of the spectral trace and pixel wavelength
 assignments.  The major difference is that each stripe is extracted separately;
-the output model is a MultiSlitModel with one slit for each DHS stripe.  The slit ID
-corresponds to the stripe number, e.g. 10, 9, 8, 7 for NRCA1.
+the output model is a `~stdatamodels.jwst.datamodels.MultiSlitModel`
+with one slit for each DHS stripe.  The slit ID
+corresponds to the stripe number, e.g., 10, 9, 8, 7 for NRCA1.
 
 The cutout height in the cross-dispersion direction is no longer hard-set at 64 pixels;
 instead it's equal to the height of the stripe, which is set by the

--- a/docs/jwst/extract_2d/main.rst
+++ b/docs/jwst/extract_2d/main.rst
@@ -14,29 +14,6 @@ are stored as one or more ``slit`` objects in an output
 `~stdatamodels.jwst.datamodels.MultiSlitModel`
 and saved as separate tuples of extensions in the output FITS file.
 
-Assumptions
------------
-This step uses the ``bounding_box`` attribute of the WCS stored in the data model,
-which is populated by the :ref:`assign_wcs <assign_wcs_step>` step; hence that step
-must be applied to the science exposure before running this step.
-
-For NIRCam, MIRI, and NIRISS WFSS modes, no ``bounding_box`` is attached to the data
-model by the :ref:`assign_wcs <assign_wcs_step>` step.
-This is to keep the WCS flexible enough to be used with any
-source catalog or similar list of objects that may be associated with the dispersed image.
-Instead, there
-is a helper method that is used to calculate the bounding boxes that contain
-the spectral trace for each object. One box is made for each spectral order of
-each object. In regular, automated processing, the ``extract_2d`` step uses the
-source catalog specified in the input
-model's meta information to create the list of objects and their corresponding
-bounding box. This list is used to make the 2D cutouts from the dispersed image.
-
-NIRCam TSGRISM exposures do not use a source catalog, so the step instead relies on the
-assumption that the source of interest is located at the aperture reference point
-and centers the extraction there.
-More details are given in :ref:`extract2d_tsgrism_non_dhs` and :ref:`extract2d_tsgrism_dhs`.
-
 Algorithm
 ---------
 This step is currently applied only to:
@@ -87,23 +64,35 @@ estimate the fractional location of the source within the given slit.
 Note that this computation can only be performed for the primary slit
 in the exposure, which is given in the "FXD_SLIT" keyword. The positions
 of sources in any additional slits cannot be estimated and therefore
-are set to 0.0 (the center of the slit).\ :sup:`1`
+are set to 0.0 (the center of the slit). [#extract2d_f1]_
 
-:sup:`1`\ Note that fixed slits that are planned as part of a combined
-MOS and FS observation do have *a priori* estimates of their source
-locations, via the :ref:`MSA metadata file <msa_metadata>`. When available,
-these source locations are directly used, instead of recomputing the source
-position from the WCS information.
+.. [#extract2d_f1] Note that fixed slits that are planned as part of a combined
+  MOS and FS observation do have *a priori* estimates of their source
+  locations, via the :ref:`MSA metadata file <msa_metadata>`. When available,
+  these source locations are directly used, instead of recomputing the source
+  position from the WCS information.
 
 .. _extract2d_nircam_miri_niriss_wfss:
 
 NIRCam, MIRI, and NIRISS WFSS
 +++++++++++++++++++++++++++++
 
+For WFSS modes, no ``bounding_box`` is attached to the data
+model by the :ref:`assign_wcs <assign_wcs_step>` step.
+This is to keep the WCS flexible enough to be used with any
+source catalog or similar list of objects that may be associated with the dispersed image.
+Instead, there
+is a helper method that is used to calculate the bounding boxes that contain
+the spectral trace for each object. One box is made for each spectral order of
+each object. In regular, automated processing, the ``extract_2d`` step uses the
+source catalog specified in the input
+model's meta information to create the list of objects and their corresponding
+bounding box. This list is used to make the 2D cutouts from the dispersed image.
+
 During normal, automated processing of WFSS grism images, the
 step parameter ``grism_objects`` is left unspecified, in which case the ``extract_2d``
 step uses the source catalog that is specified in the input model's meta information,
-``input_model.meta.source_catalog.filename`` ("SCATFILE" keyword) to define the
+``input_model.meta.source_catalog`` ("SCATFILE" keyword) to define the
 list of objects to be extracted.
 Otherwise, a user can submit a list of `~stdatamodels.jwst.transforms.GrismObject` that contains information
 about the objects that they want extracted.
@@ -257,9 +246,9 @@ defined in that list::
     result = step.call(input_model, grism_objects=grism_objects)
 
 ``result`` is a `~stdatamodels.jwst.datamodels.MultiSlitModel`,
-containing one `~stdatamodels.jwst.datamodels.SlitModel`
-instance for each extracted object, which includes metadata that identify
-each object and the actual extracted data arrays, e.g.:
+with its ``slits`` attribute containing one spectrum for each
+extracted object including metadata that identify
+each source ID and the actual extracted data arrays, e.g.:
 
 .. doctest-skip::
 

--- a/docs/jwst/extract_2d/main.rst
+++ b/docs/jwst/extract_2d/main.rst
@@ -42,19 +42,18 @@ Algorithm
 This step is currently applied only to:
 
 * :ref:`extract2d_nirspec_fs_mos`
-* NIRSpec TSO (BrightObj)
 * :ref:`extract2d_nircam_miri_niriss_wfss`
 * :ref:`extract2d_tsgrism_non_dhs` and :ref:`extract2d_tsgrism_dhs`
 
 .. _extract2d_nirspec_fs_mos:
 
-NIRSpec Fixed Slit and MOS
-++++++++++++++++++++++++++
+NIRSpec FS, MOS, and TSO (BrightObj)
+++++++++++++++++++++++++++++++++++++
 
 If the step parameter ``slit_name`` is left unspecified, the default behavior is
 to extract all slits that project onto the detector. A single slit may be extracted by
 specifying the slit name with the ``slit_name`` argument. In the case of a NIRSpec
-fixed-slit exposure the allowed slit names are: "S1600A1", "S200A1", "S200A2", "S200B1"
+fixed-slit (FS) exposure the allowed slit names are: "S1600A1", "S200A1", "S200A2", "S200B1"
 and "S400A1". For NIRSpec MOS exposures, the slit name is the slitlet number from the
 MSA metadata file, corresponding to the value of the "SLTNAME" keyword in FITS products,
 and it has to be provided as a string, e.g., ``slit_name='60'``.

--- a/docs/jwst/extract_2d/reference_files.rst
+++ b/docs/jwst/extract_2d/reference_files.rst
@@ -1,8 +1,8 @@
 Reference Files
 ===============
 
-The ``extract_2d`` step uses the WAVELENGTHRANGE reference file.
-The WAVELENGTHRANGE reference file is only used for NIRCam, MIRI, and NIRISS
+The ``extract_2d`` step uses the :ref:`bg_wlrange_reffile`
+but only for NIRCam, MIRI, and NIRISS
 Wide-Field Slitless Spectroscopy (WFSS) exposures.
 
 .. include:: ../references_general/wavelengthrange_reffile.inc

--- a/jwst/assign_wcs/util.py
+++ b/jwst/assign_wcs/util.py
@@ -38,6 +38,7 @@ __all__ = [
     "MSAFileError",
     "NoDataOnDetectorError",
     "calc_rotation_matrix",
+    "create_grism_bbox",
     "wrap_ra",
     "update_fits_wcsinfo",
     "is_sky_like",

--- a/jwst/extract_2d/extract_2d.py
+++ b/jwst/extract_2d/extract_2d.py
@@ -1,6 +1,4 @@
-#
-#  Top level module for 2d extraction.
-#
+"""Functions for 2D extraction."""
 
 import logging
 
@@ -35,22 +33,23 @@ def extract2d(
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.ImageModel` or `~jwst.datamodels.CubeModel`
+    input_model : `~stdatamodels.jwst.datamodels.ImageModel` or \
+                  `~stdatamodels.jwst.datamodels.CubeModel`
         Input data model. May be updated in place with a "SKIPPED" status,
         if a new model cannot be created.
-    slit_names : list containing strings or ints
+    slit_names : list of str or int
         Slit names to be processed.
-    source_ids : list containing strings or ints
-        Source ids to be processed.
-    source_ra : list[float]
-        Source right ascensions to be processed (has effect for WFSS modes only)
-    source_dec : list[float]
-        Source declinations to be processed (has effect for WFSS modes only)
+    source_ids : list of str or int
+        Source IDs to be processed.
+    source_ra : list of float
+        Source right ascensions to be processed (WFSS modes only).
+    source_dec : list of float
+        Source declinations to be processed (WFSS modes only).
     max_sep : float
-        Radius in arcseconds within which source_ra and source_dec will be matched
+        Radius in arcseconds within which ``source_ra`` and ``source_dec`` will be matched
         to sources in the catalog. If no source is found within this radius, a warning
-        will be emitted and no source will be extracted corresponding to that ra, dec pair.
-        Has effect for WFSS modes only.
+        will be emitted and no source will be extracted corresponding to that RA, Dec pair.
+        (WFSS modes only.)
     reference_files : dict
         Reference files.
     grism_objects : list
@@ -60,18 +59,18 @@ def extract2d(
         This will override the default which for NRC_TSGRISM is a set
         size of 64 pixels.
     wfss_extract_half_height : int
-        Cross-dispersion extraction half height in pixels, WFSS mode.
+        Cross-dispersion extraction half height in pixels (WFSS modes only).
         Overwrites the computed extraction height.
     extract_orders : list
         A list of spectral orders to be extracted.
     mmag_extract : float
-        Minimum (faintest) abmag to extract for WFSS mode.
+        Minimum (faintest) ABmag to extract (WFSS modes only).
     nbright : float
-        Number of brightest objects to extract, WFSS mode.
+        Number of brightest objects to extract (WFSS modes only).
 
     Returns
     -------
-    output_model : `~stdatamodels.jwst.datamodels.MultiSlitModel` or
+    output_model : `~stdatamodels.jwst.datamodels.MultiSlitModel` or \
                    `~stdatamodels.jwst.datamodels.SlitModel`
         Datamodel containing spectral cutouts.
     """

--- a/jwst/extract_2d/extract_2d_step.py
+++ b/jwst/extract_2d/extract_2d_step.py
@@ -14,15 +14,15 @@ class Extract2dStep(Step):
     spec = """
         slit_names = force_list(default=None)   # slits to be extracted
         source_ids = force_list(default=None)     # source ids to be extracted
+        extract_orders = int_list(default=None)  # list of orders to extract
+        tsgrism_extract_height =  integer(default=None)  # extraction height in pixels, TSGRISM mode
         source_ra = force_list(default=None)  # source RAs to be extracted, WFSS only
         source_dec = force_list(default=None)  # source DECs to be extracted, WFSS only
         source_max_sep = float(default=2.0)  # maximum separation in arcseconds around source_ra, source_dec, WFSS only
-        extract_orders = int_list(default=None)  # list of orders to extract
         grism_objects = list(default=None)  # list of grism objects to use
-        tsgrism_extract_height =  integer(default=None)  # extraction height in pixels, TSGRISM mode
-        wfss_extract_half_height =  integer(default=5)  # extraction half height in pixels, WFSS mode
-        wfss_mmag_extract = float(default=None)  # minimum abmag to extract, WFSS mode
-        wfss_nbright = integer(default=1000)  # number of brightest objects to extract, WFSS mode
+        wfss_extract_half_height =  integer(default=5)  # extraction half height in pixels, WFSS modes
+        wfss_mmag_extract = float(default=None)  # minimum abmag to extract, WFSS modes
+        wfss_nbright = integer(default=1000)  # number of brightest objects to extract, WFSS modes
     """  # noqa: E501
 
     reference_file_types = ["wavelengthrange"]

--- a/jwst/extract_2d/extract_2d_step.py
+++ b/jwst/extract_2d/extract_2d_step.py
@@ -1,3 +1,5 @@
+"""Perform extract_2d calibration step."""
+
 from jwst.extract_2d import extract_2d
 from jwst.stpipe import Step
 
@@ -33,11 +35,11 @@ class Extract2dStep(Step):
         ----------
         input_data : str, `~stdatamodels.jwst.datamodels.ImageModel`, or \
                      `~stdatamodels.jwst.datamodels.CubeModel`
-            Input datamodel or file name.
+            Input filename or datamodel.
 
         Returns
         -------
-        result : `~stdatamodels.jwst.datamodels.MultiSlitModel`, or \
+        result : `~stdatamodels.jwst.datamodels.MultiSlitModel` or \
                  `~stdatamodels.jwst.datamodels.SlitModel`
             Output datamodel containing spectral cutouts in separate extensions.
         """

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -555,7 +555,6 @@ def extract_grism_objects(
         Radius in arcseconds within which ``source_ra`` and ``source_dec`` will be matched
         to sources in the catalog. If no source is found within this radius, a warning
         will be emitted and no source will be extracted corresponding to that RA, Dec pair.
-        This parameter is only used for WFSS modes.
 
     mmag_extract : float
         The minimum magnitude extraction cutoff. Sources fainter than this
@@ -565,11 +564,11 @@ def extract_grism_objects(
         Compute a wavelength array for the datamodel.
 
     wfss_extract_half_height : int
-        Cross-dispersion extraction half height in pixels (WFSS modes only).
+        Cross-dispersion extraction half height in pixels.
         Overwrites the computed extraction height.
 
     nbright : int
-        Number of brightest objects to extract (WFSS modes only).
+        Number of brightest objects to extract.
 
     Returns
     -------
@@ -846,7 +845,7 @@ def compute_dispersion(wcs):
     """
     Compute the pixel dispersion.
 
-    Make a model for the pixel dispersion from the ```grismconf`` specs.
+    Make a model for the pixel dispersion from the ``grismconf`` specs.
 
     Parameters
     ----------

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -1,6 +1,4 @@
-#
-#  Module for 2d extraction of grism spectra
-#
+"""Functions for 2D extraction of grism spectra."""
 
 import copy
 import logging
@@ -53,7 +51,7 @@ def build_grism_submodel(
     Parameters
     ----------
     sub_model : `~stdatamodels.jwst.datamodels.SlitModel`
-        The SlitModel to be filled with arrays and WCS information.
+        The data model to be filled with arrays and WCS information.
     input_model : `~stdatamodels.jwst.datamodels.CubeModel`
         The parent model from which the 2D extraction is taken.
     xmin : int
@@ -68,7 +66,7 @@ def build_grism_submodel(
         The WCS object from the parent model, modified to fit the
         extracted region.
     compute_wavelength : bool
-        If True, compute the wavelength array of the extracted region.
+        If `True`, compute the wavelength array of the extracted region.
     order : int
         The spectral order of the extracted region.
     name : str, optional
@@ -85,7 +83,7 @@ def build_grism_submodel(
     Returns
     -------
     `~stdatamodels.jwst.datamodels.SlitModel`
-        The sub_model updated in-place.
+        The ``sub_model`` updated in-place.
     """
     # Cut out the subarray from the input data arrays
     ext_data = input_model.data[..., ymin : ymax + 1, xmin : xmax + 1].copy()
@@ -162,30 +160,30 @@ def extract_tso_object(
     ----------
     input_model : `~stdatamodels.jwst.datamodels.CubeModel` or \
                   `~stdatamodels.jwst.datamodels.ImageModel`
-        The input TSO data is an instance of a CubeModel (3D) or ImageModel (2D)
+        The input TSO data can be a cube (3D) or an image (2D).
 
     reference_files : dict
-        Needs to include the name of the wavelengthrange reference file
+        This dictionary must contain the name of the
+        WAVELENGTHRANGE reference file.
 
-    tsgrism_extract_height : int
+    tsgrism_extract_height : int, optional
         The extraction height, in total, for the spectrum in the
         cross-dispersion direction. If this is other than None,
-        it will override the team default of 64 pixels. The team
+        it will override the default of 64 pixels. The instrument team
         wants the source centered near row 34, so the extraction
         height is not the same on either size of the central row.
 
-    extract_orders : list[ints]
-        This is an optional parameter that will override the
-        orders specified for extraction in the wavelengthrange
-        reference file.
+    extract_orders : list of int, optional
+        Overrides the orders specified for extraction in the
+        WAVELENGTHRANGE reference file.
 
-    compute_wavelength : bool
+    compute_wavelength : bool, optional
         Compute a wavelength array for the datamodel.
 
     Returns
     -------
     output_model : `~stdatamodels.jwst.datamodels.SlitModel`
-        Output SlitModel containing extracted spectrum
+        Output model containing extracted spectrum.
 
     Notes
     -----
@@ -202,7 +200,7 @@ def extract_tso_object(
     in the WFSS modes are overkill. Instead, similar structures are created
     during the extract2d process and then directly used.
 
-    https://jwst-docs.stsci.edu/near-infrared-camera/nircam-observing-modes/nircam-time-series-observations/nircam-grism-time-series
+    https://jwst-docs.stsci.edu/jwst-near-infrared-camera/nircam-observing-modes/nircam-time-series-observations/nircam-grism-time-series
     """
     # Check for reference files
     if not isinstance(reference_files, dict):
@@ -402,7 +400,7 @@ def _extract_tso_dhs_object(
                   `~stdatamodels.jwst.datamodels.ImageModel`
         The input TSO DHS data.
     wavelengthrange : list
-        The wavelength range table from the wavelengthrange reference file.
+        The wavelength range table from the WAVELENGTHRANGE reference file.
     available_orders : list of int
         The spectral orders to extract.
     compute_wavelength : bool
@@ -411,7 +409,7 @@ def _extract_tso_dhs_object(
     Returns
     -------
     output_model : `~stdatamodels.jwst.datamodels.MultiSlitModel`
-        Output MultiSlitModel with one slit per stripe.
+        Output model with one slit per stripe.
     """
     output_model = datamodels.MultiSlitModel()
     output_model.update(input_model)
@@ -524,103 +522,107 @@ def extract_grism_objects(
     nbright=None,
 ):
     """
-    Extract 2d boxes around each objects spectra for each order.
+    Extract 2D boxes around each objects spectra for each order.
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.ImageModel`
-        An instance of an ImageModel, this is the grism image
+    input_model : `~stdatamodels.jwst.datamodels.ImageModel`
+        Model of the grism image.
 
-    grism_objects : list(GrismObject)
-        A list of GrismObjects
+    grism_objects : list of `~stdatamodels.jwst.transforms.GrismObject`
+        A list of grism objects.
 
     reference_files : dict
-        Needs to include the name of the wavelengthrange reference file
+        This dictionary must contain the name of the
+        WAVELENGTHRANGE reference file.
 
     extract_orders : int
-        Spectral orders to extract
+        Spectral orders to extract.
 
     source_ids : list
         List of source IDs to extract.
 
-    source_ra : list[float]
-        Source right ascensions to be processed. The nearest matching source to each RA/DEC pair
-        will be extracted. If both source_ids and source_ra/source_dec are provided,
+    source_ra : list of float
+        Source right ascensions to be processed. The nearest matching source to each RA/Dec pair
+        will be extracted. If both ``source_ids`` and ``source_ra``/``source_dec`` are provided,
         the lists will be combined and their union extracted.
 
-    source_dec : list[float]
-        Source declinations to be processed, must have same length as source_ra.
+    source_dec : list of float
+        Source declinations to be processed, must have same length as ``source_ra``.
 
     max_sep : float
-        Radius in arcseconds within which source_ra and source_dec will be matched
+        Radius in arcseconds within which ``source_ra`` and ``source_dec`` will be matched
         to sources in the catalog. If no source is found within this radius, a warning
-        will be emitted and no source will be extracted corresponding to that ra, dec pair.
-        Has effect for WFSS modes only.
+        will be emitted and no source will be extracted corresponding to that RA, Dec pair.
+        This parameter is only used for WFSS modes.
 
     mmag_extract : float
-        Sources with magnitudes fainter than this minimum magnitude extraction
-        cutoff will not be extracted
+        The minimum magnitude extraction cutoff; Sources fainter than this
+        will not be extracted.
 
     compute_wavelength : bool
         Compute a wavelength array for the datamodel.
 
-    wfss_extract_half_height : int, (optional)
-        Cross-dispersion extraction half height in pixels, WFSS mode.
+    wfss_extract_half_height : int
+        Cross-dispersion extraction half height in pixels (WFSS mode only).
         Overwrites the computed extraction height.
 
     nbright : int
-        Number of brightest objects to extract for WFSS mode.
+        Number of brightest objects to extract (WFSS mode only).
 
     Returns
     -------
-    output_model : `~jwst.datamodels.MultiSlitModel`
-        Output MultiSlitModel DataModel of extracted spectra
+    output_model : `~stdatamodels.jwst.datamodels.MultiSlitModel`
+        Output model of extracted spectra.
 
     Notes
     -----
-    This method supports NRC_WFSS and NIS_WFSS only
+    This method supports NRC_WFSS and NIS_WFSS only.
 
-    GrismObject is a named tuple which contains distilled
+    `~stdatamodels.jwst.transforms.GrismObject`
+    is a named tuple which contains distilled
     information about each catalog object. It can be created
-    by calling jwst.assign_wcs.util.create_grism_bbox() which
-    will return a list of GrismObjects that contain the bounding
-    boxes that will be used to define the 2d extraction area.
+    by calling :func:`~jwst.assign_wcs.util.create_grism_bbox` which
+    will return a list of `~stdatamodels.jwst.transforms.GrismObject`
+    that contains the bounding
+    boxes that will be used to define the 2D extraction area.
 
     For each spectral order, the configuration file contains a
     magnitude-cutoff value. The total list of objects to extract is limited
     by both MMAG_EXTRACT and NBRIGHT. Sources with magnitudes fainter than the
     extraction cutoff (MMAG_EXTRACT) will not be extracted, but are
     accounted for when computing the spectral contamination and background
-    estimates. The default value is 99 right now.
-    NBRIGHT further limits the list to the NBRIGHT brightest objects.
-    The default value is 999 right now.
+    estimates; The default value is 99.
+    NBRIGHT further limits the list to the NBRIGHT brightest objects;
+    The default value is 999.
 
-    The sensitivity information from the original aXe style configuration
+    The sensitivity information from the original aXe-style configuration
     file needs to be modified by the passband of the filter used for
     the direct image to get the min and max wavelengths
-    which correspond to t=0 and t=1, this currently has been done by the team
-    and the min and max wavelengths to use to calculate t are stored in the
-    grism reference file as wavelengthrange.
+    which correspond to ``t=0`` and ``t=1``.
+    The min and max wavelengths used to calculate ``t`` are stored in the
+    grism WAVELENGTHRANGE reference file.
 
-    Step 1: Convert the source catalog from the reference frame of the
-            uberimage to that of the dispersed image.  For the Vanilla
-            Pipeline we assume that the pointing information in the file
-            headers is sufficient.  This will be strictly true if all images
-            were obtained in a single visit (same guide stars).
+    1. Convert the source catalog from the reference frame of the
+       uberimage to that of the dispersed image.  For the Vanilla
+       Pipeline, we assume that the pointing information in the file
+       headers is sufficient.  This will be strictly true if all images
+       were obtained in a single visit (same guide stars).
 
-    Step 2: Record source information for each object in the catalog: position
-            (RA and Dec), shape (A_IMAGE, B_IMAGE, THETA_IMAGE), and all
-            available magnitudes, and minimum bounding boxes
+    2. Record source information for each object in the catalog: position
+       (RA, Dec), shape (A_IMAGE, B_IMAGE, THETA_IMAGE), and all
+       available magnitudes, and minimum bounding boxes.
 
-    Step 3: Compute the trace and wavelength solutions for each object in the
-            catalog and for each spectral order.  Record this information.
+    3. Compute the trace and wavelength solutions for each object in the
+       catalog and for each spectral order.  Record this information.
 
-    Step 4: Compute the WIDTH of each spectral subwindow, which may be fixed or
-            variable. The cross-dispersion size is taken from the minimum
-            bounding box.
+    4. Compute the WIDTH of each spectral subwindow, which may be fixed or
+       variable. The cross-dispersion size is taken from the minimum
+       bounding box.
 
-    Each of the virtual slits in the output MultiSlitModel will have its own
-    WCS object that is a copy of the input_model WCS, but with an additional
+    Each of the virtual slits in the output
+    `~stdatamodels.jwst.datamodels.MultiSlitModel` will have its own
+    WCS object that is a copy of the input model's WCS, but with an additional
     transform from "grism_slit" to "grism_detector" prepended to it; this
     transform encodes a shift to the center of the slit and a binding to the
     slit's bounding box.
@@ -820,7 +822,7 @@ def extract_grism_objects(
 
 def clamp(value, minval, maxval):
     """
-    Return the value clipped between minval and maxval.
+    Return the value clipped between given min and max values.
 
     Parameters
     ----------
@@ -833,7 +835,7 @@ def clamp(value, minval, maxval):
 
     Returns
     -------
-    value: float
+    value : float
         The value that falls within the min-max range or the minimum limit
     """
     return max(minval, min(value, maxval))
@@ -843,7 +845,7 @@ def compute_dispersion(wcs):
     """
     Compute the pixel dispersion.
 
-    Make a model for the pixel dispersion from the grismconf specs
+    Make a model for the pixel dispersion from the ```grismconf`` specs.
 
     Parameters
     ----------
@@ -852,24 +854,25 @@ def compute_dispersion(wcs):
 
     Returns
     -------
-    dispersion : ndarray-like
-        The pixel dispersion [in m].
+    dispersion : ndarray
+        The pixel dispersion in meters.
     """
     raise NotImplementedError
 
 
 def compute_tso_wavelength_array(slit):
     """
-    Compute the wavelength array for a slit with gwcs object.
+    Compute the wavelength array for a slit with WCS.
 
     Parameters
     ----------
-    slit : `~jwst.datamodels.SlitModel`
-        JWST slit datamodel containing a meta.wcs GWCS object
+    slit : `~stdatamodels.jwst.datamodels.SlitModel`
+        JWST slit datamodel containing a ``meta.wcs`` that is a
+        `~gwcs.wcs.WCS` object
 
     Returns
     -------
-    wavelength : numpy.array
+    wavelength : ndarray
         The wavelength array
     """
     wcs = slit.meta.wcs
@@ -887,27 +890,27 @@ def compute_tso_offset_center(
 
     In the case that an Offset Special Requirement is requested in the APT,
     the source is no longer at the aperture reference point.
-    The dither.x_offset and dither.y_offset values encode the offset
+    The ``dither.x_offset`` and ``dither.y_offset`` values encode the offset
     in units of arcseconds. They need to be translated from Ideal to
     detector coordinates and into pixel units.
 
     Parameters
     ----------
-    input_model : ImageModel
-        The input data model
-    distortion : DistortionModel
-        The distortion model
+    input_model : `~stdatamodels.jwst.datamodels.ImageModel`
+        The input data model.
+    distortion : `~stdatamodels.jwst.datamodels.DistortionModel`
+        The distortion model.
 
     Returns
     -------
-    xc, yc : tuple
-        The x and y center of the image in direct image coordinates
+    xc, yc : float
+        The x and y center of the image in direct image coordinates.
 
     Raises
     ------
     ValueError
-        If the distortion model requires less than four or more than five
-        inputs, a ValueError will be raised.
+        The distortion model requires less than four or more than five
+        inputs.
 
     Notes
     -----
@@ -938,16 +941,17 @@ def compute_tso_offset_center(
 
 def compute_wfss_wavelength(slit):
     """
-    Compute the wavelength array for a slit with gwcs object.
+    Compute the wavelength array for a slit with WCS.
 
     Parameters
     ----------
-    slit : `~jwst.datamodels.SlitModel`
-        JWST slit datamodel containing a meta.wcs GWCS object
+    slit : `~stdatamodels.jwst.datamodels.SlitModel`
+        JWST slit datamodel containing a ``meta.wcs`` that is a
+        `~gwcs.wcs.WCS` object
 
     Returns
     -------
-    wavelength : numpy.array
+    wavelength : ndarray
         The wavelength array
     """
     x, y = grid_from_bounding_box(slit.meta.wcs.bounding_box)
@@ -959,7 +963,7 @@ def radec_to_source_ids(catalog, source_ids=None, source_ra=None, source_dec=Non
     """
     Convert source RA/Dec lists to source IDs from the catalog.
 
-    If a source_ids list is provided, it will be combined with the
+    If a ``source_ids`` list is provided, it will be combined with the
     source IDs found from the RA/Dec lists to form a union.
 
     Parameters
@@ -970,20 +974,20 @@ def radec_to_source_ids(catalog, source_ids=None, source_ra=None, source_dec=Non
     source_ids : list
         List of source IDs to extract.
 
-    source_ra : list[float]
-        Source right ascensions to be processed. The nearest matching source to each RA/DEC pair
-        will be extracted. If both source_ids and source_ra/source_dec are provided,
+    source_ra : list of float
+        Source right ascensions to be processed. The nearest matching source to each RA/Dec pair
+        will be extracted. If both ``source_ids`` and ``source_ra``/``source_dec`` are provided,
         the lists will be combined and their union extracted.
 
-    source_dec : list[float]
-        Source declinations to be processed, must have same length as source_ra.
+    source_dec : list of float
+        Source declinations to be processed, must have same length as ``source_ra``.
 
     max_sep : float
         Maximum separation in arcsec to consider a catalog source a match to the provided RA/Dec.
 
     Returns
     -------
-    source_ids : np.ndarray or None
+    source_ids : ndarray or None
         List of unique source IDs to extract.
     """
     catalog = read_source_catalog(catalog)

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -200,6 +200,7 @@ def extract_tso_object(
     in the WFSS modes are overkill. Instead, similar structures are created
     during the extract2d process and then directly used.
 
+    For more information on the NRC_TSGRISM mode, see:
     https://jwst-docs.stsci.edu/jwst-near-infrared-camera/nircam-observing-modes/nircam-time-series-observations/nircam-grism-time-series
     """
     # Check for reference files
@@ -557,18 +558,18 @@ def extract_grism_objects(
         This parameter is only used for WFSS modes.
 
     mmag_extract : float
-        The minimum magnitude extraction cutoff; Sources fainter than this
+        The minimum magnitude extraction cutoff. Sources fainter than this
         will not be extracted.
 
     compute_wavelength : bool
         Compute a wavelength array for the datamodel.
 
     wfss_extract_half_height : int
-        Cross-dispersion extraction half height in pixels (WFSS mode only).
+        Cross-dispersion extraction half height in pixels (WFSS modes only).
         Overwrites the computed extraction height.
 
     nbright : int
-        Number of brightest objects to extract (WFSS mode only).
+        Number of brightest objects to extract (WFSS modes only).
 
     Returns
     -------
@@ -577,7 +578,7 @@ def extract_grism_objects(
 
     Notes
     -----
-    This method supports NRC_WFSS and NIS_WFSS only.
+    This method supports WFSS modes only.
 
     `~stdatamodels.jwst.transforms.GrismObject`
     is a named tuple which contains distilled
@@ -592,9 +593,9 @@ def extract_grism_objects(
     by both MMAG_EXTRACT and NBRIGHT. Sources with magnitudes fainter than the
     extraction cutoff (MMAG_EXTRACT) will not be extracted, but are
     accounted for when computing the spectral contamination and background
-    estimates; The default value is 99.
+    estimates; the default value is 99.
     NBRIGHT further limits the list to the NBRIGHT brightest objects;
-    The default value is 999.
+    the default value is 999.
 
     The sensitivity information from the original aXe-style configuration
     file needs to be modified by the passband of the filter used for
@@ -604,8 +605,8 @@ def extract_grism_objects(
     grism WAVELENGTHRANGE reference file.
 
     1. Convert the source catalog from the reference frame of the
-       uberimage to that of the dispersed image.  For the Vanilla
-       Pipeline, we assume that the pointing information in the file
+       uber-image to that of the dispersed image.
+       We assume that the pointing information in the file
        headers is sufficient.  This will be strictly true if all images
        were obtained in a single visit (same guide stars).
 

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -1,6 +1,5 @@
-#
-#  Module for 2d extraction of Nirspec fixed slits or MOS slitlets.
-#
+"""Functions for 2D extraction of NIRSpec fixed slits or MOS slitlets."""
+
 import logging
 
 import numpy as np
@@ -37,16 +36,16 @@ def nrs_extract2d(input_model, slit_names=None, source_ids=None):
                   `~stdatamodels.jwst.datamodels.CubeModel`
         Input data model. May be updated in place with a "SKIPPED" status,
         if a new model cannot be created.
-    slit_names : list containing strings or ints
+    slit_names : list of str or int
         Slit names.
-    source_ids : list containing strings or ints
-        Source ids.
+    source_ids : list of str or int
+        Source IDs.
 
     Returns
     -------
-    output_model : `~stdatamodels.jwst.datamodels.MultiSlitModel`, or
+    output_model : `~stdatamodels.jwst.datamodels.MultiSlitModel` or \
                    `~stdatamodels.jwst.datamodels.SlitModel`
-        DataModel containing extracted slit(s)
+        Data model containing extracted slit(s).
     """
     exp_type = input_model.meta.exposure.type.upper()
 
@@ -144,12 +143,12 @@ def select_slits(open_slits, slit_names, source_ids):
     slit_names : list
         List of slit names to process
     source_ids : list
-        List of source ids to process
+        List of source IDs to process
 
     Returns
     -------
     selected_open_slits : list
-        List of slits selected by slit_name or source_id
+        List of slits selected by ``slit_names`` or ``source_ids``
 
     Raises
     ------
@@ -201,16 +200,17 @@ def process_slit(input_model, slit):
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.ImageModel` or `~jwst.datamodels.CubeModel`
-        Input data model. The ``CubeModel`` is used only for TSO data, i.e.
-        ``NRS_BRIGHTOBJ`` exposure or internal lamp exposures with lamp_mode
+    input_model : `~stdatamodels.jwst.datamodels.ImageModel` or \
+                  `~stdatamodels.jwst.datamodels.CubeModel`
+        Input data model. The cube model is used only for TSO data, i.e.,
+        ``NRS_BRIGHTOBJ`` exposure or internal lamp exposures with ``lamp_mode``
         set to ``BRIGHTOBJ``.
     slit : `~stdatamodels.jwst.transforms.models.Slit`
         A slit object.
 
     Returns
     -------
-    new_model : `~jwst.datamodels.SlitModel`
+    new_model : `~stdatamodels.jwst.datamodels.SlitModel`
         The new data model for a slit.
     xlo, xhi, ylo, yhi : float
         The corners of the extracted slit in pixel space.
@@ -229,10 +229,10 @@ def set_slit_attributes(output_model, slit, xlo, xhi, ylo, yhi):
 
     Parameters
     ----------
-    output_model : `~jwst.datamodels.SlitModel`
+    output_model : `~stdatamodels.jwst.datamodels.SlitModel`
         The output model representing a slit.
-    slit : namedtuple
-        A `~stdatamodels.jwst.transforms.models.Slit` object representing a slit.
+    slit : `~stdatamodels.jwst.transforms.models.Slit`
+        An object representing a slit.
     xlo, xhi, ylo, yhi : float
         Indices into the data array where extraction should be done.
         These are converted to "pixel indices" - the center of a pixel.
@@ -278,17 +278,17 @@ def set_slit_attributes(output_model, slit, xlo, xhi, ylo, yhi):
 
 def offset_wcs(slit_wcs):
     """
-    Prepend a Shift transform to the slit WCS to account for subarrays.
+    Prepend a shift transform to the slit WCS to account for subarrays.
 
     Parameters
     ----------
     slit_wcs : `~gwcs.wcs.WCS`
-        The WCS for this  slit.
+        The WCS for this slit.
 
     Returns
     -------
-    xlo, xhi, ylo, yhi : tuple of floats
-        Indices of the bounding box of the WCS
+    xlo, xhi, ylo, yhi : tuple of float
+        Indices of the bounding box of the WCS.
     """
     xlo, xhi = to_index(slit_wcs.bounding_box[0])
     ylo, yhi = to_index(slit_wcs.bounding_box[1])
@@ -303,18 +303,19 @@ def offset_wcs(slit_wcs):
 
 def extract_slit(input_model, slit):
     """
-    Extract a slit from a full frame image.
+    Extract a slit from a full-frame image.
 
     Parameters
     ----------
-    input_model : `~jwst.datamodels.image.ImageModel` or `~jwst.datamodels.cube.CubeModel`
+    input_model : `~stdatamodels.jwst.datamodels.ImageModel` or \
+                  `~stdatamodels.jwst.datamodels.CubeModel`
         The input model.
     slit : `~stdatamodels.jwst.transforms.models.Slit`
         A slit object.
 
     Returns
     -------
-    new_model : `~jwst.datamodels.SlitModel`
+    new_model : `~stdatamodels.jwst.datamodels.SlitModel`
         The slit data model with WCS attached to it.
     """
     slit_wcs = nirspec.nrs_wcs_set_input(input_model, slit.name)
@@ -369,12 +370,7 @@ def extract_slit(input_model, slit):
 
 
 class DitherMetadataError(Exception):
-    """
-    Handle DitherMetadataError exception.
-
-    This exception is raised if a Slit object doesn't have the required
-    dither attribute, or the x and y offsets aren't numeric.
-    """
+    """Slit object does not have the required dither attribute, or the x and y offsets are not numeric."""  # noqa: E501
 
     pass
 
@@ -385,7 +381,7 @@ def get_source_xpos(slit):
 
     Parameters
     ----------
-    slit : `~jwst.datamodels.SlitModel`
+    slit : `~stdatamodels.jwst.datamodels.SlitModel`
         The slit object.
 
     Returns

--- a/jwst/extract_2d/nirspec.py
+++ b/jwst/extract_2d/nirspec.py
@@ -370,7 +370,7 @@ def extract_slit(input_model, slit):
 
 
 class DitherMetadataError(Exception):
-    """Slit object does not have the required dither attribute, or the x and y offsets are not numeric."""  # noqa: E501
+    """Slit object does not have the required dither attribute, or the offsets are not numeric."""
 
     pass
 


### PR DESCRIPTION
Towards [JP-4107](https://jira.stsci.edu/browse/JP-4107)

This PR addresses `extract_2d` portion of https://github.com/spacetelescope/jwst/issues/9793 . Only touch docs so should not need RT.

On main:

* https://jwst-pipeline.readthedocs.io/en/latest/jwst/extract_2d/index.html

With this patch:

* https://jwst-pipeline--10739.org.readthedocs.build/en/10739/jwst/extract_2d/index.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)