### PR TITLE
JP-4307: Fail clearly when ramp fitting produces no slopes

### DIFF
--- a/jwst/ramp_fitting/ramp_fit_step.py
+++ b/jwst/ramp_fitting/ramp_fit_step.py
@@ -160,6 +160,15 @@ def create_optional_results_model(input_model, opt_info):
     return opt_model
 
 
+def _validate_ramp_fit_outputs(image_info, integ_info):
+    """Require ramp fitting to produce both exposure- and integration-level slopes."""
+    if image_info is None or integ_info is None:
+        raise RuntimeError(
+            "Ramp fitting did not produce slope products; the input may contain no usable ramps."
+        )
+
+
+
 class RampFitStep(Step):
     """Fit ramp data to determine the mean count rate."""
 
@@ -271,6 +280,7 @@ class RampFitStep(Step):
             dqflags.pixel,
             suppress_one_group=self.suppress_one_group,
         )
+        _validate_ramp_fit_outputs(image_info, integ_info)
 
         # Save the OLS_C optional fit product, if it exists.
         if opt_info is not None:

--- a/jwst/ramp_fitting/tests/test_ramp_fit_empty_output.py
+++ b/jwst/ramp_fitting/tests/test_ramp_fit_empty_output.py
@@ -1,0 +1,16 @@
+import pytest
+
+from jwst.ramp_fitting.ramp_fit_step import _validate_ramp_fit_outputs
+
+
+def test_ramp_fit_output_validation_accepts_products():
+    _validate_ramp_fit_outputs({"slope": object()}, {"slope": object()})
+
+
+@pytest.mark.parametrize(
+    "image_info, integ_info",
+    [(None, None), ({"slope": object()}, None), (None, {"slope": object()})],
+)
+def test_ramp_fit_output_validation_rejects_missing_products(image_info, integ_info):
+    with pytest.raises(RuntimeError, match="did not produce slope products"):
+        _validate_ramp_fit_outputs(image_info, integ_info)


### PR DESCRIPTION
Resolves [JP-4307](https://jira.stsci.edu/browse/JP-4307)

Closes #10407

## Summary

- detect when ramp fitting returns no exposure-level or integration-level slope product
- raise an informative error instead of silently returning `(None, None)`
- make fully unusable/saturated Level-1b inputs halt at ramp fitting rather than failing later because expected rate products are missing
- add focused regression coverage for missing output combinations

## Testing

- `pytest -q jwst/ramp_fitting/tests/test_ramp_fit_empty_output.py`
- 4 passed on Python 3.13 with the JWST `.[test]` environment

A numbered `ramp_fitting` news fragment will be added after the PR number is assigned.