### PR TITLE
JP-4080: Add sky-coordinate centre for IFU extraction

### DIFF
--- a/docs/jwst/extract_1d/arguments.rst
+++ b/docs/jwst/extract_1d/arguments.rst
@@ -131,6 +131,12 @@ The following arguments apply to **IFU data** only:
   IFU cubes. Must be given in x,y order and in units of pixels along the x,y
   axes of the 3-D IFU cube, e.g., ``--center_xy="27,28"``.
 
+``--center_radec`` (string, default=None)
+  A string representing a list of two decimal-degree values giving the desired right ascension and
+  declination for the center of the circular extraction aperture. The sky coordinate is transformed
+  through the IFU cube WCS to the appropriate x/y location, so the same coordinate can be reused across
+  IFU bands with different pixel grids. ``center_xy`` and ``center_radec`` are mutually exclusive.
+
 ``--ifu_autocen`` (boolean, default=False)
   Switch to select whether or not to enable auto-centroiding of the extraction
   aperture for IFU point sources.  Auto-centroiding works by median collapsing the

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -3,12 +3,13 @@
 import logging
 
 import crds
+import numpy as np
 from stdatamodels.jwst import datamodels
 
 from jwst.datamodels import ModelContainer, SourceModelContainer
 from jwst.datamodels.utils.wfss_multispec import make_wfss_multiexposure
 from jwst.extract_1d import extract
-from jwst.extract_1d.ifu import ifu_extract1d
+from jwst.extract_1d.ifu import ifu_extract1d, locn_from_wcs
 from jwst.extract_1d.soss_extract import soss_extract
 from jwst.lib.exposure_types import NIS_SOSS_SUPPORTED_SUBARRAYS
 from jwst.stpipe import Step
@@ -41,6 +42,7 @@ class Extract1dStep(Step):
     save_residual_image = boolean(default=False)  # save residual image to disk
 
     center_xy = float_list(min=2, max=2, default=None)  # IFU extraction x/y center
+    center_radec = float_list(min=2, max=2, default=None)  # IFU extraction RA/Dec center in degrees
     ifu_autocen = boolean(default=False) # Auto source centering for IFU point source data.
     bkg_sigma_clip = float(default=3.0)  # background sigma clipping threshold for IFU
     ifu_rfcorr = boolean(default=True) # Apply 1d residual fringe correction (MIRI MRS only)
@@ -247,6 +249,26 @@ class Extract1dStep(Step):
 
         return band_check
 
+    @staticmethod
+    def _resolve_ifu_center(model, center_xy, center_radec):
+        """Resolve an optional IFU sky-coordinate extraction center to cube pixels."""
+        if center_xy is not None and center_radec is not None:
+            raise ValueError("center_xy and center_radec cannot both be specified")
+        if center_radec is None:
+            return center_xy
+
+        center_xy = locn_from_wcs(model, center_radec[0], center_radec[1])
+        if center_xy is None or not np.all(np.isfinite(center_xy)):
+            raise ValueError("center_radec could not be transformed to a valid IFU cube position")
+        log.info(
+            "Using IFU sky-coordinate center RA=%g, Dec=%g -> x=%g, y=%g",
+            center_radec[0],
+            center_radec[1],
+            center_xy[0],
+            center_xy[1],
+        )
+        return center_xy
+
     def _extract_ifu(self, model, exp_type, extract_ref, apcorr_ref):
         """
         Extract IFU spectra from a single datamodel.
@@ -287,6 +309,7 @@ class Extract1dStep(Step):
                 "Turning off residual fringe correction because it only works on MIRI MRS data"
             )
 
+        center_xy = self._resolve_ifu_center(model, self.center_xy, self.center_radec)
         result = ifu_extract1d(
             model,
             extract_ref,
@@ -294,7 +317,7 @@ class Extract1dStep(Step):
             self.subtract_background,
             self.bkg_sigma_clip,
             apcorr_ref,
-            self.center_xy,
+            center_xy,
             self.ifu_autocen,
             self.ifu_rfcorr,
             self.ifu_rscale,

--- a/jwst/extract_1d/tests/test_ifu_sky_center.py
+++ b/jwst/extract_1d/tests/test_ifu_sky_center.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+from stdatamodels.jwst import datamodels
+
+from jwst.extract_1d import extract_1d_step
+
+
+def test_center_radec_is_transformed_to_cube_pixels(monkeypatch):
+    model = datamodels.IFUCubeModel((2, 3, 4))
+
+    monkeypatch.setattr(extract_1d_step, "locn_from_wcs", lambda model, ra, dec: (12.5, 13.5))
+
+    center = extract_1d_step.Extract1dStep._resolve_ifu_center(
+        model, None, (123.4, -54.3)
+    )
+
+    assert center == (12.5, 13.5)
+    model.close()
+
+
+def test_center_xy_and_center_radec_are_mutually_exclusive():
+    model = datamodels.IFUCubeModel((2, 3, 4))
+
+    with pytest.raises(ValueError, match="cannot both be specified"):
+        extract_1d_step.Extract1dStep._resolve_ifu_center(
+            model, (10.0, 11.0), (123.4, -54.3)
+        )
+
+    model.close()
+
+
+def test_invalid_sky_transform_is_rejected(monkeypatch):
+    model = datamodels.IFUCubeModel((2, 3, 4))
+    monkeypatch.setattr(extract_1d_step, "locn_from_wcs", lambda model, ra, dec: (np.nan, 4.0))
+
+    with pytest.raises(ValueError, match="valid IFU cube position"):
+        extract_1d_step.Extract1dStep._resolve_ifu_center(
+            model, None, (123.4, -54.3)
+        )
+
+    model.close()


### PR DESCRIPTION
## Summary

- add `center_radec` for IFU extraction, allowing the aperture centre to be specified in RA/Dec rather than cube pixels
- transform the requested sky position through the existing IFU WCS before extraction
- reject simultaneous `center_xy` and `center_radec` inputs and invalid WCS transformations
- document the new control and add focused regression tests

Addresses #9719.