### PR TITLE
JP-4118: Warn before allocating unusually large IFU cubes

### DIFF
--- a/jwst/cube_build/ifu_cube.py
+++ b/jwst/cube_build/ifu_cube.py
@@ -24,6 +24,25 @@ log = logging.getLogger(__name__)
 
 __all__ = ["IFUCubeData", "IncorrectInputError", "IncorrectParameterError"]
 
+LARGE_CUBE_VOXEL_THRESHOLD = 100_000_000
+
+
+def _check_cube_size(naxis1, naxis2, naxis3):
+    """Return the cube voxel count and warn for unusually large allocations."""
+    total_num = naxis1 * naxis2 * naxis3
+    if total_num > LARGE_CUBE_VOXEL_THRESHOLD:
+        log.warning(
+            "Requested IFU cube has %d voxels (%d x %d x %d), exceeding the "
+            "%d-voxel warning threshold. Cube allocation may fail; check input "
+            "coverage and cube sampling.",
+            total_num,
+            naxis1,
+            naxis2,
+            naxis3,
+            LARGE_CUBE_VOXEL_THRESHOLD,
+        )
+    return total_num
+
 
 class IFUCubeData:
     """
@@ -649,7 +668,7 @@ class IFUCubeData:
         cb_suffix = self.define_cubename_suffix()
         self.output_name = self.output_name_base + cb_suffix
 
-        total_num = self.naxis1 * self.naxis2 * self.naxis3
+        total_num = _check_cube_size(self.naxis1, self.naxis2, self.naxis3)
 
         self.spaxel_flux = np.zeros(total_num, dtype=np.float64)
         self.spaxel_weight = np.zeros(total_num, dtype=np.float64)

--- a/jwst/cube_build/tests/test_cube_size_warning.py
+++ b/jwst/cube_build/tests/test_cube_size_warning.py
@@ -1,0 +1,18 @@
+import logging
+
+from jwst.cube_build.ifu_cube import _check_cube_size
+
+
+def test_typical_cube_does_not_warn(caplog):
+    with caplog.at_level(logging.WARNING, logger="jwst.cube_build.ifu_cube"):
+        total = _check_cube_size(60, 60, 8000)
+    assert total == 28_800_000
+    assert "exceeding" not in caplog.text
+
+
+def test_large_cube_warns_before_allocation(caplog):
+    with caplog.at_level(logging.WARNING, logger="jwst.cube_build.ifu_cube"):
+        total = _check_cube_size(1001, 1001, 100)
+    assert total == 100_200_100
+    assert "100200100 voxels" in caplog.text
+    assert "100000000-voxel warning threshold" in caplog.text


### PR DESCRIPTION
Resolves [JP-4118](https://jira.stsci.edu/browse/JP-4118)

Closes #9835.

## Summary

- calculate the requested IFU cube voxel count immediately before allocation
- warn when the cube exceeds 100 million voxels, as proposed in the issue
- include the requested dimensions and voxel count in the warning
- add tests for a normal large-MRS cube and a pathological cube above the threshold

The warning is emitted before the large `spaxel_*` arrays are allocated, making pathological footprints easier to diagnose without changing cube-building results.

## Testing

- `pytest -q jwst/cube_build/tests/test_cube_size_warning.py` (2 passed)
