### PR TITLE
JP-4437: Avoid SlitModel overhead in wfss_contam

### DIFF
--- a/changes/10835.wfss_contam.rst
+++ b/changes/10835.wfss_contam.rst
@@ -1,0 +1,1 @@
+Avoid schema overhead from repeated SlitModel init when constructing simulation cutouts. For one crowded NIRISS field with ~9000 cutouts, this reduced step runtime by about 60 seconds

--- a/jwst/wfss_contam/observations.py
+++ b/jwst/wfss_contam/observations.py
@@ -520,6 +520,7 @@ def _construct_simulated_cutout(
         xsize=thisobj_maxx - thisobj_minx + 1,
         ystart=thisobj_miny + 1,
         ysize=thisobj_maxy - thisobj_miny + 1,
-        data=img,
+        # Match SlitModel float32 dtype
+        data=img.astype(np.float32, copy=False),
         spectral_order=order,
     )

--- a/jwst/wfss_contam/observations.py
+++ b/jwst/wfss_contam/observations.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 import multiprocessing as mp
 import time
@@ -7,13 +8,33 @@ import numpy as np
 from astropy.stats import SigmaClip
 from astropy.utils.exceptions import AstropyUserWarning
 from photutils.background import Background2D, MedianBackground
-from stdatamodels.jwst import datamodels
 
 from jwst.wfss_contam.disperse import disperse
 
 log = logging.getLogger(__name__)
 
-__all__ = ["background_subtract", "Observation"]
+__all__ = ["background_subtract", "Observation", "SimulatedCutout"]
+
+
+@dataclasses.dataclass
+class SimulatedCutout:
+    """
+    Lightweight container for simulated cutout data and attributes.
+
+    This class looks a lot like `~stdatamodels.jwst.datamodels.SlitModel` but avoids the
+    schema-copy and schema-validation overhead of constructing a full SlitModel for
+    every dispersed source in every spectral order. These objects are purely internal
+    bookkeeping and are never added to an output datamodel.
+    """
+
+    source_id: int
+    name: str
+    xstart: int
+    ystart: int
+    xsize: int
+    ysize: int
+    data: np.ndarray
+    spectral_order: int
 
 
 def background_subtract(
@@ -388,7 +409,7 @@ class Observation:
         for sid in source_results:
             bounds = source_results[sid]["bounds"]
             img = source_results[sid]["image"]
-            slitmodel = _construct_slitmodel(img, bounds, sid, order)
+            slitmodel = _construct_simulated_cutout(img, bounds, sid, order)
             fluxmodels = source_results[sid].get("model_counts", [])
             for i, fm in enumerate(fluxmodels):
                 # use i+1 indexing because typically the first model will be the linear order
@@ -465,14 +486,14 @@ def _aggregate_by_source(results, sid, source_results):
     }
 
 
