### PR TITLE
Validate VAR_RNOISE for IVM resampling

### DIFF
--- a/jwst/resample/resample.py
+++ b/jwst/resample/resample.py
@@ -80,8 +80,8 @@ class ResampleImage(Resample):
         ``weight_type="ivm"`` (the default), the weighting will be
         determined per-pixel using the inverse of the read noise
         (VAR_RNOISE) array stored in each input image.
-        If the ``VAR_RNOISE`` array does not exist,
-        the variance is set to 1 for all pixels (i.e., equal weighting).
+        The ``VAR_RNOISE`` array must exist and match the science data
+        shape; otherwise a `ValueError` is raised.
         If ``weight_type="exptime"``, the weight will be set equal
         to the measurement time when available and to
         the exposure time otherwise.
@@ -819,6 +819,13 @@ def input_jwst_model_to_dict(model, weight_type, enable_var, compute_err):
     dict
         A dictionary of keywords and values expected by `stcal.resample`.
     """
+    if weight_type is not None and weight_type.startswith("ivm"):
+        var_rnoise = model.var_rnoise
+        if var_rnoise is None or var_rnoise.shape != model.data.shape:
+            raise ValueError(
+                "IVM weighting requires VAR_RNOISE to exist and match the science data shape"
+            )
+
     model_dict = {
         # arrays:
         "data": model.data,

--- a/jwst/resample/tests/test_ivm_validation.py
+++ b/jwst/resample/tests/test_ivm_validation.py
@@ -1,0 +1,17 @@
+import numpy as np
+import pytest
+from stdatamodels.jwst.datamodels import ImageModel
+
+from jwst.resample.resample import input_jwst_model_to_dict
+
+
+def test_ivm_rejects_mismatched_var_rnoise():
+    model = ImageModel((4, 5))
+    model.var_rnoise = np.ones((3, 5), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="IVM weighting requires VAR_RNOISE"):
+        input_jwst_model_to_dict(
+            model, weight_type="ivm", enable_var=False, compute_err=None
+        )
+
+    model.close()


### PR DESCRIPTION
## Summary

- reject IVM weighting when `VAR_RNOISE` is missing or does not match the science-data shape
- avoid silently producing scientifically plausible output from invalid inverse-variance inputs
- update the resampling documentation to describe the validation
- add focused regression coverage for mismatched `VAR_RNOISE`

Addresses the IVM-weighting portion of #9424.

## Testing

- `pytest -q jwst/resample/tests/test_ivm_validation.py`
- passed on Python 3.13 with the repository `.[test]` environment
