### PR TITLE
JP-4357: Put contam estimates into x1d products for WFSS data

### DIFF
--- a/changes/10841.combine_1d.rst
+++ b/changes/10841.combine_1d.rst
@@ -1,0 +1,1 @@
+Add CONTAM_FLUX and CONTAM_SURF_BRIGHT columns to c1d products if the wfss_contam step was run

--- a/changes/10841.extract_1d.rst
+++ b/changes/10841.extract_1d.rst
@@ -1,0 +1,1 @@
+Add CONTAM_FLUX and CONTAM_SURF_BRIGHT columns to x1d products if the wfss_contam step was run

--- a/docs/jwst/combine_1d/description.rst
+++ b/docs/jwst/combine_1d/description.rst
@@ -72,8 +72,9 @@ for all sources in the observation.
 The spectral table for this model contains the same columns as the `~stdatamodels.jwst.datamodels.CombinedSpecModel`, but
 each row in the table contains the combined spectrum for a single source. The spectral columns
 are 2D: each row is a 1D vector containing all data points for the spectrum. In addition, the
-spectral tables for this model have extra 1D columns to contain the metadata for the spectrum in each row.
-These metadata fields include:
+spectral tables for this model have extra 2D columns CONTAM_FLUX and CONTAM_SURF_BRIGHT
+for the contamination estimate, and extra 1D columns to contain the metadata
+for the spectrum in each row. These metadata fields include:
 
 * SOURCE_ID
 * N_ALONGDISP
@@ -85,6 +86,12 @@ Note that the vector columns have the same length for all the sources in the tab
 the number of elements in the table rows is set by the spectrum with the most data points.
 The other spectra are NaN-padded to match the longest spectrum,
 and the number of valid data points for each spectrum is recorded in the N_ALONGDISP column.
+
+.. note::
+    The CONTAM_FLUX and CONTAM_SURF_BRIGHT columns are computed from the input x1d files in
+    an identical way to the FLUX and SURF_BRIGHT columns, respectively. As it currently stands,
+    the pipeline only combines fluxes from a single orient, and in that case all input spectra
+    should be contaminated in the same way. The columns are NaN-filled if the WfssContamStep was not run.
 
 For example, to access the wavelength and flux for a specific source ID (say, 1200)
 in a `~stdatamodels.jwst.datamodels.WFSSMultiCombinedSpecModel`::

--- a/docs/jwst/extract_1d/description.rst
+++ b/docs/jwst/extract_1d/description.rst
@@ -123,7 +123,10 @@ The extension metadata contains a unique exposure ID (FITS keyword EXPGRPID) for
 which combines exposure grouping metadata, the exposure number, and the spectral order.
 The spectral tables for this model contain the same columns as the
 `~stdatamodels.jwst.datamodels.MultiSpecModel`, but
-each row in the table contains the full spectrum for a single source and order. The spectral columns
+each row in the table contains the full spectrum for a single source and order. There are two
+additional columns for WFSS modes, CONTAM_FLUX and CONTAM_SURF_BRIGHT, which hold
+the simulated contamination estimate for each source if the ``wfss_contam`` step was run
+(otherwise those columns are NaN-filled). The spectral columns
 are 2D: each row is a 1D vector containing all data points for the spectrum. In addition, the
 spectral tables for this model have extra 1D columns to contain the metadata for the spectrum in each row.
 These metadata fields include:

--- a/jwst/combine_1d/combine1d.py
+++ b/jwst/combine_1d/combine1d.py
@@ -93,6 +93,12 @@ class InputSpectrumModel:
         Unit for the flux values.
     sb_unit : str
         Unit for the surface brightness values.
+    has_contam : bool
+        Flag to indicate the contamination columns are present, i.e., this is a WFSS mode.
+    contam_flux : ndarray or None
+        Input contaminating flux, if present.
+    contam_surf_bright : ndarray or None
+        Input contaminating surface brightness, if present.
     """
 
     def __init__(self, ms, spec, exptime_key):
@@ -103,6 +109,15 @@ class InputSpectrumModel:
         self.sb_error = spec.spec_table.field("sb_error")
         self.dq = spec.spec_table.field("dq")
         self.nelem = self.wavelength.shape[0]
+
+        # contam_flux and contam_surf_bright are present for WFSS modes
+        self.has_contam = "contam_flux" in spec.spec_table.columns
+        if self.has_contam:
+            self.contam_flux = spec.spec_table.field("contam_flux")
+            self.contam_surf_bright = spec.spec_table.field("contam_surf_bright")
+        else:
+            self.contam_flux = None
+            self.contam_surf_bright = None
         self.unit_weight = False  # may be reset below
         self.right_ascension = np.zeros_like(self.wavelength)
         self.declination = np.zeros_like(self.wavelength)
@@ -147,6 +162,9 @@ class InputSpectrumModel:
         self.right_ascension = None
         self.declination = None
         self.source_id = None
+        self.has_contam = False
+        self.contam_flux = None
+        self.contam_surf_bright = None
 
 
 class OutputSpectrumModel:
@@ -175,6 +193,12 @@ class OutputSpectrumModel:
         Output spectral WCS.
     normalized : bool
         Flag to indicate data has been combined (sums are normalized).
+    has_contam : bool
+        Flag to indicate the contamination columns are present, i.e., this is a WFSS mode.
+    contam_flux : ndarray or None
+        Output contaminating flux, if present.
+    contam_surf_bright : ndarray or None
+        Output contaminating surface brightness, if present.
     """
 
     def __init__(self):
