### PR TITLE
Require `phot_unit` metadata for WFSS photom references

### DIFF
--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -696,6 +696,11 @@ class DataSet:
             raise DataModelTypeError(
                 f"Unexpected input data model type for WFSS: {str(self.input)}"
             )
+
+        phot_unit = getattr(ftab, "phot_unit", None)
+        if phot_unit is None:
+            raise ValueError("WFSS photom reference file is missing required 'phot_unit' metadata")
+
         fields_to_match = {}
         for field in match_fields:
             value = getattr(self, field)
@@ -717,7 +722,6 @@ class DataSet:
             row = find_row(ftab.phot_table, fields_to_match)
             if row is None:
                 continue
-            phot_unit = getattr(ftab, "phot_unit", None)
             for integ_row in range(len(spec.spec_table)):
                 self.integ_row = integ_row
                 self.photom_io(

--- a/jwst/photom/tests/test_photom.py
+++ b/jwst/photom/tests/test_photom.py
@@ -1942,6 +1942,18 @@ def test_unit_handling_phot_unit_not_astropy():
         ds.calc_nircam(ftab)
 
 
+def test_wfss_phot_unit_required():
+    """WFSS calibration should fail if phot_unit metadata is missing."""
+    input_model = create_input(
+        "NIRCAM", "NRCALONG", "NRC_WFSS", filter_used="F356W", pupil="GRISMR"
+    )
+    ds = photom.DataSet(input_model)
+    ftab = create_photom_nircam_wfss(min_wl=2.4, max_wl=5.0, min_r=8.0, max_r=9.0)
+    ftab.phot_unit = None
+    with pytest.raises(ValueError, match="missing required 'phot_unit' metadata"):
+        ds.calc_nircam(ftab)
+
+
 def test_fgs():
     """Test the calc_fgs method of the DataSet class in photom.py."""
     input_model = create_input("FGS", "GUIDER1", "FGS_IMAGE")


### PR DESCRIPTION
## Summary

- require WFSS photom reference files to define `phot_unit`
- fail before modifying the reference table when the metadata is missing
- add a NIRCam WFSS regression test for the missing-metadata case

A missing `phot_unit` currently lets the photom step continue without the required unit conversion, which can silently produce incorrectly calibrated science products.

Fixes #10754.

## Testing

- added `test_wfss_phot_unit_required`
- the branch is based directly on current upstream `main`; repository CI will exercise the full supported test matrix