### PR TITLE
add upper pin for crds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "asdf>=5.1,<6",
     "astropy>=7.2",
     "BayesicFitting>=3.2.2",
-    "crds>=12.0.4,!=13.1.15",
+    "crds>=12.0.4,!=13.1.15,<14",
     "gwcs>=1.0.3,<2",
     "numpy>=2.0",
     "photutils>=3.0,<4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "asdf>=5.1,<6",
     "astropy>=7.2",
     "BayesicFitting>=3.2.2",
-    "crds>=12.0.4,!=13.1.15,<14",
+    "crds>=12.0.4,!=13.1.15,<15",
     "gwcs>=1.0.3,<2",
     "numpy>=2.0",
     "photutils>=3.0,<4",


### PR DESCRIPTION
From slack conversation with @alphasentaurii crds follows semantic versioning.

This PR adds an upper pin for the next major version (15).

regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/33905836230

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
