### PR TITLE
set `results_root` default to also point to `regression-tests/runs` in jfrog spec file

### DIFF
--- a/changes/10830.other.rst
+++ b/changes/10830.other.rst
@@ -1,0 +1,1 @@
+fix hardcoded references to ``jwst-pipeline-results/`` in regression test code to point to ``jwst-pipeline-results/regression-tests/runs/``

--- a/jwst/regtest/conftest.py
+++ b/jwst/regtest/conftest.py
@@ -33,7 +33,8 @@ def artifactory_repos(pytestconfig):
     inputs_root : str
         The Artifactory inputs root, set to "jwst-pipeline" unless found in the config.
     results_root : str
-        The Artifactory results root, set to "jwst-pipeline-results" unless found in the config.
+        The Artifactory results root, set to "jwst-pipeline-results/regression-tests/runs"
+        unless found in the config.
     """
     inputs_root = pytestconfig.getini("inputs_root")
     # in pytest 8 inputs_root will be None
@@ -48,7 +49,7 @@ def artifactory_repos(pytestconfig):
     results_root = pytestconfig.getini("results_root")
     # see not above about inputs_root
     if not results_root:
-        results_root = "jwst-pipeline-results"
+        results_root = "jwst-pipeline-results/regression-tests/runs"
     else:
         results_root = results_root[0]
     return inputs_root, results_root

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,7 +215,7 @@ norecursedirs = [
 ]
 junit_family = "xunit2"
 inputs_root = "jwst-pipeline"
-results_root = "jwst-pipeline-results"
+results_root = "jwst-pipeline-results/regression-tests/runs"
 text_file_format = "rst"
 doctest_plus = "enabled"
 doctest_rst = "enabled"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
Even though https://github.com/spacetelescope/RegressionTests/pull/380 and https://github.com/spacetelescope/jwst/pull/10641 explicitly set the results upload to `jwst-pipeline-results/regression-tests/runs`, I failed to realize the actual spec files used `results_root` instead, which was still set to the root of the results repo. This PR should fix that for the okify files, both in their upload location and in the actual diff paths in the spec JSON

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
