### PR TITLE
Catch whitelight flux-count mismatches in CFN median-image processing

### DIFF
--- a/jwst/clean_flicker_noise/tests/test_tso_median_image_flux_count.py
+++ b/jwst/clean_flicker_noise/tests/test_tso_median_image_flux_count.py
@@ -1,0 +1,24 @@
+import pytest
+
+from jwst.assign_wcs.assign_wcs_step import AssignWcsStep
+from jwst.clean_flicker_noise import tso_median_image as tmi
+from jwst.clean_flicker_noise.tests import helpers
+
+
+def test_nrs_bots_whitelight_flux_count_mismatch(monkeypatch):
+    input_model = helpers.make_nrs_bots_rateints()
+    wcs_model = AssignWcsStep.call(input_model)
+
+    original_run = tmi.WhiteLightStep.run
+
+    def drop_last_flux(self, *args, **kwargs):
+        table = original_run(self, *args, **kwargs)
+        return table[:-1]
+
+    monkeypatch.setattr(tmi.WhiteLightStep, "run", drop_last_flux)
+
+    with pytest.raises(ValueError, match="does not match number of integrations"):
+        tmi.make_median_image(wcs_model, wcs_model)
+
+    input_model.close()
+    wcs_model.close()

--- a/jwst/clean_flicker_noise/tso_median_image.py
+++ b/jwst/clean_flicker_noise/tso_median_image.py
@@ -277,6 +277,11 @@ def make_median_image(input_model, rateints_model, soss_refmodel=None):
         else:
             wlc_flux = whitelight_table["whitelight_flux"].value
 
+        if len(wlc_flux) != nints:
+            raise ValueError(
+                f"Whitelight flux count ({len(wlc_flux)}) does not match number of integrations ({nints})"
+            )
+
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", RuntimeWarning)
             norm_flux = wlc_flux / np.nanmedian(wlc_flux)


### PR DESCRIPTION
## Summary

- validate that the white-light flux count matches the number of input integrations before normalization
- raise a controlled `ValueError` so `clean_flicker_noise` follows its existing skip/FAILED path instead of producing a misleading downstream indexing error
- add focused NIRSpec BOTS regression coverage

Fixes #10774.

## Testing

- `pytest -q jwst/clean_flicker_noise/tests/test_tso_median_image_flux_count.py`
- passed on Python 3.13 with the repository `.[test]` environment