-def _construct_slitmodel(
+def _construct_simulated_cutout(
     img,
     bounds,
     sid,
     order,
 ):
     """
-    Turn an output image from a single source/order into a SlitModel.
+    Turn an output image from a single source/order into a SimulatedCutout.
 
     Parameters
     ----------
@@ -487,18 +508,18 @@ def _construct_slitmodel(
 
     Returns
     -------
-    `~stdatamodels.jwst.datamodels.SlitModel`
+    SimulatedCutout
         Simulated source cutout containing the dispersed pixel values
     """
     [thisobj_minx, thisobj_maxx, thisobj_miny, thisobj_maxy] = bounds
-    slitmodel = datamodels.SlitModel()
-    slitmodel.source_id = sid
-    slitmodel.name = f"{sid}"
-    slitmodel.xstart = thisobj_minx + 1  # FITS pixels are 1-indexed, matching extract_2d convention
-    slitmodel.xsize = thisobj_maxx - thisobj_minx + 1
-    slitmodel.ystart = thisobj_miny + 1  # FITS pixels are 1-indexed, matching extract_2d convention
-    slitmodel.ysize = thisobj_maxy - thisobj_miny + 1
-    slitmodel.meta.wcsinfo.spectral_order = order
-    slitmodel.data = img
-
-    return slitmodel
+    return SimulatedCutout(
+        source_id=sid,
+        name=f"{sid}",
+        # FITS pixels are 1-indexed, matching extract_2d convention
+        xstart=thisobj_minx + 1,
+        xsize=thisobj_maxx - thisobj_minx + 1,
+        ystart=thisobj_miny + 1,
+        ysize=thisobj_maxy - thisobj_miny + 1,
+        data=img,
+        spectral_order=order,
+    )

--- a/jwst/wfss_contam/tests/test_wfss_contam.py
+++ b/jwst/wfss_contam/tests/test_wfss_contam.py
@@ -6,6 +6,7 @@ import stdatamodels.jwst.datamodels as dm
 from astropy.table import QTable
 
 from jwst.assign_wcs.tests.test_niriss import create_imaging_wcs
+from jwst.wfss_contam.observations import SimulatedCutout
 from jwst.wfss_contam.wfss_contam import (
     CutoutOverlapError,
     UnmatchedSourceIDError,
@@ -324,16 +325,18 @@ def two_source_input(tmp_cwd, grism_wcs):
     model.close()
 
 
-def _make_slit(source_id, order, xstart, ystart, data, **fluxmodels):
-    slit = dm.SlitModel()
-    slit.source_id = source_id
-    slit.meta.wcsinfo.spectral_order = order
-    slit.xstart = xstart
-    slit.ystart = ystart
-    slit.data = data.astype(np.float32)
+def _make_simul_cutout(source_id, order, xstart, ystart, data, **fluxmodels):
+    slit = SimulatedCutout(
+        source_id=source_id,
+        name=None,
+        xstart=xstart,
+        ystart=ystart,
+        xsize=data.shape[1],
+        ysize=data.shape[0],
+        data=data.astype(np.float32),
+        spectral_order=order,
+    )
     slit.dq = np.zeros(data.shape, dtype=np.uint32)
-    slit.xsize = data.shape[1]
-    slit.ysize = data.shape[0]
     for k, v in fluxmodels.items():
         setattr(slit, k, v.astype(np.float32))
     return slit
@@ -363,8 +366,8 @@ def test_iteration_improves_contamination_correction(
     def MockObservation():
         """Use SimpleNamespace to make a mock Observation object with pre-built simulated cutouts."""
         obs = types.SimpleNamespace()
-        simul_A = _make_slit(1, 1, _ITER_XA, _ITER_YA, flat.copy(), fluxmodel_1=tilt.copy())
-        simul_B = _make_slit(2, 1, _ITER_XB, _ITER_YB, flat.copy(), fluxmodel_1=tilt.copy())
+        simul_A = _make_simul_cutout(1, 1, _ITER_XA, _ITER_YA, flat.copy(), fluxmodel_1=tilt.copy())
+        simul_B = _make_simul_cutout(2, 1, _ITER_XB, _ITER_YB, flat.copy(), fluxmodel_1=tilt.copy())
         obs.simulated_cutouts = [simul_A, simul_B]
         obs.simulated_image = np.zeros(_ITER_FRAME_SHAPE)
         obs.source_ids = {1, 2}

--- a/jwst/wfss_contam/tests/test_wfss_contam.py
+++ b/jwst/wfss_contam/tests/test_wfss_contam.py
@@ -336,7 +336,6 @@ def _make_simul_cutout(source_id, order, xstart, ystart, data, **fluxmodels):
         data=data.astype(np.float32),
         spectral_order=order,
     )
-    slit.dq = np.zeros(data.shape, dtype=np.uint32)
     for k, v in fluxmodels.items():
         setattr(slit, k, v.astype(np.float32))
     return slit

--- a/jwst/wfss_contam/wfss_contam.py
+++ b/jwst/wfss_contam/wfss_contam.py
@@ -388,7 +388,7 @@ def _match_simulated_cutouts(output_model, obs):
         or ``None`` where no match was found.
     """
     simul_sids = [s.source_id for s in obs.simulated_cutouts]
-    simul_orders = [s.meta.wcsinfo.spectral_order for s in obs.simulated_cutouts]
+    simul_orders = [s.spectral_order for s in obs.simulated_cutouts]
 
     matched_flat_simuls = []
     good_idxs = []


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4437](https://jira.stsci.edu/browse/JP-4437)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR introduces a lightweight replacement to the `SlitModel` instances that were being used to hold cutouts of the simulated dispersed sources.  The `SlitModel` instances were never actually put into a `MultiSlitModel` or returned from the step anyway, so the loss of schema validation makes no difference.

For one NIRISS dataset in a crowded field with default options, where ~9000 cutouts are created (1800 sources x 5 spectral orders), this shaves a minute off the processing time, from 4 minutes to 3 minutes on a single core, and from 2 minutes to 1 minute on 6 cores.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