@@ -191,6 +215,9 @@ class OutputSpectrumModel:
         self.source_id = None
         self.flux_unit = None
         self.sb_unit = None
+        self.has_contam = False
+        self.contam_flux = None
+        self.contam_surf_bright = None
 
     def assign_wavelengths(self, input_spectra):
         """
@@ -257,6 +284,15 @@ class OutputSpectrumModel:
         weight = np.zeros((nspec, nelem), dtype=np.float64)
         count = np.zeros((nspec, nelem), dtype=np.float64)
 
+        # contam_flux and contam_surf_bright are present for WFSS modes
+        self.has_contam = any(in_spec.has_contam for in_spec in input_spectra)
+        if self.has_contam:
+            contam_flux = np.zeros((nspec, nelem), dtype=np.float64)
+            contam_surf_bright = np.zeros((nspec, nelem), dtype=np.float64)
+        else:
+            contam_flux = None
+            contam_surf_bright = None
+
         self.flux_unit = input_spectra[0].flux_unit
         self.sb_unit = input_spectra[0].sb_unit
 
@@ -297,9 +333,29 @@ class OutputSpectrumModel:
                 sb_error[s, k] = in_spec.sb_error[i]
                 weight[s, k] = in_spec.weight[i]
                 count[s, k] = 1.0
+                if self.has_contam and in_spec.has_contam:
+                    contam_flux[s, k] = in_spec.contam_flux[i]
+                    contam_surf_bright[s, k] = in_spec.contam_surf_bright[i]
 
-        (flux, flux_error, surf_bright, sb_error, weight, count) = self.combine_spectra(
-            flux, flux_error, surf_bright, sb_error, weight, count, sigma_clip=sigma_clip
+        (
+            flux,
+            flux_error,
+            surf_bright,
+            sb_error,
+            weight,
+            count,
+            contam_flux,
+            contam_surf_bright,
+        ) = self.combine_spectra(
+            flux,
+            flux_error,
+            surf_bright,
+            sb_error,
+            weight,
+            count,
+            contam_flux=contam_flux,
+            contam_surf_bright=contam_surf_bright,
+            sigma_clip=sigma_clip,
         )
 
         if n_nan > 0:
@@ -312,6 +368,8 @@ class OutputSpectrumModel:
         self.dq = dq
         self.weight = weight
         self.count = count
+        self.contam_flux = contam_flux
+        self.contam_surf_bright = contam_surf_bright
 
         # Since the output wavelengths will not usually be exactly the same
         # as the input wavelengths, it's possible that there will be output
@@ -332,10 +390,22 @@ class OutputSpectrumModel:
             self.dq = self.dq[index]
             self.weight = self.weight[index]
             self.count = self.count[index]
+            if self.has_contam:
+                self.contam_flux = self.contam_flux[index]
+                self.contam_surf_bright = self.contam_surf_bright[index]
         del index
 
     def combine_spectra(
-        self, flux, flux_error, surf_bright, sb_error, weight, count, sigma_clip=None
+        self,
+        flux,
+        flux_error,
+        surf_bright,
+        sb_error,
+        weight,
+        count,
+        contam_flux=None,
+        contam_surf_bright=None,
+        sigma_clip=None,
     ):
         """
         Combine accumulated spectra.
@@ -355,9 +425,13 @@ class OutputSpectrumModel:
             Pixel weights for input spectra
         count : ndarray, 2-D
             Count of how many values at each index in the input arrays.
+        contam_flux : ndarray, 2-D, optional
+            Contaminating fluxes of input spectra, if present.
+        contam_surf_bright : ndarray, 2-D, optional
+            Contaminating surface brightnesses of input spectra, if present.
         sigma_clip : float, optional
             Factor for clipping outliers.  Compares input spectra to the
-            median and medaian absolute devaition, by default None.
+            median and median absolute deviation, by default None.
 
         Returns
         -------
@@ -373,6 +447,10 @@ class OutputSpectrumModel:
             Total, per wavelength weights.
         count : ndarray, 1-D
             Total count of spectra contributing to each wavelength.
