### PR TITLE
JP-4429: Represent MultiSlitModel slit WCSs in a more compact way for WFSS modes

### DIFF
--- a/changes/10781.extract_2d.rst
+++ b/changes/10781.extract_2d.rst
@@ -1,0 +1,1 @@
+For WFSS modes, make the internal representation of slit WCS objects more efficient. This improves file I/O performance of cal files and other MultiSlitModel-type files, especially if wfss_nbright is set to a large value.

--- a/jwst/extract_2d/grisms.py
+++ b/jwst/extract_2d/grisms.py
@@ -758,6 +758,12 @@ def extract_grism_objects(
                 subwcs.insert_frame(
                     input_frame=grism_slit, output_frame="grism_detector", transform=tr
                 )
+                # Force the pipelines to share their grism_detector-world transforms.
+                # We want that transform to be serialized just once on save
+                # instead of copied a bunch of times.
+                # It was found that validation of all those copies is very slow, and inflates
+                # the file size unnecessarily.
+                subwcs.pipeline[1:] = inwcs.pipeline[:]
 
                 new_slit = datamodels.SlitModel(
                     data=ext_data,


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4429](https://jira.stsci.edu/browse/JP-4429)

<!-- describe the changes comprising this PR here -->
Each slit of the MultiSlitModel generated by Extract2dStep for WFSS modes has its own WCS object.  Those WCSs are largely identical, with the only differences being their bounding boxes (unique to each source cutout's shape) and a linear shift in x, y from the full-frame detector to the location of the cutout.  Prior to this PR, each WCS was fully separate, i.e. a deep copy, and the very large number of astropy Models made validation slow during file I/O and inflated file size unnecessarily.

This PR forces the shared parts of the WCS pipelines for each slit to be represented using references to one another, rather than deep copies.  This makes file I/O much faster, as the ASDF validator now only validates the shared portion of the WCS once, and decreases file size.

For a test NIRISS WFSS dataset, the cal file from a Spec2Pipeline run with default options (wfss_nbright=100 in extract_2d) takes 5.7 seconds to load and 4.2 seconds to save on main, and has a file size of 34 MB.  On this PR branch, the same takes 1.58 seconds to load and 1.16 seconds to save on main, and has a file size of 29 MB.

The larger the value of wfss_nbright, the larger fractional impact this change has.  This is important because setting a large value of wfss_nbright is the current recommended workaround to https://jira.stsci.edu/browse/JP-4409.

See the JIRA ticket for details about what types of changes to one slit's WCS would alter the rest of the slits' WCSs.


<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
