### PR TITLE
Compare table column units in regression tests

### DIFF
--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -403,6 +403,11 @@ def diff_astropy_tables():
         for col_name in truth.colnames:
             try:
                 try:
+                    assert result[col_name].unit == truth[col_name].unit
+                except AssertionError as err:
+                    diffs.append(f"Column '{col_name}' unit does not match\n{err}")
+
+                try:
                     assert result[col_name].dtype == truth[col_name].dtype
                 except AssertionError as err:
                     diffs.append(f"Column '{col_name}' dtype does not match\n{err}")

--- a/jwst/regtest/test_infrastructure.py
+++ b/jwst/regtest/test_infrastructure.py
@@ -107,6 +107,17 @@ def test_diff_astropy_tables_dtype(diff_astropy_tables, two_tables):
         assert diff_astropy_tables(path1, path2)
 
 
+def test_diff_astropy_tables_unit(diff_astropy_tables, two_tables):
+    path1, path2 = two_tables
+
+    t1 = Table.read(path1)
+    t1["d"].unit = u.km / u.s
+    t1.write(path1, overwrite=True, format="ascii.ecsv")
+
+    with pytest.raises(AssertionError, match="unit does not match"):
+        assert diff_astropy_tables(path1, path2)
+
+
 def test_diff_astropy_tables_all_equal(diff_astropy_tables, two_tables):
     path1, path2 = two_tables
 


### PR DESCRIPTION
## Summary

- compare Astropy table column units in `diff_astropy_tables`
- report a regression failure when a result changes or drops a scientific unit
- add a focused ECSV unit-mismatch test

The ECSV regression helper already checks column names, dtypes, and values. Units are scientifically significant metadata and should be protected by the same regression comparison.

Fixes #10631.

## Testing

- added `test_diff_astropy_tables_unit`
- the branch is based directly on current upstream `main`; repository CI will exercise the full supported test matrix