+        contam_flux : ndarray, 1-D, or None
+            Combined 1-D contaminating fluxes, if present.
+        contam_surf_bright : ndarray, 1-D, or None
+            Combined 1-D contaminating surface brightnesses, if present.
         """
         # Catch warnings for all NaN slices in an array.
         with warnings.catch_warnings():
@@ -397,6 +475,9 @@ class OutputSpectrumModel:
                 sb_error[clipped] = np.nan
                 count[clipped] = 0
                 weight[clipped] = 0
+                if contam_flux is not None:
+                    contam_flux[clipped] = np.nan
+                    contam_surf_bright[clipped] = np.nan
 
             # Perform a weighted sum of the input spectra
             sum_weight = np.nansum(weight, axis=0)
@@ -407,10 +488,24 @@ class OutputSpectrumModel:
             surf_bright = np.nansum(surf_bright * weight, axis=0) / sum_weight_nonzero
             sb_error = np.sqrt(np.nansum((sb_error * weight) ** 2, axis=0)) / sum_weight_nonzero
             count = np.nansum(count, axis=0)
+            if contam_flux is not None:
+                contam_flux = np.nansum(contam_flux * weight, axis=0) / sum_weight_nonzero
+                contam_surf_bright = (
+                    np.nansum(contam_surf_bright * weight, axis=0) / sum_weight_nonzero
+                )
 
         self.normalized = True
 
-        return flux, flux_error, surf_bright, sb_error, sum_weight, count
+        return (
+            flux,
+            flux_error,
+            surf_bright,
+            sb_error,
+            sum_weight,
+            count,
+            contam_flux,
+            contam_surf_bright,
+        )
 
     def create_output_data(self):
         """
@@ -427,22 +522,26 @@ class OutputSpectrumModel:
         cmb_dtype = datamodels.CombinedSpecModel().get_dtype("spec_table")
 
         # Note that these arrays have to be in the right order.
-        data = np.array(
-            list(
-                zip(
-                    self.wavelength,
-                    self.flux,
-                    self.flux_error,
-                    self.surf_bright,
-                    self.sb_error,
-                    self.dq,
-                    self.weight,
-                    self.count,
-                    strict=False,
-                )
-            ),
-            dtype=cmb_dtype,
-        )
+        data_list = [
+            self.wavelength,
+            self.flux,
+            self.flux_error,
+            self.surf_bright,
+            self.sb_error,
+            self.dq,
+            self.weight,
+            self.count,
+        ]
+        if self.has_contam:
+            # add contam columns in the same positions used for WFSSCombinedSpecModel
+            data_list.insert(2, self.contam_flux)
+            data_list.insert(5, self.contam_surf_bright)
+            descr = cmb_dtype.descr
+            descr.insert(2, ("CONTAM_FLUX", float))
+            descr.insert(5, ("CONTAM_SURF_BRIGHT", float))
+            cmb_dtype = np.dtype(descr)
+
+        data = np.array(list(zip(*data_list, strict=False)), dtype=cmb_dtype)
         output_model = datamodels.CombinedSpecModel(spec_table=data)
 
         output_model.spec_table.columns["wavelength"].unit = "um"
@@ -450,6 +549,9 @@ class OutputSpectrumModel:
         output_model.spec_table.columns["error"].unit = self.flux_unit
         output_model.spec_table.columns["surf_bright"].unit = self.sb_unit
         output_model.spec_table.columns["sb_error"].unit = self.sb_unit
+        if self.has_contam:
+            output_model.spec_table.columns["contam_flux"].unit = self.flux_unit
+            output_model.spec_table.columns["contam_surf_bright"].unit = self.sb_unit
 
         return output_model
 
@@ -466,6 +568,9 @@ class OutputSpectrumModel:
         self.wcs = None
         self.normalized = False
         self.source_id = None
+        self.has_contam = False
+        self.contam_flux = None
+        self.contam_surf_bright = None
 
 
 def count_input(input_spectra):

--- a/jwst/combine_1d/combine1d.py
+++ b/jwst/combine_1d/combine1d.py
@@ -477,6 +477,7 @@ class OutputSpectrumModel:
                 weight[clipped] = 0
                 if contam_flux is not None:
                     contam_flux[clipped] = np.nan
+                if contam_surf_bright is not None:
                     contam_surf_bright[clipped] = np.nan
 
             # Perform a weighted sum of the input spectra
@@ -490,6 +491,7 @@ class OutputSpectrumModel:
             count = np.nansum(count, axis=0)
             if contam_flux is not None:
                 contam_flux = np.nansum(contam_flux * weight, axis=0) / sum_weight_nonzero
+            if contam_surf_bright is not None:
                 contam_surf_bright = (
                     np.nansum(contam_surf_bright * weight, axis=0) / sum_weight_nonzero
                 )

--- a/jwst/combine_1d/tests/test_combine1d.py
+++ b/jwst/combine_1d/tests/test_combine1d.py
@@ -278,6 +278,7 @@ def test_wfss_multi_input(wfss_multiexposure):
     assert tab.shape == (N_SOURCES,)
     assert result.meta.cal_step.combine_1d == "COMPLETE"
     assert np.allclose(tab["FLUX"], 1.0)
+    assert np.allclose(tab["CONTAM_FLUX"], 0.1)
 
     # check that metadata was passed through correctly
     assert np.allclose(tab["SOURCE_RA"], 0.0)

