### PR TITLE
JP-4399: Allow ImprintStep to load Level-2 associations

### DIFF
--- a/jwst/imprint/imprint_step.py
+++ b/jwst/imprint/imprint_step.py
@@ -1,6 +1,7 @@
 """Remove NIRSpec MSA imprint structure from an exposure."""
 
 import logging
+from collections import defaultdict
 
 from stdatamodels.jwst import datamodels
 
@@ -24,9 +25,15 @@ class ImprintStep(Step):
     spec = """
     """  # noqa: E501
 
-    def process(self, input_data, imprint):
+    def process(self, input_data, imprint=None):
         """
         Subtract an imprint image from the input data.
+
+        The input may be supplied as a Level-2 association containing a science
+        exposure and one or more members with ``exptype='imprint'``. In that
+        case, the science and imprint members are taken from the association.
+        An explicit imprint list may still be supplied as the second argument,
+        as is done when the step is called from ``Spec2Pipeline``.
 
         If a single imprint image is provided, it is directly subtracted
         without further checks.
@@ -48,15 +55,21 @@ class ImprintStep(Step):
         Parameters
         ----------
         input_data : str or `~stdatamodels.jwst.datamodels.JwstDataModel`
-            Input exposure to be corrected.
-        imprint : list of str or `~stdatamodels.jwst.datamodels.JwstDataModel`
-            Imprint exposures associated with the input.
+            Input exposure to be corrected, or a Level-2 association containing
+            the science and imprint exposures.
+        imprint : list of str or `~stdatamodels.jwst.datamodels.JwstDataModel`, optional
+            Imprint exposures associated with the input. If not supplied, they
+            are read from ``input_data`` as a Level-2 association.
 
         Returns
         -------
         `~stdatamodels.jwst.datamodels.JwstDataModel`
             The imprint subtracted exposure.
         """
+        if imprint is None:
+            asn = self.load_as_level2_asn(input_data)
+            input_data, imprint = self._asn_get_data(asn)
+
         # Open the input science image and get its dither pattern position number
         output_model = self.prepare_output(input_data)
         pos_no = output_model.meta.dither.position_number
@@ -74,8 +87,8 @@ class ImprintStep(Step):
 
             if len(imprint) == 1:
                 # Exactly one imprint provided: use it.
-                match_model = datamodels.open(imprint[0])
-                imprint_models.append(match_model)
+                match_model = imprint_model
+                imprint_models.append(imprint_model)
             elif is_bkgd != imprint_bkg:
                 # More than one imprint and imprint does not match input's
                 # background status. Don't consider it further.
@@ -116,3 +129,31 @@ class ImprintStep(Step):
             model.close()
 
         return output_model
+
+    def _asn_get_data(self, asn):
+        """Return the science and imprint members from a Level-2 association."""
+        members_by_type = defaultdict(list)
+
+        if len(asn["products"]) > 1:
+            log.warning("Multiple products in input association. Using only the first one.")
+
+        product = asn["products"][0]
+        for member in product["members"]:
+            members_by_type[member["exptype"].lower()].append(member["expname"])
+
+        science_members = members_by_type["science"]
+        if not science_members:
+            raise ValueError(f"No science exposure found in association product {product['name']}.")
+        if len(science_members) > 1:
+            log.warning(
+                "Multiple science exposures found in association product %s. Using only the first one.",
+                product["name"],
+            )
+
+        science_member = science_members[0]
+        imprint_members = members_by_type["imprint"]
+        log.info("Working on input %s ...", science_member)
+        if imprint_members:
+            log.info("Using %d imprint exposure(s) from the input association.", len(imprint_members))
+
+        return science_member, imprint_members

--- a/jwst/imprint/tests/test_imprint.py
+++ b/jwst/imprint/tests/test_imprint.py
@@ -58,9 +58,9 @@ def test_step_from_association(tmp_path):
     science.close()
     imprint.close()
 
-    asn = asn_from_list([str(science_path)], rule=DMSLevel2bBase)
+    asn = asn_from_list([science_path.name], rule=DMSLevel2bBase)
     asn["products"][0]["members"].append(
-        {"expname": str(imprint_path), "exptype": "imprint"}
+        {"expname": imprint_path.name, "exptype": "imprint"}
     )
     _, serialized = asn.dump()
     asn_path = tmp_path / "imprint_asn.json"

--- a/jwst/imprint/tests/test_imprint.py
+++ b/jwst/imprint/tests/test_imprint.py
@@ -3,6 +3,8 @@
 import numpy as np
 from stdatamodels.jwst.datamodels import ImageModel
 
+from jwst.associations.asn_from_list import asn_from_list
+from jwst.associations.lib.rules_level2_base import DMSLevel2bBase
 from jwst.imprint import ImprintStep
 
 
@@ -44,6 +46,30 @@ def test_step_single_imprint():
     # for a single imprint, it's used anyway
     assert result.meta.cal_step.imprint_subtract == "COMPLETE"
     assert result.data.sum() == 0
+
+
+def test_step_from_association(tmp_path):
+    science = make_imagemodel(10, 10, value=3.0)
+    imprint = make_imagemodel(10, 10, value=1.0)
+    science_path = tmp_path / "science.fits"
+    imprint_path = tmp_path / "imprint.fits"
+    science.save(science_path)
+    imprint.save(imprint_path)
+    science.close()
+    imprint.close()
+
+    asn = asn_from_list([str(science_path)], rule=DMSLevel2bBase)
+    asn["products"][0]["members"].append(
+        {"expname": str(imprint_path), "exptype": "imprint"}
+    )
+    _, serialized = asn.dump()
+    asn_path = tmp_path / "imprint_asn.json"
+    asn_path.write_text(serialized)
+
+    result = ImprintStep.call(str(asn_path))
+
+    assert result.meta.cal_step.imprint_subtract == "COMPLETE"
+    assert np.all(result.data == 2.0)
 
 
 def test_step_match_dither():


### PR DESCRIPTION
Resolves [JP-4399](https://jira.stsci.edu/browse/JP-4399)

Closes #10675.

## Summary

- allow standalone `ImprintStep` calls to accept a Level-2 association containing science and imprint members
- extract the science exposure and `exptype='imprint'` members from the association when no explicit imprint list is supplied
- preserve the existing explicit imprint-list interface used by `Spec2Pipeline`
- add regression coverage for association-based imprint subtraction using normal relative association member names

This makes `imprint_subtract` usable as a standalone step without changing the existing imprint matching or subtraction behaviour.

## Testing

- the first full matrix run completed 4022 tests successfully, with the only test failure caused by the new fixture writing full paths into the association
- that fixture has been corrected to use standard relative association member names
- dependency checks pass on the corrected commit; the refreshed full matrix is running
