### PR TITLE
JP-4436: Explicitly allow paths in association member names

### DIFF
--- a/jwst/background/background_step.py
+++ b/jwst/background/background_step.py
@@ -2,7 +2,6 @@
 
 import logging
 from collections import defaultdict
-from pathlib import Path
 
 import numpy as np
 from stdatamodels.jwst import datamodels
@@ -245,11 +244,11 @@ class BackgroundStep(Step):
         exp_type = sci.meta.exposure.type
         if exp_type in WFSS_TYPES:
             try:
-                sci.meta.source_catalog = Path(members_by_type["sourcecat"][0]).name
+                sci.meta.source_catalog = members_by_type["sourcecat"][0]
                 log.info(f"Using sourcecat file {sci.meta.source_catalog}")
-                sci.meta.segmentation_map = Path(members_by_type["segmap"][0]).name
+                sci.meta.segmentation_map = members_by_type["segmap"][0]
                 log.info(f"Using segmentation map {sci.meta.segmentation_map}")
-                sci.meta.direct_image = Path(members_by_type["direct_image"][0]).name
+                sci.meta.direct_image = members_by_type["direct_image"][0]
                 log.info(f"Using direct image {sci.meta.direct_image}")
             except IndexError:
                 if sci.meta.source_catalog is None:

--- a/jwst/pipeline/calwebb_spec2.py
+++ b/jwst/pipeline/calwebb_spec2.py
@@ -229,11 +229,11 @@ class Spec2Pipeline(Pipeline):
         # name from the asn and record it to the meta
         if exp_type in WFSS_TYPES:
             try:
-                science.meta.source_catalog = Path(members_by_type["sourcecat"][0]).name
+                science.meta.source_catalog = members_by_type["sourcecat"][0]
                 log.info(f"Using sourcecat file {science.meta.source_catalog}")
-                science.meta.segmentation_map = Path(members_by_type["segmap"][0]).name
+                science.meta.segmentation_map = members_by_type["segmap"][0]
                 log.info(f"Using segmentation map {science.meta.segmentation_map}")
-                science.meta.direct_image = Path(members_by_type["direct_image"][0]).name
+                science.meta.direct_image = members_by_type["direct_image"][0]
                 log.info(f"Using direct image {science.meta.direct_image}")
             except IndexError:
                 if science.meta.source_catalog is None:
@@ -281,7 +281,6 @@ class Spec2Pipeline(Pipeline):
                     raise RuntimeError("Cannot determine WCS.")
 
         # Steps whose order is the same for all types of input:
-
         # Self-calibrate to flag bad/warm pixels, and apply flags
         # to both background and science exposures.
         # skipped by default for all modes

--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -126,6 +126,8 @@ class JwstStep(_Step):
         from jwst.associations.lib.update_path import update_key_value
         from jwst.associations.load_as_asn import LoadAsLevel2Asn
 
+        if isinstance(obj, (str, Path)):
+            obj = Path(self.input_dir) / Path(obj)
         asn = LoadAsLevel2Asn.load(obj, basename=self.output_file)
         update_key_value(asn, "expname", (), mod_func=self.make_input_path)
         return asn

--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -14,6 +14,7 @@ from stpipe import Step as _Step
 
 from jwst import __version__, __version_commit__
 from jwst.associations import Association
+from jwst.associations.load_as_asn import LoadAsLevel2Asn
 from jwst.datamodels import ModelContainer, ModelLibrary
 from jwst.lib import exposure_types
 from jwst.lib.suffix import remove_suffix
@@ -124,10 +125,15 @@ class JwstStep(_Step):
         """
         # Prevent circular import:
         from jwst.associations.lib.update_path import update_key_value
-        from jwst.associations.load_as_asn import LoadAsLevel2Asn
 
-        if isinstance(obj, (str, Path)):
+        # If input has no parent path and input_dir is provided, prepend input_dir to asn expname
+        if (
+            isinstance(obj, (str, Path))
+            and self.input_dir is not None
+            and Path(obj).parent == Path()
+        ):
             obj = Path(self.input_dir) / Path(obj)
+
         asn = LoadAsLevel2Asn.load(obj, basename=self.output_file)
         update_key_value(asn, "expname", (), mod_func=self.make_input_path)
         return asn

--- a/jwst/stpipe/core.py
+++ b/jwst/stpipe/core.py
@@ -14,7 +14,6 @@ from stpipe import Step as _Step
 
 from jwst import __version__, __version_commit__
 from jwst.associations import Association
-from jwst.associations.load_as_asn import LoadAsLevel2Asn
 from jwst.datamodels import ModelContainer, ModelLibrary
 from jwst.lib import exposure_types
 from jwst.lib.suffix import remove_suffix
@@ -125,6 +124,9 @@ class JwstStep(_Step):
         """
         # Prevent circular import:
         from jwst.associations.lib.update_path import update_key_value
+        from jwst.associations.load_as_asn import (
+            LoadAsLevel2Asn,  # PLC0415: Prevent circular import
+        )
 
         # If input has no parent path and input_dir is provided, prepend input_dir to asn expname
         if (


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4436](https://jira.stsci.edu/browse/JP-4436)

<!-- describe the changes comprising this PR here -->
This PR addresses inconsistent behavior between exposure types when paths are included in association member names.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] If you have a specific reviewer in mind, tag them.
- [ ] add a build milestone, i.e. `Build 12.0` (use the [latest build](https://github.com/spacetelescope/jwst/milestones) if not sure)
- [ ] Does this PR change user-facing code / API? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/jwst/blob/main/changes/README.rst) for instructions) 
    - if your change breaks **step-level or public API** ([as defined in the docs](https://jwst.readthedocs.io/en/latest/jwst/user_documentation/more_information.html#api-public-vs-private)), also add a `changes/<PR#>.breaking.rst` news fragment
  - [ ] update or add relevant tests
  - [ ] update relevant docstrings and / or `docs/` page
  - [ ] [start a regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) and include a link to the running job ([click here for instructions](https://github.com/spacetelescope/RegressionTests/blob/main/docs/running_regression_tests.md))
    - [ ] Do truth files need to be updated ("okified")?
      - [ ] **after the reviewer has approved these changes**, run `okify_regtests` to update the truth files
- [ ] if a JIRA ticket exists, [make sure it is resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
