### PR TITLE
TST: Even more debugging for mysterious Artifactory errors

### DIFF
--- a/jwst/regtest/regtestdata.py
+++ b/jwst/regtest/regtestdata.py
@@ -1,7 +1,6 @@
 import os
 import os.path as op
 import pprint
-import sys
 import warnings
 from difflib import unified_diff
 from glob import glob as _sys_glob
@@ -514,6 +513,7 @@ def _data_glob_url(*url_parts, root=None):
             "1000 results. Use an API key and define API_KEY_FILE environment "
             "variable to get full search results.",
             UserWarning,
+            stacklevel=2,
         )
         headers = None
 

--- a/jwst/regtest/regtestdata.py
+++ b/jwst/regtest/regtestdata.py
@@ -1,7 +1,6 @@
 import os
 import os.path as op
 import pprint
-import warnings
 from difflib import unified_diff
 from glob import glob as _sys_glob
 from pathlib import Path
@@ -508,14 +507,11 @@ def _data_glob_url(*url_parts, root=None):
         with open(envkey) as fp:
             headers = {"X-JFrog-Art-Api": fp.readline().strip()}
     except (PermissionError, FileNotFoundError):
-        warnings.warn(
+        raise PermissionError(
             "Anonymous Artifactory search requests are limited to "
             "1000 results. Use an API key and define API_KEY_FILE environment "
-            "variable to get full search results.",
-            UserWarning,
-            stacklevel=2,
-        )
-        headers = None
+            "variable to get full search results."
+        ) from None
 
     search_url = "/".join([root, "api/search/pattern"])
 

--- a/jwst/regtest/regtestdata.py
+++ b/jwst/regtest/regtestdata.py
@@ -2,6 +2,7 @@ import os
 import os.path as op
 import pprint
 import sys
+import warnings
 from difflib import unified_diff
 from glob import glob as _sys_glob
 from pathlib import Path
@@ -508,11 +509,11 @@ def _data_glob_url(*url_parts, root=None):
         with open(envkey) as fp:
             headers = {"X-JFrog-Art-Api": fp.readline().strip()}
     except (PermissionError, FileNotFoundError):
-        print(  # noqa: T201
-            "Warning: Anonymous Artifactory search requests are limited to "  # noqa: T201
+        warnings.warn(
+            "Anonymous Artifactory search requests are limited to "
             "1000 results. Use an API key and define API_KEY_FILE environment "
             "variable to get full search results.",
-            file=sys.stderr,
+            UserWarning,
         )
         headers = None
 
@@ -535,5 +536,5 @@ def _data_glob_url(*url_parts, root=None):
         if "files" in r_json:
             return r_json["files"]
         raise KeyError(
-            f"URL data glob failed\n    status_code: {r.status_code}\n    JSON:\n{r_json}"
+            f"URL data glob failed for {search_url}\n    JSON:\n{r_json}"
         )

--- a/jwst/regtest/regtestdata.py
+++ b/jwst/regtest/regtestdata.py
@@ -535,6 +535,4 @@ def _data_glob_url(*url_parts, root=None):
         r_json = r.json()
         if "files" in r_json:
             return r_json["files"]
-        raise KeyError(
-            f"URL data glob failed for {search_url}\n    JSON:\n{r_json}"
-        )
+        raise KeyError(f"URL data glob failed for {search_url}\n    JSON:\n{r_json}")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

Even more debugging for mysterious Artifactory errors that only appear on cron job of nightly stable. This is a follow-up of #10770 for #10763 .

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md)) https://github.com/spacetelescope/RegressionTests/actions/runs/32050027574 and https://github.com/spacetelescope/RegressionTests/actions/runs/32074472251
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
