### PR TITLE
Preserve TweakReg alignment failure diagnostics

### DIFF
--- a/jwst/tweakreg/tests/test_failure_diagnostics.py
+++ b/jwst/tweakreg/tests/test_failure_diagnostics.py
@@ -1,0 +1,16 @@
+import logging
+
+import stcal.tweakreg.tweakreg as twk
+
+from jwst.tweakreg.tweakreg_step import _log_alignment_failure
+
+
+def test_alignment_failure_logs_context_and_traceback(caplog):
+    caplog.set_level(logging.WARNING, logger="jwst.tweakreg.tweakreg_step")
+    try:
+        raise twk.TweakregError("not enough matches")
+    except twk.TweakregError as error:
+        _log_alignment_failure("Relative", error)
+
+    assert "Relative alignment failed: not enough matches" in caplog.text
+    assert "TweakregError" in caplog.text

--- a/jwst/tweakreg/tweakreg_step.py
+++ b/jwst/tweakreg/tweakreg_step.py
@@ -30,6 +30,12 @@ def _oxford_or_str_join(str_list):
         return ", ".join(map(repr, str_list[:-1])) + ", or " + repr(str_list[-1])
 
 
+def _log_alignment_failure(kind, error):
+    """Log alignment failures with operation context and traceback details."""
+    log.warning(f"{kind} alignment failed: {error}", exc_info=True)
+
+
+
 SINGLE_GROUP_REFCAT = ["GAIAREFCAT", "GAIADR3", "GAIADR2", "GAIADR1"]
 """List of astrometric catalogs available to the tweakreg step."""
 
@@ -307,7 +313,7 @@ class TweakRegStep(Step):
                     yoffset=self.yoffset,
                 )
             except twk.TweakregError as e:
-                log.warning(str(e))
+                _log_alignment_failure("Relative", e)
                 local_align_failed = True
             else:
                 local_align_failed = False
@@ -340,7 +346,7 @@ class TweakRegStep(Step):
                     )
                     images.shelve(ref_image, 0, modify=False)
                 except twk.TweakregError as e:
-                    log.warning(str(e))
+                    _log_alignment_failure("Absolute", e)
                     images.shelve(ref_image, 0, modify=False)
                     record_step_status(images, "tweakreg", success=False)
                     return images


### PR DESCRIPTION
## Summary

- add explicit relative or absolute alignment context to caught `TweakregError` exceptions
- preserve the original exception traceback in warning logs
- add focused regression coverage for the diagnostic output

This addresses the TweakReg alignment portion of #10563, making failed alignment attempts diagnosable from pipeline logs without changing existing graceful-failure behaviour.

Addresses #10563.

## Testing

- `pytest -q jwst/tweakreg/tests/test_failure_diagnostics.py`
- passed on Python 3.13 with the repository `.[test]` environment

A numbered `tweakreg` news fragment will be added after the PR number is assigned.