### PR TITLE
Remove identical repeated calls to world-to-direct transform in wfss_contam

### DIFF
--- a/changes/10826.wfss_contam.rst
+++ b/changes/10826.wfss_contam.rst
@@ -1,0 +1,1 @@
+Remove identical repeated calls to the sky-to-direct WCS transform in the disperse code. For one NIRCam dataset tested, runtime was reduced by 25 percent

--- a/jwst/wfss_contam/disperse.py
+++ b/jwst/wfss_contam/disperse.py
@@ -107,11 +107,7 @@ def _disperse_onto_grism(x0_sky, y0_sky, sky_to_imgxy, imgxy_to_grismxy, lambdas
     lambdas : ndarray
         Wavelengths corresponding to each dispersed pixel
     """
-    # sky_to_imgxy (the "world" to "detector" transform) is a purely geometric,
-    # achromatic distortion: it does not depend on wavelength (as also assumed by
-    # _determine_native_wl_spacing, which evaluates it with a placeholder wavelength
-    # of 1). So evaluate it once on the unique per-pixel positions instead of on the
-    # full (n_lam, n_pixels) outer product used further down, avoiding redundant work.
+    # Evaluate sky-to-direct transform once on the unique per-pixel positions
     x0_xy, y0_xy, _, _ = sky_to_imgxy(x0_sky, y0_sky, 1, order)
     n_pixels = len(x0_xy)
     n_lam = len(lambdas)

--- a/jwst/wfss_contam/disperse.py
+++ b/jwst/wfss_contam/disperse.py
@@ -115,6 +115,8 @@ def _disperse_onto_grism(x0_sky, y0_sky, sky_to_imgxy, imgxy_to_grismxy, lambdas
     y0_xy = np.repeat(y0_xy[np.newaxis, :], n_lam, axis=0)
     lambdas = np.repeat(lambdas[:, np.newaxis], n_pixels, axis=1)
     x0s, y0s = imgxy_to_grismxy(x0_xy, y0_xy, lambdas, order)
+
+    # x0s, y0s now have shape (n_lam, n_pixels)
     return x0s, y0s, lambdas
 
 

--- a/jwst/wfss_contam/disperse.py
+++ b/jwst/wfss_contam/disperse.py
@@ -107,17 +107,18 @@ def _disperse_onto_grism(x0_sky, y0_sky, sky_to_imgxy, imgxy_to_grismxy, lambdas
     lambdas : ndarray
         Wavelengths corresponding to each dispersed pixel
     """
-    # x/y in image frame of grism image is the same for all wavelengths
-    x0_sky = np.repeat(x0_sky[np.newaxis, :], len(lambdas), axis=0)
-    y0_sky = np.repeat(y0_sky[np.newaxis, :], len(lambdas), axis=0)
-
-    x0_xy, y0_xy, _, _ = sky_to_imgxy(x0_sky, y0_sky, lambdas, order)
-    del x0_sky, y0_sky
-
-    # Convert to x/y in grism frame.
-    lambdas = np.repeat(lambdas[:, np.newaxis], x0_xy.shape[1], axis=1)
+    # sky_to_imgxy (the "world" to "detector" transform) is a purely geometric,
+    # achromatic distortion: it does not depend on wavelength (as also assumed by
+    # _determine_native_wl_spacing, which evaluates it with a placeholder wavelength
+    # of 1). So evaluate it once on the unique per-pixel positions instead of on the
+    # full (n_lam, n_pixels) outer product used further down, avoiding redundant work.
+    x0_xy, y0_xy, _, _ = sky_to_imgxy(x0_sky, y0_sky, 1, order)
+    n_pixels = len(x0_xy)
+    n_lam = len(lambdas)
+    x0_xy = np.repeat(x0_xy[np.newaxis, :], n_lam, axis=0)
+    y0_xy = np.repeat(y0_xy[np.newaxis, :], n_lam, axis=0)
+    lambdas = np.repeat(lambdas[:, np.newaxis], n_pixels, axis=1)
     x0s, y0s = imgxy_to_grismxy(x0_xy, y0_xy, lambdas, order)
-    # x0s, y0s now have shape (n_lam, n_pixels)
     return x0s, y0s, lambdas
 
 


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR removes identical repeated calls to the world-to-direct transform in `wfss_contam.disperse`.  For one NIRCam dataset tested, this decreases the runtime of `wfss_contam` on a single core from 482 seconds to 360 seconds.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