--- a/jwst/datamodels/utils/flat_multispec.py
+++ b/jwst/datamodels/utils/flat_multispec.py
@@ -263,19 +263,18 @@ def expand_table(spec):
     new_spec_list = []
     n_spectra = len(spec.spec_table)
 
-    # handle contam_flux/contam_surf_bright for WFSS modes
+    # handle contam for WFSS modes
     data_type = datamodels.SpecModel().schema["properties"]["spec_table"]["datatype"]
     columns_to_copy = [col["name"] for col in data_type]
     out_dtype = datamodels.SpecModel().get_dtype("spec_table")
     has_contam = "CONTAM_FLUX" in all_columns
     if has_contam:
+        # indexing matches WFSSSpecModel schema
         descr = out_dtype.descr
-        idx = columns_to_copy.index("FLUX") + 1
-        columns_to_copy.insert(idx, "CONTAM_FLUX")
-        descr.insert(idx, ("CONTAM_FLUX", float))
-        idx = columns_to_copy.index("SURF_BRIGHT") + 1
-        columns_to_copy.insert(idx, "CONTAM_SURF_BRIGHT")
-        descr.insert(idx, ("CONTAM_SURF_BRIGHT", float))
+        columns_to_copy.insert(2, "CONTAM_FLUX")
+        descr.insert(2, ("CONTAM_FLUX", float))
+        columns_to_copy.insert(7, "CONTAM_SURF_BRIGHT")
+        descr.insert(7, ("CONTAM_SURF_BRIGHT", float))
         out_dtype = np.dtype(descr)
     columns_to_copy = np.array(columns_to_copy)
 

--- a/jwst/datamodels/utils/flat_multispec.py
+++ b/jwst/datamodels/utils/flat_multispec.py
@@ -282,6 +282,8 @@ def expand_table(spec):
         # initialize a new SpecModel
         spec_row = spec.spec_table[i]
         n_elements = int(spec_row["N_ALONGDISP"])
+        if n_elements == 0:
+            continue
 
         # Copy over the vector columns from input spec_table to output spec_table
         spec_table = np.empty(n_elements, dtype=out_dtype)

--- a/jwst/datamodels/utils/flat_multispec.py
+++ b/jwst/datamodels/utils/flat_multispec.py
@@ -262,19 +262,33 @@ def expand_table(spec):
     all_columns = np.array([str(x) for x in spec.spec_table.dtype.names])
     new_spec_list = []
     n_spectra = len(spec.spec_table)
+
+    # handle contam_flux/contam_surf_bright for WFSS modes
+    data_type = datamodels.SpecModel().schema["properties"]["spec_table"]["datatype"]
+    columns_to_copy = [col["name"] for col in data_type]
+    out_dtype = datamodels.SpecModel().get_dtype("spec_table")
+    has_contam = "CONTAM_FLUX" in all_columns
+    if has_contam:
+        descr = out_dtype.descr
+        idx = columns_to_copy.index("FLUX") + 1
+        columns_to_copy.insert(idx, "CONTAM_FLUX")
+        descr.insert(idx, ("CONTAM_FLUX", float))
+        idx = columns_to_copy.index("SURF_BRIGHT") + 1
+        columns_to_copy.insert(idx, "CONTAM_SURF_BRIGHT")
+        descr.insert(idx, ("CONTAM_SURF_BRIGHT", float))
+        out_dtype = np.dtype(descr)
+    columns_to_copy = np.array(columns_to_copy)
+
     for i in range(n_spectra):
         # initialize a new SpecModel
         spec_row = spec.spec_table[i]
         n_elements = int(spec_row["N_ALONGDISP"])
-        new_spec = datamodels.SpecModel()
-        data_type = new_spec.schema["properties"]["spec_table"]["datatype"]
-        columns_to_copy = np.array([col["name"] for col in data_type])
 
         # Copy over the vector columns from input spec_table to output spec_table
-        spec_table = np.empty(n_elements, dtype=new_spec.get_dtype("spec_table"))
+        spec_table = np.empty(n_elements, dtype=out_dtype)
         for col_name in columns_to_copy:
             spec_table[col_name] = spec_row[col_name][:n_elements]
-        new_spec.spec_table = spec_table
+        new_spec = datamodels.SpecModel(spec_table=spec_table)
 
         # Copy over the metadata columns from input spec_table to the spectrum's metadata
         meta_columns = all_columns[~np.isin(all_columns, columns_to_copy)].tolist()

--- a/jwst/datamodels/utils/tests/wfss_helpers.py
+++ b/jwst/datamodels/utils/tests/wfss_helpers.py
@@ -43,10 +43,14 @@ def example_spec():
     spec = dm.SpecModel()
     spectable_dtype = spec.schema["properties"]["spec_table"]["datatype"]
     recarray_dtype = [(d["name"], d["datatype"]) for d in spectable_dtype]
+    # add contam columns
+    recarray_dtype.insert(2, ("CONTAM_FLUX", "f4"))
+    recarray_dtype.insert(7, ("CONTAM_SURF_BRIGHT", "f4"))
     spec.meta.wcs = mock_wcs()
     spec_table = np.recarray((N_ROWS,), dtype=recarray_dtype)
     spec_table["WAVELENGTH"] = np.linspace(1.0, 10.0, N_ROWS)
     spec_table["FLUX"] = np.ones(N_ROWS)
