### PR TITLE
JP-4291: Correct NIRCam TSGRISM SIAF reference-pixel indexing

### DIFF
--- a/jwst/assign_wcs/nircam.py
+++ b/jwst/assign_wcs/nircam.py
@@ -266,6 +266,21 @@ def _build_sky_pipeline_steps(input_model, reference_files, n_passthrough):
     return distortion, va_corr, tel2sky
 
 
+def _get_tsgrism_source_center(input_model):
+    """Return the TSGRISM source reference position in 0-indexed WCS pixels."""
+    xc = input_model.meta.wcsinfo.siaf_xref_sci
+    yc = input_model.meta.wcsinfo.siaf_yref_sci
+
+    if xc is None:
+        raise ValueError("XREF_SCI is missing.")
+    if yc is None:
+        raise ValueError("YREF_SCI is missing.")
+
+    # SIAF XREF_SCI/YREF_SCI values stored in FITS metadata are 1-indexed,
+    # while GWCS detector/direct-image coordinates are 0-indexed.
+    return xc - 1, yc - 1
+
+
 def tsgrism(input_model, reference_files):
     """
     Create WCS pipeline for a NIRCAM Time Series Grism observation.
@@ -330,13 +345,7 @@ def tsgrism(input_model, reference_files):
     # crpix1 <--> xref_sci and crpix2 <--> yref_sci
     # offsets in X are handled in extract_2d, e.g. if an offset
     # special requirement was specified in the APT.
-    xc, yc = (input_model.meta.wcsinfo.siaf_xref_sci, input_model.meta.wcsinfo.siaf_yref_sci)
-
-    if xc is None:
-        raise ValueError("XREF_SCI is missing.")
-
-    if yc is None:
-        raise ValueError("YREF_SCI is missing.")
+    xc, yc = _get_tsgrism_source_center(input_model)
 
     xcenter = Const1D(xc)
     xcenter.inverse = Const1D(xc)

--- a/jwst/assign_wcs/tests/test_nircam_tsgrism_indexing.py
+++ b/jwst/assign_wcs/tests/test_nircam_tsgrism_indexing.py
@@ -1,0 +1,23 @@
+import pytest
+from stdatamodels.jwst.datamodels import CubeModel
+
+from jwst.assign_wcs.nircam import _get_tsgrism_source_center
+
+
+def test_tsgrism_siaf_reference_position_is_converted_to_zero_indexing():
+    model = CubeModel((1, 2, 2))
+    model.meta.wcsinfo.siaf_xref_sci = 1024.5
+    model.meta.wcsinfo.siaf_yref_sci = 35.0
+
+    assert _get_tsgrism_source_center(model) == (1023.5, 34.0)
+    model.close()
+
+
+def test_tsgrism_source_center_requires_siaf_reference_position():
+    model = CubeModel((1, 2, 2))
+    model.meta.wcsinfo.siaf_xref_sci = None
+    model.meta.wcsinfo.siaf_yref_sci = 35.0
+
+    with pytest.raises(ValueError, match="XREF_SCI is missing"):
+        _get_tsgrism_source_center(model)
+    model.close()


### PR DESCRIPTION
Resolves [JP-4291](https://jira.stsci.edu/browse/JP-4291)

Closes #10369.
Addresses #6730.

## Summary

- convert `siaf_xref_sci` and `siaf_yref_sci` from FITS/SIAF 1-indexed coordinates to GWCS 0-indexed coordinates before constructing the NIRCam TSGRISM transform
- keep the FITS metadata itself unchanged
- centralize the conversion in a small helper with explicit validation
- add regression coverage for the one-pixel coordinate conversion and missing reference metadata

This removes the one-pixel wavelength/astrometric offset identified for non-DHS `NRC_TSGRISM` data.

## Testing

- `pytest -q jwst/assign_wcs/tests/test_nircam_tsgrism_indexing.py`
- 2 passed on Python 3.13 with the repository `.[test]` environment
