### PR TITLE
JP-4411: Remove incorrect WFSS source-catalog warnings

### DIFF
--- a/jwst/background/background_sub_wfss.py
+++ b/jwst/background/background_sub_wfss.py
@@ -76,8 +76,6 @@ def subtract_wfss_bkg(
             # Create a mask from the source catalog, True where there are no sources,
             # i.e. in regions we can use as background.
             bkg_mask = _mask_from_source_cat(model, wl_range_name, mmag_extract)
-            log.warning("No source_catalog found in input.meta, and custom mask not specified. ")
-            log.warning("No sources will be masked for background scaling.")
             if not _sufficient_background_pixels(model.dq, bkg_mask, bkg_ref.data):
                 log.warning("Not enough background pixels to work with.")
                 log.warning("Step will be marked FAILED.")

--- a/jwst/background/tests/test_wfss_catalog_logging.py
+++ b/jwst/background/tests/test_wfss_catalog_logging.py
@@ -1,0 +1,40 @@
+import logging
+
+import numpy as np
+from stdatamodels.jwst import datamodels
+
+from jwst.background import background_sub_wfss
+
+
+def test_catalog_mask_does_not_log_missing_catalog(monkeypatch, caplog):
+    model = datamodels.ImageModel(
+        data=np.ones((4, 4)),
+        err=np.ones((4, 4)),
+        dq=np.zeros((4, 4), dtype=np.uint32),
+    )
+    model.meta.source_catalog = "catalog.ecsv"
+    model.meta.wcsinfo.dispersion_direction = 1
+    bkg = datamodels.ImageModel(
+        data=np.ones((4, 4)),
+        dq=np.zeros((4, 4), dtype=np.uint32),
+    )
+    monkeypatch.setattr(background_sub_wfss.datamodels, "open", lambda _: bkg)
+    monkeypatch.setattr(
+        background_sub_wfss, "get_subarray_model", lambda science, reference: reference
+    )
+    monkeypatch.setattr(
+        background_sub_wfss,
+        "_mask_from_source_cat",
+        lambda *args, **kwargs: np.zeros((4, 4), dtype=bool),
+    )
+    with caplog.at_level(logging.WARNING, logger=background_sub_wfss.__name__):
+        result = background_sub_wfss.subtract_wfss_bkg(
+            model, "background.fits", "wavelengthrange.asdf"
+        )
+    try:
+        assert result.meta.cal_step.bkg_subtract == "FAILED"
+        assert "No source_catalog found" not in caplog.text
+        assert "No sources will be masked" not in caplog.text
+        assert "Not enough background pixels" in caplog.text
+    finally:
+        result.close()


### PR DESCRIPTION
Resolves [JP-4411](https://jira.stsci.edu/browse/JP-4411)

Closes #10725.

## Summary

- remove two incorrect WFSS warnings that report a missing source catalog after a source mask has already been created from one
- preserve the correct insufficient-background warning and FAILED step status
- add a focused regression test for the catalog-present failure path

This is a logging-only correction and does not change the derived background scaling or calibrated science data.

## Testing

- `pytest -q jwst/background/tests/test_wfss_catalog_logging.py` (1 passed)