+    spec_table["CONTAM_FLUX"] = np.ones(N_ROWS, dtype=np.float32) / 10.0
     spec.spec_table = spec_table
     spec.spec_table.columns["wavelength"].unit = "um"
     return spec

--- a/jwst/datamodels/utils/tests/wfss_helpers.py
+++ b/jwst/datamodels/utils/tests/wfss_helpers.py
@@ -43,7 +43,7 @@ def example_spec():
     spec = dm.SpecModel()
     spectable_dtype = spec.schema["properties"]["spec_table"]["datatype"]
     recarray_dtype = [(d["name"], d["datatype"]) for d in spectable_dtype]
-    # add contam columns
+    # add contam columns right after flux and sb columns. matches order in schema
     recarray_dtype.insert(2, ("CONTAM_FLUX", "f4"))
     recarray_dtype.insert(7, ("CONTAM_SURF_BRIGHT", "f4"))
     spec.meta.wcs = mock_wcs()

--- a/jwst/datamodels/utils/wfss_multispec.py
+++ b/jwst/datamodels/utils/wfss_multispec.py
@@ -61,7 +61,14 @@ def make_wfss_multiexposure(input_list):
     # for calwebb_spec3 the outer loop is over sources and the inner loop is over exposures
     # for calwebb_spec2 it is the opposite, but outer loop (exposures) should have just one element
     for model in results_list:
-        for spec in model.spec:
+        for i, spec in enumerate(model.spec):
+            # get the data type for the first spectrum
+            if i == 0:
+                # get the input datatype, and give it the same format as a schema
+                # to be compatible with determine_vector_and_meta_columns
+                # while retaining any extra columns (i.e. contam_flux, contam_surf_bright)
+                dt = spec.spec_table.dtype.descr
+                input_datatype = [{"name": name, "datatype": str(dtype)} for name, dtype in dt]
             fname = getattr(spec.meta, "filename", None)
             exp_number = getattr(spec.meta, "group_id", None)
 
@@ -94,10 +101,9 @@ def make_wfss_multiexposure(input_list):
     n_rows_by_exposure = [exposure_counter[n]["n_rows"] for n in exposure_numbers]
 
     # Set up output table column names and dtypes
-    # Use SpecModel.spectable to determine the vector-like columns
+    # Input spec datatype is used to determine the vector-like columns
     # The additional metadata columns are all those that are defined in WFSSMultiSpecModel
-    # but not in SpecModel
-    input_datatype = dm.SpecModel().schema["properties"]["spec_table"]["datatype"]
+    # but not in the input spec datatype
     output_datatype = dm.WFSSSpecModel().schema["properties"]["spec_table"]["datatype"]
     all_columns, is_vector = determine_vector_and_meta_columns(input_datatype, output_datatype)
     defaults = dm.WFSSSpecModel().schema["properties"]["spec_table"]["default"]

--- a/jwst/datamodels/utils/wfss_multispec.py
+++ b/jwst/datamodels/utils/wfss_multispec.py
@@ -249,7 +249,10 @@ def make_wfss_multicombined(results_list):
     n_sources = len(results_list)
 
     # figure out column names and dtypes
-    input_datatype = dm.CombinedSpecModel().schema["properties"]["spec_table"]["datatype"]
+    # use the actual input dtype, rather than the static CombinedSpecModel schema,
+    # to correctly retain any extra columns (i.e. contam_flux, contam_surf_bright)
+    dt = results_list[0].spec[0].spec_table.dtype.descr
+    input_datatype = [{"name": name, "datatype": str(dtype)} for name, dtype in dt]
     output_schema = dm.WFSSMultiCombinedSpecModel().schema
     output_table_schema = output_schema["properties"]["spec"]["items"]["properties"]["spec_table"]
     output_datatype = output_table_schema["datatype"]

--- a/jwst/datamodels/utils/wfss_multispec.py
+++ b/jwst/datamodels/utils/wfss_multispec.py
@@ -62,7 +62,6 @@ def make_wfss_multiexposure(input_list):
     # for calwebb_spec2 it is the opposite, but outer loop (exposures) should have just one element
     for model in results_list:
         for i, spec in enumerate(model.spec):
-            # get the data type for the first spectrum
             if i == 0:
                 # get the input datatype, and give it the same format as a schema
                 # to be compatible with determine_vector_and_meta_columns

--- a/jwst/datamodels/utils/wfss_multispec.py
+++ b/jwst/datamodels/utils/wfss_multispec.py
@@ -249,8 +249,8 @@ def make_wfss_multicombined(results_list):
     n_sources = len(results_list)
 
     # figure out column names and dtypes
