### PR TITLE
JP-4384: Make cube_pa override IFU alignment

### DIFF
--- a/docs/jwst/cube_build/arguments.rst
+++ b/docs/jwst/cube_build/arguments.rst
@@ -86,7 +86,9 @@ The following arguments control the size and sampling characteristics of the out
   Declination center, in decimal degrees, of the IFU cube that defines the location of xi/eta tangent plane projection origin.
 
 ``cube_pa``
-  The position angle of the IFU cube in decimal degrees (E from N).
+  The position angle of the IFU cube in decimal degrees (E from N). If ``cube_pa`` is supplied together with
+  ``coord_system=ifualign``, the explicit position angle takes precedence and the output cube is built in the
+  sky coordinate system at the requested position angle.
 
 ``nspax_x``
   The odd integer number of spaxels to use in the x dimension of the tangent plane.

--- a/jwst/cube_build/cube_build_step.py
+++ b/jwst/cube_build/cube_build_step.py
@@ -52,6 +52,18 @@ class CubeBuildStep(Step):
 
     reference_file_types = ["cubepar"]
 
+    @staticmethod
+    def _resolve_coord_system(coord_system, cube_pa):
+        """Resolve coordinate-system precedence for an explicit cube position angle."""
+        if coord_system == "world":
+            coord_system = "skyalign"
+        if cube_pa is not None and coord_system == "ifualign":
+            log.info(
+                "cube_pa overrides coord_system=ifualign; using the requested sky position angle"
+            )
+            coord_system = "skyalign"
+        return coord_system
+
     def process(self, input_data):
         """
         Build an IFU cube from overlapping IFU image data.
@@ -137,8 +149,7 @@ class CubeBuildStep(Step):
         # 1. skyalign (ra dec) (aka world)
         # 2. ifualign (ifu cube aligned with slicer plane/ MRS local coord system)
         # 3. internal_cal (local IFU - ifu cubes built in local IFU system)
-        if self.coord_system == "world":
-            self.coord_system = "skyalign"
+        self.coord_system = self._resolve_coord_system(self.coord_system, self.cube_pa)
 
         self.interpolation = "pointcloud"  # initialize
 

--- a/jwst/cube_build/tests/test_cube_pa_precedence.py
+++ b/jwst/cube_build/tests/test_cube_pa_precedence.py
@@ -1,0 +1,13 @@
+from jwst.cube_build.cube_build_step import CubeBuildStep
+
+
+def test_cube_pa_overrides_ifualign_coordinate_system():
+    assert CubeBuildStep._resolve_coord_system("ifualign", 37.5) == "skyalign"
+
+
+def test_ifualign_is_preserved_without_cube_pa():
+    assert CubeBuildStep._resolve_coord_system("ifualign", None) == "ifualign"
+
+
+def test_world_alias_is_normalized_to_skyalign():
+    assert CubeBuildStep._resolve_coord_system("world", None) == "skyalign"


### PR DESCRIPTION
## Summary

- make an explicit `cube_pa` take precedence over `coord_system=ifualign`
- resolve the conflicting configuration to `skyalign` so the existing cube WCS code applies the requested position angle
- preserve `ifualign` behaviour when `cube_pa` is not specified
- document the precedence rule and add focused regression tests

Fixes #10639.