### PR TITLE
Flag non-finite resampled pixels as `DO_NOT_USE`

### DIFF
--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -430,6 +430,7 @@ class ResampleImage(Resample):
 
         if self.propagate_dq:
             model.dq = info_dict["dq"]
+            model.dq[~np.isfinite(model.data)] |= pixel["DO_NOT_USE"]
 
         if self.compute_err:
             model.err = info_dict["err"]

--- a/jwst/resample/tests/test_resample_step.py
+++ b/jwst/resample/tests/test_resample_step.py
@@ -1039,6 +1039,29 @@ def test_wcs_keywords(nircam_rate):
     result.close()
 
 
+def test_nonfinite_resampled_pixels_are_do_not_use(nircam_rate):
+    """Non-finite output science pixels should be marked DO_NOT_USE."""
+    im = AssignWcsStep.call(nircam_rate, sip_approx=False)
+    output_shape = (300, 300)
+    crpix = (output_shape[0] // 2, output_shape[1] // 2)
+    crval = tuple(np.mean(im.meta.wcs.footprint(), axis=0))
+
+    result = ResampleStep.call(
+        im,
+        propagate_dq=True,
+        output_shape=output_shape,
+        crpix=crpix,
+        crval=crval,
+    )
+
+    nonfinite = ~np.isfinite(result.data)
+    assert np.any(nonfinite)
+    assert np.all((result.dq[nonfinite] & dqflags.pixel["DO_NOT_USE"]) != 0)
+
+    im.close()
+    result.close()
+
+
 @pytest.mark.parametrize(
     "n_images,weight_type",
     [


### PR DESCRIPTION
## Summary

- set the `DO_NOT_USE` DQ bit on resampled pixels whose SCI value is NaN or infinite
- preserve any other propagated DQ bits by OR-ing the flag
- add a regression test using an enlarged output footprint with no-input pixels

This keeps SCI and DQ semantically consistent for drizzled products and prevents no-data pixels from appearing valid to downstream analysis.

Fixes #10651.

## Testing

- added `test_nonfinite_resampled_pixels_are_do_not_use`
- the branch is based directly on current upstream `main`; repository CI will exercise the full supported test matrix