-    # use the actual input dtype, rather than the static CombinedSpecModel schema,
-    # to correctly retain any extra columns (i.e. contam_flux, contam_surf_bright)
+    # use the actual input dtype instead of the schema
+    # so we retain any extra columns (i.e. contam_flux, contam_surf_bright)
     dt = results_list[0].spec[0].spec_table.dtype.descr
     input_datatype = [{"name": name, "datatype": str(dtype)} for name, dtype in dt]
     output_schema = dm.WFSSMultiCombinedSpecModel().schema

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1776,8 +1776,8 @@ def create_extraction(
             )
             contam_flux = contam_results[0]
         else:
-            contam_flux = np.zeros_like(sum_flux)
-            contam_surf_bright = np.zeros_like(sum_flux)
+            contam_flux = np.zeros_like(sum_flux) * np.nan
+            contam_surf_bright = np.zeros_like(sum_flux) * np.nan
 
         # Save the scene model and residual
         if save_scene_model:

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -1295,7 +1295,9 @@ def define_aperture(input_model, slit, extract_params, exp_type):
     return ra, dec, wavelength, profile, bg_profile, nod_profile, limits
 
 
-def extract_one_slit(data_model, integration, profile, bg_profile, nod_profile, extract_params):
+def extract_one_slit(
+    data_model, integration, profile, bg_profile, nod_profile, extract_params, data_attr="data"
+):
     """
     Extract data for one slit, or spectral order, or integration.
 
@@ -1332,6 +1334,9 @@ def extract_one_slit(data_model, integration, profile, bg_profile, nod_profile, 
     extract_params : dict
         Parameters read from the EXTRACT1D reference file, as returned by
         :func:`get_extract_parameters`.
+    data_attr : str
+        Name of attribute where data array is found. This is typically "data" but
+        can be "contam" when extracting contamination estimates for WFSS data.
 
     Returns
     -------
@@ -1377,7 +1382,9 @@ def extract_one_slit(data_model, integration, profile, bg_profile, nod_profile, 
         Residual 2D image from the input minus the scene model.
     """
     # Get the data and variance arrays
-    data = data_model.data
+    data = getattr(data_model, data_attr, None)
+    if data is None:
+        raise AttributeError(f"Data model has no attribute {data_attr}")
     var_rnoise = data_model.var_rnoise
     var_poisson = data_model.var_poisson
     var_flat = data_model.var_flat
@@ -1756,6 +1763,22 @@ def create_extraction(
             residual_2d,
         ) = extract_one_slit(data_model, integ, profile, bg_profile, nod_profile, extract_params)
 
+        if getattr(data_model, "contam", None) is not None:
+            # compute contamination in identical way
+            contam_results = extract_one_slit(
+                data_model,
+                integ,
+                profile,
+                bg_profile,
+                nod_profile,
+                extract_params,
+                data_attr="contam",
+            )
+            contam_flux = contam_results[0]
+        else:
+            contam_flux = np.zeros_like(sum_flux)
+            contam_surf_bright = np.zeros_like(sum_flux)
+
         # Save the scene model and residual
         if save_scene_model:
             if isinstance(scene_model, datamodels.CubeModel):
