### PR TITLE
Fetch uncached MSAFlagOpen WCS reference files

### DIFF
--- a/jwst/msaflagopen/msaflagopen_step.py
+++ b/jwst/msaflagopen/msaflagopen_step.py
@@ -1,8 +1,10 @@
 """Flag pixels affected by open MSA shutters in NIRSpec exposures."""
 
 import logging
+from pathlib import Path
 
-from stpipe.crds_client import reference_uri_to_cache_path
+from crds import api as crds_api
+from stpipe.crds_client import get_context_used, reference_uri_to_cache_path
 
 from jwst.assign_wcs import AssignWcsStep
 from jwst.msaflagopen import msaflag_open
@@ -84,10 +86,24 @@ def create_reference_filename_dictionary(input_model):
         ref_file = getattr(input_model.meta.ref_file, ref_type)
         ref_files[ref_type] = ref_file.name
 
-    # Convert from crds protocol to absolute filenames
-    for key in ref_files.keys():
-        if ref_files[key].startswith("crds://"):
-            ref_files[key] = reference_uri_to_cache_path(
-                ref_files[key], input_model.crds_observatory
-            )
+    # Convert CRDS URIs to local paths, fetching exact recorded references
+    # when they are not already present in the local cache.
+    for key, ref_file in ref_files.items():
+        if isinstance(ref_file, str) and ref_file.startswith("crds://"):
+            ref_files[key] = _reference_uri_to_local_path(ref_file, input_model)
     return ref_files
+
+
+def _reference_uri_to_local_path(reference_uri, input_model):
+    """Resolve a CRDS URI to a readable local reference-file path."""
+    cache_path = reference_uri_to_cache_path(reference_uri, input_model.crds_observatory)
+    if Path(cache_path).exists():
+        return cache_path
+
+    context = getattr(input_model.meta.ref_file.crds, "context_used", None)
+    if not context:
+        context = get_context_used(input_model.crds_observatory)
+
+    basename = reference_uri.removeprefix("crds://")
+    log.info("Fetching reference file %s using CRDS context %s", basename, context)
+    return crds_api.dump_references(context, [basename])[basename]

--- a/jwst/msaflagopen/tests/test_msa_open.py
+++ b/jwst/msaflagopen/tests/test_msa_open.py
@@ -5,7 +5,7 @@ from stdatamodels.jwst.datamodels import ImageModel, dqflags
 from stdatamodels.jwst.transforms.models import Slit
 
 from jwst.assign_wcs import AssignWcsStep
-from jwst.msaflagopen import MSAFlagOpenStep
+from jwst.msaflagopen import MSAFlagOpenStep, msaflagopen_step
 from jwst.msaflagopen.msaflag_open import (
     boundingbox_to_indices,
     create_slitlets,
@@ -178,3 +178,37 @@ def test_custom_ref_file():
     # input is not modified
     assert result is not im
     assert im.meta.cal_step.msa_flagging is None
+
+
+def test_reference_dictionary_fetches_uncached_crds_reference(monkeypatch, tmp_path):
+    model = ImageModel()
+    for ref_type in AssignWcsStep.reference_file_types:
+        getattr(model.meta.ref_file, ref_type).name = None
+
+    ref_type = AssignWcsStep.reference_file_types[0]
+    basename = "jwst_nirspec_test_0001.asdf"
+    getattr(model.meta.ref_file, ref_type).name = f"crds://{basename}"
+    model.meta.ref_file.crds.context_used = "jwst_1234.pmap"
+
+    uncached_path = tmp_path / basename
+    downloaded_path = tmp_path / "downloaded.asdf"
+    monkeypatch.setattr(
+        msaflagopen_step,
+        "reference_uri_to_cache_path",
+        lambda reference_uri, observatory: str(uncached_path),
+    )
+
+    calls = {}
+
+    def fake_dump_references(context, references):
+        calls["context"] = context
+        calls["references"] = references
+        return {basename: str(downloaded_path)}
+
+    monkeypatch.setattr(msaflagopen_step.crds_api, "dump_references", fake_dump_references)
+
+    result = msaflagopen_step.create_reference_filename_dictionary(model)
+
+    assert result[ref_type] == str(downloaded_path)
+    assert calls == {"context": "jwst_1234.pmap", "references": [basename]}
+    assert any(value is None for key, value in result.items() if key != ref_type)


### PR DESCRIPTION
## Summary

- tolerate missing `meta.ref_file` entries when reconstructing the NIRSpec WCS reference set
- resolve recorded `crds://` reference URIs to the local cache when available
- fetch the exact recorded reference with CRDS when it is not present locally
- prefer the CRDS context recorded in the input model, falling back to the active context only when necessary
- add focused regression coverage for an uncached reference alongside missing optional reference entries

This prevents `MSAFlagOpenStep` from failing simply because a WCS reference used by the calibrated input is not already present in the local CRDS cache.

Closes #10766.

## Testing

- `pytest -q jwst/msaflagopen/tests/test_msa_open.py -k reference_dictionary_fetches_uncached_crds_reference`
- 1 passed on Python 3.13 with the repository `.[test]` environment
