### PR TITLE
Interpolate aperture corrections for non-default encircled energies

### DIFF
--- a/jwst/source_catalog/reference_data.py
+++ b/jwst/source_catalog/reference_data.py
@@ -107,30 +107,42 @@ class ReferenceData:
         Parameters
         ----------
         aperture_ee : int
-            The aperture encircled energy value. Must exactly match the value
-            in a row of the APCORR reference file.
+            The aperture encircled energy value. Values between tabulated
+            APCORR rows are linearly interpolated.
 
         Returns
         -------
         ee_row : `astropy.io.fits.FITS_rec`
-            The row of the APCORR reference file that matches the input
+            The matching or interpolated APCORR row.
         """
-        ee_percent = np.round(self._aperture_ee_table["eefraction"] * 100)
-        row_mask = ee_percent == aperture_ee
+        ee_percent = self._aperture_ee_table["eefraction"] * 100.0
+        row_mask = np.isclose(ee_percent, aperture_ee)
         ee_row = self._aperture_ee_table[row_mask]
-        if len(ee_row) == 0:
-            raise RuntimeError(
-                "Aperture encircled energy value of "
-                f"{aperture_ee} appears to be invalid. No "
-                "matching row was found in the APCORR "
-                "reference file {self.apcorr_filename}"
-            )
         if len(ee_row) > 1:
             raise RuntimeError(
                 "More than one matching row was found in "
                 "the APCORR reference file "
                 f"{self.apcorr_filename}"
             )
+        if len(ee_row) == 1:
+            return ee_row
+
+        order = np.argsort(ee_percent)
+        ee_sorted = ee_percent[order]
+        if aperture_ee < ee_sorted[0] or aperture_ee > ee_sorted[-1]:
+            raise RuntimeError(
+                "Aperture encircled energy value of "
+                f"{aperture_ee} is outside the range available in the APCORR "
+                f"reference file {self.apcorr_filename}"
+            )
+
+        log.info(f"Interpolating APCORR data to {aperture_ee}% encircled energy")
+        ee_row = self._aperture_ee_table[order[:1]].copy()
+        for name in self._aperture_ee_table.dtype.names:
+            values = self._aperture_ee_table[name]
+            if values.ndim == 1 and np.issubdtype(values.dtype, np.number):
+                ee_row[name][0] = np.interp(aperture_ee, ee_sorted, values[order])
+
         return ee_row
 
     @lazyproperty

--- a/jwst/source_catalog/tests/test_apcorr_interpolation.py
+++ b/jwst/source_catalog/tests/test_apcorr_interpolation.py
@@ -1,0 +1,28 @@
+from jwst.source_catalog import SourceCatalogStep
+from jwst.source_catalog.tests.helpers import make_nircam_model, mock_apcorr
+
+
+def test_nondefault_aperture_ee_is_interpolated():
+    model = make_nircam_model()
+    apcorr = mock_apcorr()
+
+    step = SourceCatalogStep(
+        aperture_ee1=35,
+        aperture_ee2=50,
+        aperture_ee3=70,
+        snr_threshold=0.5,
+        npixels=5,
+        bkg_boxsize=50,
+        kernel_fwhm=2.0,
+        save_results=False,
+        override_apcorr=apcorr,
+    )
+
+    catalog = step.run(model)
+
+    assert catalog is not None
+    assert "aper35_flux" in catalog.colnames
+    assert "aper50_flux" in catalog.colnames
+    assert "aper70_flux" in catalog.colnames
+
+    model.close()


### PR DESCRIPTION
## Summary

- preserve exact APCORR rows when the requested encircled-energy value is tabulated
- linearly interpolate scalar numeric APCORR fields for requested values within the tabulated range
- reject out-of-range encircled-energy requests
- add source-catalog regression coverage using a non-default 35% encircled-energy aperture

This intentionally addresses only the interpolation portion of #10332; per-aperture background-annulus behaviour remains unchanged.

## Testing

- `pytest -q jwst/source_catalog/tests/test_apcorr_interpolation.py`
- passed on Python 3.13 with the repository `.[test]` environment
