### PR TITLE
JP-1276: Reject imaging inputs in Spec2Pipeline

### DIFF
--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -51,6 +51,16 @@ GRISM_TYPES = ["NRC_TSGRISM", "NIS_WFSS", "NRC_GRISM", "NRC_WFSS"]
 EXP_TYPES_USING_REFBKGDS = ["NIS_WFSS", "NRC_GRISM", "NRC_WFSS", "NIS_SOSS", "MIR_WFSS"]
 WFSS_TYPES = ["NIS_WFSS", "NRC_GRISM", "NRC_WFSS", "MIR_WFSS"]
 TA_TYPES = ["MIR_LRS-FIXEDSLIT", "MIR_LRS-SLITLESS"]
+IMAGE_TYPES = {"MIR_IMAGE", "NRC_IMAGE", "NIS_IMAGE", "FGS_IMAGE"}
+
+
+def _validate_spec2_exposure_type(exp_type):
+    """Reject standard imaging exposures passed to the spectroscopic pipeline."""
+    if exp_type in IMAGE_TYPES:
+        raise ValueError(
+            f"Exposure type {exp_type} is imaging data and is not supported by "
+            "Spec2Pipeline; use Image2Pipeline instead."
+        )
 
 log = logging.getLogger(__name__)
 
@@ -212,6 +222,7 @@ class Spec2Pipeline(Pipeline):
         science = self.prepare_output(science_member)
 
         exp_type = science.meta.exposure.type
+        _validate_spec2_exposure_type(exp_type)
         if isinstance(science, datamodels.CubeModel):
             multi_int = True
         else:

--- a/jwst/pipeline/tests/test_spec2_input_validation.py
+++ b/jwst/pipeline/tests/test_spec2_input_validation.py
@@ -1,0 +1,13 @@
+import pytest
+
+from jwst.pipeline.calwebb_spec2 import _validate_spec2_exposure_type
+
+
+@pytest.mark.parametrize("exp_type", ["MIR_IMAGE", "NRC_IMAGE", "NIS_IMAGE", "FGS_IMAGE"])
+def test_spec2_rejects_imaging_exposure_types(exp_type):
+    with pytest.raises(ValueError, match="imaging data"):
+        _validate_spec2_exposure_type(exp_type)
+
+
+def test_spec2_accepts_spectroscopic_exposure_type():
+    _validate_spec2_exposure_type("NRS_FIXEDSLIT")


### PR DESCRIPTION
Resolves [JP-1276](https://jira.stsci.edu/browse/JP-1276)

Closes #4532

## Summary

- reject standard imaging exposure types passed to `Spec2Pipeline`
- fail before imaging data can produce misleading spectroscopic `cal`/`x1d` products
- direct users to `Image2Pipeline`
- add focused coverage for MIR_IMAGE, NRC_IMAGE, NIS_IMAGE, FGS_IMAGE and a valid spectroscopic exposure

## Testing

- `pytest -q jwst/pipeline/tests/test_spec2_input_validation.py`
- 5 passed on Python 3.13 with the JWST `.[test]` environment

A numbered `pipeline` news fragment will be added after the PR number is assigned.