### PR TITLE
Switch data glob that is suddenly failing to use aql

### DIFF
--- a/jwst/regtest/regtestdata.py
+++ b/jwst/regtest/regtestdata.py
@@ -1,6 +1,7 @@
 import os
 import os.path as op
 import pprint
+import re
 import sys
 from difflib import unified_diff
 from glob import glob as _sys_glob
@@ -221,7 +222,7 @@ class RegtestData:
             file_paths = _data_glob_local(path, glob)
         elif check_url(root):
             root_path = self.env
-            file_paths = _data_glob_url(self._inputs_root, f"{self.env}/{path}", glob, root)
+            file_paths = _data_glob_url(self._inputs_root, os.path.join(self.env, path), glob, root)
         else:
             raise BigdataError(f"Path cannot be found: {path}")
 
@@ -522,6 +523,11 @@ def _data_glob_url(repo, path, glob, root):
         headers = None
 
     search_url = "/".join([root, "api/search/aql"])
+
+    # check inputs for only valid characters
+    for value in (repo, path, glob):
+        if not re.fullmatch(r"[a-zA-Z0-9\_\-\*\.\/]+", value):
+            raise ValueError(f"{value} contains invalid characters")
 
     aql = f"""items.find({{\
         "repo": "{repo}", \

--- a/jwst/regtest/regtestdata.py
+++ b/jwst/regtest/regtestdata.py
@@ -482,8 +482,14 @@ def _data_glob_url(repo, path, glob, root):
 
     Parameters
     ----------
-    *url_parts : (str[,...])
-        List of components that will be used to create a URL path
+    repo : str
+        Artifactory repository.
+
+    path : str
+        Path in repository.
+
+    glob : str
+        Filename glob to match.
 
     root : str
         The root server path to the Artifactory server.
@@ -518,7 +524,13 @@ def _data_glob_url(repo, path, glob, root):
 
     search_url = "/".join([root, "api/search/aql"])
 
-    aql = f"""items.find({{"repo": "{repo}", "type": "file", "path": {{"$match": "{path}"}}, "name": {{"$match": "{glob}"}}}}).include("repo","path","name")"""
+    aql = f"""items.find({{\
+        "repo": "{repo}", \
+        "type": "file", \
+        "path": {{"$match": "{path}"}}, \
+        "name": {{"$match": "{glob}"}}}}\
+    ).include("repo","path","name")\
+    """
 
     # 900 is the default aql timeout
     with requests.post(search_url, data=aql, headers=headers, timeout=900) as r:

--- a/jwst/regtest/regtestdata.py
+++ b/jwst/regtest/regtestdata.py
@@ -221,7 +221,7 @@ class RegtestData:
             file_paths = _data_glob_local(path, glob)
         elif check_url(root):
             root_path = self.env
-            file_paths = _data_glob_url(self._inputs_root, self.env, path, glob, root=root)
+            file_paths = _data_glob_url(self._inputs_root, f"{self.env}/{path}", glob, root)
         else:
             raise BigdataError(f"Path cannot be found: {path}")
 
@@ -476,7 +476,7 @@ def _data_glob_local(*glob_parts):
     return _sys_glob(str(full_glob))
 
 
-def _data_glob_url(*url_parts, root=None):
+def _data_glob_url(repo, path, glob, root):
     """
     Perform a glob on a URL path.
 
@@ -516,24 +516,15 @@ def _data_glob_url(*url_parts, root=None):
         )
         headers = None
 
-    search_url = "/".join([root, "api/search/pattern"])
+    search_url = "/".join([root, "api/search/aql"])
 
-    # Join and re-split the url so that every component is identified.
-    url = "/".join([root] + list(url_parts))
-    all_parts = url.split("/")
+    aql = f"""items.find({{"repo": "{repo}", "type": "file", "path": {{"$match": "{path}"}}, "name": {{"$match": "{glob}"}}}}).include("repo","path","name")"""
 
-    # Pick out "jwst-pipeline", the repo name
-    repo = all_parts[4]
-
-    # Format the pattern
-    pattern = repo + ":" + "/".join(all_parts[5:])
-
-    # Make the query
-    params = {"pattern": pattern}
-    with requests.get(search_url, params=params, headers=headers, timeout=60) as r:
+    # 900 is the default aql timeout
+    with requests.post(search_url, data=aql, headers=headers, timeout=900) as r:
         r_json = r.json()
-        if "files" in r_json:
-            return r_json["files"]
+        if "results" in r_json:
+            return [r["path"] for r in r_json["results"]]
         raise KeyError(
             f"URL data glob failed\n    status_code: {r.status_code}\n    JSON:\n{r_json}"
         )

--- a/jwst/regtest/regtestdata.py
+++ b/jwst/regtest/regtestdata.py
@@ -500,9 +500,8 @@ def _data_glob_url(repo, path, glob, root):
     url_paths : [str[, ...]]
         Full URLS that match the glob criterion
     """
-    # Fix root root-ed-ness
-    if root.endswith("/"):
-        root = root[:-1]
+    path = path.rstrip("/")
+    root = root.rstrip("/")
 
     # Access
     try:
@@ -536,7 +535,7 @@ def _data_glob_url(repo, path, glob, root):
     with requests.post(search_url, data=aql, headers=headers, timeout=900) as r:
         r_json = r.json()
         if "results" in r_json:
-            return [r["path"] for r in r_json["results"]]
+            return [os.path.join(r["path"], r["name"]) for r in r_json["results"]]
         raise KeyError(
             f"URL data glob failed\n    status_code: {r.status_code}\n    JSON:\n{r_json}"
         )

--- a/jwst/tests/test_infrastructure.py
+++ b/jwst/tests/test_infrastructure.py
@@ -63,9 +63,9 @@ def test_data_glob_url(glob_filter, nfiles, pytestconfig, request):
     """
     inputs_root = pytestconfig.getini("inputs_root")[0]
     env = request.config.getoption("env")
-    path = os.path.join(inputs_root, env, "infrastructure/test_data_glob")
+    path = os.path.join(env, "infrastructure/test_data_glob")
 
-    files = _data_glob_url(path, glob_filter, root=get_bigdata_root())
+    files = _data_glob_url(inputs_root, path, glob_filter, get_bigdata_root())
     assert len(files) == nfiles
 
 


### PR DESCRIPTION
Nightly regression tests are regularly showing errors during interaction with artifactory (https://github.com/spacetelescope/jwst/issues/10763). The failures seem to be specific to `_data_glob_url` and the REST API search request. @tjanuario pointed out that the REST API timeout is 30 seconds whereas the AQL timeout is 900.

This PR switches the REST API search request to an equivalent AQL query (partly translated by github copilot). Testing locally with a script that stresses artifactory by issues several requests I was unable to get the AQL query to fail but was able to consistently get the REST query to fail.

The hope is that this will fix the random errors by providing more time for artifactory to respond.

Regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/32136348173 all pass

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
