### PR TITLE
remove step_instance.call usage

### DIFF
--- a/docs/jwst/extract_2d/main.rst
+++ b/docs/jwst/extract_2d/main.rst
@@ -243,7 +243,7 @@ The ``grism_objects`` list created in the above examples can now be used
 as input to the ``extract_2d`` step in order to extract the particular objects
 defined in that list::
 
-    result = step.call(input_model, grism_objects=grism_objects)
+    result = Extract2dStep.call(input_model, grism_objects=grism_objects)
 
 ``result`` is a `~stdatamodels.jwst.datamodels.MultiSlitModel`,
 with its ``slits`` attribute containing one spectrum for each

--- a/jwst/assign_wcs/tests/test_wcs.py
+++ b/jwst/assign_wcs/tests/test_wcs.py
@@ -249,8 +249,7 @@ def test_sip_approx(tmp_path):
     hdu1 = create_hdul()
     im = ImageModel(hdu1)
 
-    pipe = AssignWcsStep()
-    result = pipe.call(
+    result = AssignWcsStep.call(
         im,
         sip_max_pix_error=0.1,
         sip_degree=3,

--- a/jwst/resample/tests/test_interface.py
+++ b/jwst/resample/tests/test_interface.py
@@ -13,4 +13,4 @@ def test_multi_integration_input(resample_class):
 
     # Resample can't handle cubes, so it should fail
     with pytest.raises(TypeError):
-        resample_class().call(cube)
+        resample_class.call(cube)

--- a/jwst/white_light/tests/test_white_light.py
+++ b/jwst/white_light/tests/test_white_light.py
@@ -418,6 +418,6 @@ def test_call_step_invalid_data(make_datamodel, log_watcher):
         message="No valid input spectra found",
         level="error",
     )
-    result = WhiteLightStep().call(input_model, save_results=True)
+    result = WhiteLightStep.call(input_model, save_results=True)
     assert result is None
     watcher.assert_seen()


### PR DESCRIPTION
Update a few tests replacing uses of `some_step_instance.call` with `StepClass.call`.

Regression tests with https://github.com/spacetelescope/stpipe/pull/360 to check that this catches all usage:
https://github.com/spacetelescope/RegressionTests/actions/runs/32031814012

all pass

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
