### PR TITLE
Mark invalid skymatch solutions as FAILED

### DIFF
--- a/jwst/skymatch/skymatch_step.py
+++ b/jwst/skymatch/skymatch_step.py
@@ -27,6 +27,12 @@ log = logging.getLogger(__name__)
 __all__ = ["SkyMatchStep"]
 
 
+def _sky_match_status(is_sky_valid):
+    """Return the calibration-step status for a sky-matching result."""
+    return "COMPLETE" if is_sky_valid else "FAILED"
+
+
+
 class SkyMatchStep(Step):
     """Subtract or equalize sky background in science images."""
 
@@ -129,12 +135,12 @@ class SkyMatchStep(Step):
             for im in images:
                 if isinstance(im, SkyImage):
                     self._set_sky_background(
-                        im, library, "COMPLETE" if im.is_sky_valid else "SKIPPED"
+                        im, library, _sky_match_status(im.is_sky_valid)
                     )
                 else:
                     for gim in im:
                         self._set_sky_background(
-                            gim, library, "COMPLETE" if gim.is_sky_valid else "SKIPPED"
+                            gim, library, _sky_match_status(gim.is_sky_valid)
                         )
 
         return library
@@ -211,7 +217,7 @@ class SkyMatchStep(Step):
 
         step_status : str
             Status of the sky subtraction step. Must be one of the following:
-            'COMPLETE', 'SKIPPED'.
+            'COMPLETE', 'FAILED'.
         """
         index = sky_image.meta["index"]
         dm = library.borrow(index)

--- a/jwst/skymatch/tests/test_failure_status.py
+++ b/jwst/skymatch/tests/test_failure_status.py
@@ -1,0 +1,11 @@
+import pytest
+
+from jwst.skymatch.skymatch_step import _sky_match_status
+
+
+@pytest.mark.parametrize(
+    "is_valid, expected",
+    [(True, "COMPLETE"), (False, "FAILED")],
+)
+def test_sky_match_status(is_valid, expected):
+    assert _sky_match_status(is_valid) == expected


### PR DESCRIPTION
Closes #10562.

## Summary

- record invalid sky-matching results with `cal_step.skymatch = FAILED` rather than `SKIPPED`
- preserve `COMPLETE` for valid sky solutions
- add focused regression coverage for calibration-step status selection

`SKIPPED` indicates that a step did not run. When sky matching runs but cannot produce a valid solution, `FAILED` more accurately records the calibration state and makes affected products easier to identify.

## Testing

- `pytest -q jwst/skymatch/tests/test_failure_status.py`
- passed on Python 3.13 with the repository `.[test]` environment

A numbered `skymatch` news fragment will be added after the PR number is assigned.