@@ -1782,6 +1805,7 @@ def create_extraction(
             sb_var_poisson = f_var_poisson / npixels_squared
             sb_var_rnoise = f_var_rnoise / npixels_squared
             sb_var_flat = f_var_flat / npixels_squared
+            contam_surf_bright = contam_flux / npixels_temp
         background /= npixels_temp
         b_var_poisson = b_var_poisson / npixels_squared
         b_var_rnoise = b_var_rnoise / npixels_squared
@@ -1816,6 +1840,7 @@ def create_extraction(
                 f_var_poisson *= pixel_solid_angle**2 * 1.0e12  # (MJy / sr)**2 --> Jy**2
                 f_var_rnoise *= pixel_solid_angle**2 * 1.0e12  # (MJy / sr)**2 --> Jy**2
                 f_var_flat *= pixel_solid_angle**2 * 1.0e12  # (MJy / sr)**2 --> Jy**2
+                contam_flux *= pixel_solid_angle * 1.0e6  # MJy / steradian --> Jy
         else:
             flux = sum_flux  # count rate
 
@@ -1830,32 +1855,39 @@ def create_extraction(
         dq[np.isnan(flux)] = datamodels.dqflags.pixel["DO_NOT_USE"]
 
         # Make a table of the values, trimming to points with valid wavelengths only
-        otab = np.array(
-            list(
-                zip(
-                    wavelength,
-                    flux[valid],
-                    error[valid],
-                    f_var_poisson[valid],
-                    f_var_rnoise[valid],
-                    f_var_flat[valid],
-                    surf_bright[valid],
-                    sb_error[valid],
-                    sb_var_poisson[valid],
-                    sb_var_rnoise[valid],
-                    sb_var_flat[valid],
-                    dq[valid],
-                    background[valid],
-                    berror[valid],
-                    b_var_poisson[valid],
-                    b_var_rnoise[valid],
-                    b_var_flat[valid],
-                    npixels[valid],
-                    strict=False,
-                )
-            ),
-            dtype=datamodels.SpecModel().get_dtype("spec_table"),
-        )
+        otab_list = [
+            wavelength,
+            flux[valid],
+            error[valid],
+            f_var_poisson[valid],
+            f_var_rnoise[valid],
+            f_var_flat[valid],
+            surf_bright[valid],
+            sb_error[valid],
+            sb_var_poisson[valid],
+            sb_var_rnoise[valid],
+            sb_var_flat[valid],
+            dq[valid],
+            background[valid],
+            berror[valid],
+            b_var_poisson[valid],
+            b_var_rnoise[valid],
+            b_var_flat[valid],
+            npixels[valid],
+        ]
+        otab_dtype = datamodels.SpecModel().get_dtype("spec_table")
+        if exp_type in WFSS_EXPTYPES:
+            # add contam columns
+            otab_list.insert(2, contam_flux[valid])
+            otab_list.insert(7, contam_surf_bright[valid])
+            # Need to modify the dtype, but it's immutable.
+            # Use descr to get it as a list
+            descr = otab_dtype.descr
+            descr.insert(2, ("CONTAM_FLUX", float))
+            descr.insert(7, ("CONTAM_SURF_BRIGHT", float))
+            otab_dtype = np.dtype(descr)
+
+        otab = np.array(list(zip(*otab_list, strict=True)), dtype=otab_dtype)
 
         spec = datamodels.SpecModel(spec_table=otab)
         spec.meta.wcs = spec_wcs.create_spectral_wcs(ra, dec, wavelength)
@@ -1870,6 +1902,10 @@ def create_extraction(
         spec.spec_table.columns["sb_var_poisson"].unit = sb_var_units
         spec.spec_table.columns["sb_var_rnoise"].unit = sb_var_units
         spec.spec_table.columns["sb_var_flat"].unit = sb_var_units
+        if "contam_flux" in spec.spec_table.columns:
+            spec.spec_table.columns["contam_flux"].unit = flux_units
+        if "contam_surf_bright" in spec.spec_table.columns:
+            spec.spec_table.columns["contam_surf_bright"].unit = sb_units
         spec.spec_table.columns["background"].unit = sb_units
         spec.spec_table.columns["bkgd_error"].unit = sb_units
         spec.spec_table.columns["bkgd_var_poisson"].unit = sb_var_units

--- a/jwst/extract_1d/tests/helpers.py
+++ b/jwst/extract_1d/tests/helpers.py
@@ -483,6 +483,8 @@ def mock_nis_wfss_l2():
     )
 
     slit0 = mock_nirspec_fs_one_slit_func()
+    # give contam a unique value so we know it has ended up in the right column later
+    slit0.contam = np.zeros_like(slit0.data) + 3
 
     nslit = 3
     for i in range(nslit):

--- a/jwst/extract_1d/tests/test_extract_1d_step.py
+++ b/jwst/extract_1d/tests/test_extract_1d_step.py
@@ -367,6 +367,9 @@ def test_save_output_wfss_l2(tmp_path, mock_niriss_wfss_l2):
         output_dir=str(tmp_path),
         suffix="x1d",
     )
+    # test that optional contam column got handled
+    np.testing.assert_allclose(result.spec[0].spec_table["contam_flux"], 150.0)
+    np.testing.assert_allclose(result.spec[0].spec_table["contam_surf_bright"], 3.0)
     result.close()
 
     fname = "test_x1d.fits"

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -1023,7 +1023,7 @@ class DataSet:
             # Fluxes are in units of Jy
             flux_unit = "Jy"
             flux_squared_unit = "Jy^2"
-            for att in ["FLUX", "FLUX_ERROR"]:
+            for att in ["FLUX", "FLUX_ERROR", "CONTAM_FLUX"]:
                 spec.spec_table[att][self.integ_row] *= conversion
                 spec.spec_table.columns[att].unit = flux_unit
             for att in ["FLUX_VAR_POISSON", "FLUX_VAR_RNOISE", "FLUX_VAR_FLAT"]:
@@ -1045,7 +1045,13 @@ class DataSet:
                 conv_sb = conversion / self.sb_conversion
             sb_unit = "MJy/sr"
             sb_var_unit = "MJy^2 / sr^2"
-            for att in ["BACKGROUND", "BKGD_ERROR", "SURF_BRIGHT", "SB_ERROR"]:
+            for att in [
+                "BACKGROUND",
+                "BKGD_ERROR",
+                "SURF_BRIGHT",
+                "SB_ERROR",
+                "CONTAM_SURF_BRIGHT",
+            ]:
                 spec.spec_table[att][self.integ_row] *= conv_sb
                 spec.spec_table.columns[att].unit = sb_unit
             for att in [

--- a/jwst/photom/photom.py
+++ b/jwst/photom/photom.py
@@ -1024,8 +1024,9 @@ class DataSet:
             flux_unit = "Jy"
             flux_squared_unit = "Jy^2"
             for att in ["FLUX", "FLUX_ERROR", "CONTAM_FLUX"]:
-                spec.spec_table[att][self.integ_row] *= conversion
-                spec.spec_table.columns[att].unit = flux_unit
+                if att in spec.spec_table.columns:
+                    spec.spec_table[att][self.integ_row] *= conversion
+                    spec.spec_table.columns[att].unit = flux_unit
             for att in ["FLUX_VAR_POISSON", "FLUX_VAR_RNOISE", "FLUX_VAR_FLAT"]:
                 spec.spec_table[att][self.integ_row] *= conversion**2.0
                 spec.spec_table.columns[att].unit = flux_squared_unit
@@ -1052,8 +1053,9 @@ class DataSet:
                 "SB_ERROR",
                 "CONTAM_SURF_BRIGHT",
             ]:
-                spec.spec_table[att][self.integ_row] *= conv_sb
-                spec.spec_table.columns[att].unit = sb_unit
+                if att in spec.spec_table.columns:
+                    spec.spec_table[att][self.integ_row] *= conv_sb
+                    spec.spec_table.columns[att].unit = sb_unit
             for att in [
                 "BKGD_VAR_POISSON",
                 "BKGD_VAR_RNOISE",

--- a/jwst/photom/tests/test_photom.py
+++ b/jwst/photom/tests/test_photom.py
@@ -225,6 +225,7 @@ def create_input(
                 tab["FLUX_VAR_FLAT"] = var_f
 
                 mod = datamodels.SpecModel(spec_table=tab)
+                _add_contam_columns(mod)
                 mod.source_id = 1000
                 mod.meta.group_id = "0"
                 mod.spectral_order = k + 1
@@ -326,6 +327,7 @@ def create_input(
                 tab["FLUX_VAR_RNOISE"] = var_r
                 tab["FLUX_VAR_FLAT"] = var_f
                 mod = datamodels.SpecModel(spec_table=tab)
+                _add_contam_columns(mod)
                 mod.source_id = 1000
                 mod.meta.group_id = "0"
                 mod.spectral_order = k + 1
@@ -424,6 +426,33 @@ def create_input(
         input_model.meta.subarray.name = subarray
 
     return input_model
+
+
+def _add_contam_columns(model):
+    """
+    Update SpecModel in place to have contam columns.
+
+    Parameters
+    ----------
+    model : SpecModel
+        Input model.
+    """
+    tab = model.spec_table
+    nelem = len(tab)
+    otab_list = list(zip(*tab.tolist()))
+    contam_flux = np.arange(nelem, dtype=np.float32) / 10.0
+    otab_list.insert(2, contam_flux)
+    contam_surf_bright = np.arange(nelem, dtype=np.float32) / 100.0
+    otab_list.insert(7, contam_surf_bright)
+    # Need to modify the dtype, but it's immutable.
+    # Use descr to get it as a list
+    otab_dtype = tab.dtype
+    descr = otab_dtype.descr
+    descr.insert(2, ("CONTAM_FLUX", float))
+    descr.insert(7, ("CONTAM_SURF_BRIGHT", float))
+    otab_dtype = np.dtype(descr)
+    new_tab = np.array(list(zip(*otab_list)), dtype=otab_dtype)
+    model.spec_table = new_tab
 
 
 def create_photom_nrs_fs(min_wl=1.0, max_wl=5.0, min_r=8.0, max_r=9.0):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "scikit-image>=0.23.1",
     "scipy>=1.18.0",
     # "stdatamodels>=6.0.0,<6.1",
-    "stdatamodels @ git+https://github.com/spacetelescope/stdatamodels.git@main",
+    "stdatamodels @ git+https://github.com/emolter/stdatamodels.git@JP-4357",
     #"stcal>=1.19.1,<2",
     "stcal @ git+https://github.com/spacetelescope/stcal.git@main",
     # "stpipe>=1.0.0,<2",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4357](https://jira.stsci.edu/browse/JP-4357)

<!-- If this PR closes a GitHub issue that is not attached to a Jira ticket, uncomment the line below, and reference it here by its number -->
<!-- Closes # -->

<!-- describe the changes comprising this PR here -->
This PR adds 1-D contamination estimates to the default output x1d products for WFSS data

The 2-d contam cutouts, which were made available by https://github.com/spacetelescope/jwst/pull/10761, are treated inside `Extract1dStep` in an identical way to the data cutouts if the `wfss_contam` step was run.  The 1-d `"CONTAM_FLUX"` and `"CONTAM_SURF_BRIGHT"` are added as optional columns to the `SpecModel.spec_table` and then placed into the `WFSSMultiSpecModel` where they are treated as required.  If `wfss_contam` was not run, the columns are NaN-filled.  The `photom` step treats the new columns in an identical way to the real data flux and surface brightness.

Requires https://github.com/spacetelescope/stdatamodels/pull/818 and they must be merged in tandem because the stdatamodels PR makes the columns required for `WFSSMultiSpecModel`.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] If you have a specific reviewer in mind, tag them.
- [x] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [x] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [x] update or add relevant tests
  - [x] update relevant docstrings and / or `docs/` page
  - [x] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [x] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
